### PR TITLE
Clarify doc notes for future config and sandbox behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Notes:
 ## Platform support
 
 - **macOS / Linux**: supported.
-- **Windows**: experimental. Support is in progress.
+- **Windows**: experimental for the R backend. The Python backend currently requires a Unix PTY and is not available on Windows.
 
 ## Sandbox
 

--- a/docs/futurework/external-mcp-console-config.md
+++ b/docs/futurework/external-mcp-console-config.md
@@ -2,11 +2,8 @@
 
 ## Summary
 
-Not implemented: `mcp-repl` does not currently support
-`--config /path/to/mcp-repl.toml`.
-
-Potential future feature: add `--config` support to keep sandbox policy in a
-dedicated file instead of long CLI arg lists.
+Potential future feature: support `mcp-repl --config /path/to/mcp-repl.toml`
+to keep sandbox policy in a dedicated file instead of long CLI arg lists.
 
 ## Motivation
 

--- a/docs/notes/eval_suite_ideas.md
+++ b/docs/notes/eval_suite_ideas.md
@@ -1,9 +1,9 @@
-# Eval suite ideas: measuring whether `mcp-console` helps
+# Eval suite ideas: measuring whether `mcp-repl` helps
 
 This document sketches a harness-agnostic eval design for answering two questions:
 
-1. Does access to `mcp-console` measurably accelerate an agent on R-centric tasks?
-2. Do different `mcp-console` tool descriptions measurably change outcomes?
+1. Does access to `mcp-repl` measurably accelerate an agent on R-centric tasks?
+2. Do different `mcp-repl` tool descriptions measurably change outcomes?
 
 The goal is a numeric benchmark that you can track over time and across tool/description variants.
 
@@ -16,10 +16,10 @@ The goal is a numeric benchmark that you can track over time and across tool/des
 
 ## Ablations (what to compare)
 
-To isolate the value of `mcp-console`, run the same tasks under controlled conditions:
+To isolate the value of `mcp-repl`, run the same tasks under controlled conditions:
 
-- **No console**: the agent cannot call `mcp-console` (baseline).
-- **Console enabled**: the agent can call `mcp-console` with the default tool description.
+- **No console**: the agent cannot call `mcp-repl` (baseline).
+- **Console enabled**: the agent can call `mcp-repl` with the default tool description.
 - **Console + description variants**: keep code identical, but swap the tool description text:
   - **Minimal**: “stateful R REPL; send code; state persists.”
   - **Operational**: include pager semantics, docs commands, debugger tips.
@@ -29,7 +29,7 @@ This is effectively an ablation over *capability* (tool present) and *policy* (h
 
 ## Task design principles (so the console matters)
 
-Good eval tasks for `mcp-console` have three properties:
+Good eval tasks for `mcp-repl` have three properties:
 
 - **Statefulness is an advantage**: repeated iteration benefits from keeping objects resident (large data, intermediate transforms, model fits).
 - **Inspection is required**: the agent must discover types/shapes/classes, error paths, or invariants; guessing is punished.
@@ -67,7 +67,7 @@ grading:
   outputs:
     score_range: [0, 1]
 tooling:
-  mcp_console:
+  mcp_repl:
     enabled: true
     description_variant: operational
 ---
@@ -94,7 +94,7 @@ If you build concrete task stubs, place them in a directory like `eval/tasks/`.
 
 **Prompt**: Given a CSV with mixed types (numeric stored as strings, factor levels with whitespace, missingness, date parsing issues), produce a small set of summary results and one plot, plus a short written report.
 
-**Why `mcp-console` helps**:
+**Why `mcp-repl` helps**:
 - Quickly inspect `str()`, `summary()`, `table()`, factor levels, missingness patterns.
 - Iterate on cleaning steps without reloading.
 - Generate a plot and visually verify it before reporting.
@@ -108,7 +108,7 @@ If you build concrete task stubs, place them in a directory like `eval/tasks/`.
 
 **Prompt**: A small R package/project contains a failing function and a minimal test suite. Fix the bug without changing the tests. (Provide the project files in the eval resources.)
 
-**Why `mcp-console` helps**:
+**Why `mcp-repl` helps**:
 - Reproduce the failure and use `debugonce()`/`browser()` to inspect local state.
 - Iterate quickly: patch code → reload/source → rerun minimal repro.
 
@@ -120,7 +120,7 @@ If you build concrete task stubs, place them in a directory like `eval/tasks/`.
 
 **Prompt**: Port a small function from Python (or C++) to R with provided fixtures. The function is subtle around edge cases (NA handling, integer overflow-ish behavior, floating precision, factor levels).
 
-**Why `mcp-console` helps**:
+**Why `mcp-repl` helps**:
 - Keep reference fixtures loaded; repeatedly compare outputs.
 - Use small probes to verify parity before finalizing.
 
@@ -131,7 +131,7 @@ If you build concrete task stubs, place them in a directory like `eval/tasks/`.
 
 **Prompt**: Run an analysis that includes a moderately long computation (e.g., bootstrap, simulation, cross-validation) with intermediate checkpoints. If it exceeds the time budget, produce partial results plus a plan to finish (as defined by the task).
 
-**Why `mcp-console` helps**:
+**Why `mcp-repl` helps**:
 - The agent can start the run, inspect partial output, adjust parameters, and continue without losing context.
 - Best-effort interrupt/restart supports recovery from wedged runs.
 
@@ -143,7 +143,7 @@ If you build concrete task stubs, place them in a directory like `eval/tasks/`.
 
 **Prompt**: Produce a plot that must satisfy concrete requirements (labels, scales, colorblind-safe palette, faceting rules, annotation, and a specified size). The dataset and the spec are provided; the plot must match the spec.
 
-**Why `mcp-console` helps**:
+**Why `mcp-repl` helps**:
 - The agent can render and visually verify the result, then adjust iteratively.
 
 **Grader**:
@@ -154,7 +154,7 @@ If you build concrete task stubs, place them in a directory like `eval/tasks/`.
 
 **Prompt**: Use `RShowDoc("R-exts")` (or another large local manual), find specific technical facts (for example, exact API names, required flags, and caveats), and write a short answer with references to the matched sections.
 
-**Why `mcp-console` helps**:
+**Why `mcp-repl` helps**:
 - The agent can traverse very large output incrementally instead of reloading docs repeatedly.
 - Pager navigation commands (`:/`, `:n`, `:seek`, `:skip`, `:where`) reduce search latency in long manuals.
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -64,6 +64,10 @@ Optional `bwrap` stage:
 - `MCP_CONSOLE_LINUX_BWRAP_NO_PROC=1` skips `/proc` mounting.
 - if `bwrap` is requested but unavailable, worker startup fails fast.
 
-## Windows status
+## Windows behavior (experimental)
 
-Windows support exists but is still experimental.
+- R backend is supported with the same policy surface (`read-only`, `workspace-write`, `danger-full-access`).
+- Python backend is currently unavailable on Windows (it requires a Unix PTY).
+- `read-only` and `workspace-write` are enforced by the Windows sandbox runner.
+- `danger-full-access` and `external-sandbox` run without built-in sandbox enforcement.
+- Some Windows environments may not support the restricted-token setup required by sandboxed modes.


### PR DESCRIPTION
Summary
- Document that `mcp-repl --config` is not yet implemented and describe the envisioned future option.
- Refine the eval suite notes to stress keeping new task catalogs in the prescribed format and location.
- Update sandbox guidance to highlight R cache roots, how to add data/config roots, and that Windows support remains experimental.