### PR TITLE
Fix pager range parser accepting extra tokens

### DIFF
--- a/src/pager/command.rs
+++ b/src/pager/command.rs
@@ -393,8 +393,12 @@ fn parse_range_spec(raw: &str) -> Option<(usize, usize)> {
     let mut parts = trimmed.split_whitespace();
     let first = parts.next()?;
     let second = parts.next();
+    let third = parts.next();
 
     if let Some(second) = second {
+        if third.is_some() {
+            return None;
+        }
         let start = first.parse::<usize>().ok()?;
         let end = second.parse::<usize>().ok()?;
         if start == 0 || end == 0 {
@@ -507,5 +511,10 @@ mod tests {
         assert_eq!(spec.context, MAX_MATCH_CONTEXT);
         assert_eq!(spec.count, MAX_MATCH_LIMIT as u64);
         assert_eq!(spec.pattern.pattern, "bar");
+    }
+
+    #[test]
+    fn range_spec_rejects_extra_tokens() {
+        assert!(parse_range_spec("1 2 3").is_none());
     }
 }


### PR DESCRIPTION
### Motivation
- The `:range` pager command previously accepted inputs like `1 2 3` and silently ignored trailing tokens, which could mask malformed user input and lead to surprising behavior.

### Description
- Update `parse_range_spec` to detect and reject extra whitespace-separated tokens by ensuring exactly two numeric tokens are present for the two-argument form. 
- Add a unit test `range_spec_rejects_extra_tokens` that asserts `parse_range_spec("1 2 3").is_none()` to prevent regressions.
- Change is confined to `src/pager/command.rs` and does not alter other command parsing paths.

### Testing
- Ran `cargo check` which completed successfully.
- Ran `cargo build` and `cargo clippy` which completed successfully (one unrelated warning reported). 
- Ran `cargo test` which could not complete in this environment due to crates.io download failures (CONNECT tunnel 403), so tests could not be fully exercised here.
- Ran `cargo +nightly fmt` which failed due to rustup/nightly metadata download errors in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f46930d48332b67bdd89879214bc)