### PR TITLE
Fix Rust 1.95 clippy warnings

### DIFF
--- a/src/debug_repl.rs
+++ b/src/debug_repl.rs
@@ -67,11 +67,7 @@ pub(crate) fn run(
     let stdin = io::stdin();
     let mut stdin = stdin.lock();
 
-    loop {
-        let Some(line) = read_line(&mut stdin)? else {
-            break;
-        };
-
+    while let Some(line) = read_line(&mut stdin)? {
         if is_exact_command(&line, "INTERRUPT") {
             let reply = worker.interrupt(DEFAULT_WRITE_STDIN_TIMEOUT);
             render_visible_reply(

--- a/src/output_timeline.rs
+++ b/src/output_timeline.rs
@@ -323,10 +323,8 @@ fn echo_event_prefix_len(line: &[u8], event: &IpcEchoEvent) -> Option<usize> {
 
     let consumed = if let Some(consumed) = consumed.strip_suffix(b"\r\n") {
         consumed
-    } else if let Some(consumed) = consumed.strip_suffix(b"\n") {
-        consumed
     } else {
-        return None;
+        consumed.strip_suffix(b"\n")?
     };
     let prefix_len = prompt.len().saturating_add(consumed.len());
     if line.len() <= prefix_len {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1056,7 +1056,7 @@ fn normalize_snapshot_text(text: &str) -> String {
     }
 
     let mut out = String::new();
-    for line in stdout_lines.into_iter().chain(stderr_lines.into_iter()) {
+    for line in stdout_lines.into_iter().chain(stderr_lines) {
         out.push_str(&line);
     }
     out

--- a/tests/write_stdin_batch.rs
+++ b/tests/write_stdin_batch.rs
@@ -5,18 +5,22 @@ mod common;
 #[cfg(not(windows))]
 use common::McpSnapshot;
 use common::TestResult;
+#[cfg(not(windows))]
 use serde_json::json;
 use std::fs;
 use std::path::PathBuf;
+#[cfg(not(windows))]
 use std::sync::{Mutex, MutexGuard, OnceLock};
 #[cfg(not(windows))]
 use tokio::time::{Duration, sleep};
 
+#[cfg(not(windows))]
 fn test_mutex() -> &'static Mutex<()> {
     static TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
     TEST_MUTEX.get_or_init(|| Mutex::new(()))
 }
 
+#[cfg(not(windows))]
 fn lock_mutex(mutex: &Mutex<()>) -> MutexGuard<'_, ()> {
     match mutex.lock() {
         Ok(guard) => guard,
@@ -24,6 +28,7 @@ fn lock_mutex(mutex: &Mutex<()>) -> MutexGuard<'_, ()> {
     }
 }
 
+#[cfg(not(windows))]
 fn lock_test_mutex() -> MutexGuard<'static, ()> {
     lock_mutex(test_mutex())
 }


### PR DESCRIPTION
## Summary

This updates `mcp-repl` for the Rust 1.95 toolchain so `main` stays green after moving forward from 1.92. The failures were all from newly triggered clippy lints, including a Windows-only `unused import` / `dead code` case in `tests/write_stdin_batch.rs`.

## User-facing changes

- None. This is a toolchain-compatibility and CI-maintenance change.

## Internal changes

- Rewrite a small read loop in `debug_repl` to satisfy `clippy::while_let_loop`.
- Simplify a suffix-stripping branch in `output_timeline` to satisfy `clippy::question_mark`.
- Remove a redundant `.into_iter()` in test snapshot normalization.
- Gate non-Windows-only test imports and helpers in `write_stdin_batch.rs` so the Windows clippy job does not fail on unused symbols.

## Notes

- No behavioral changes are intended.
- The scope is limited to the fixes needed for the newer clippy lint set after upgrading from Rust 1.92.
