### PR TITLE
ci: make release backfill workflow release-only

### DIFF
--- a/.github/workflows/release-backfill.yml
+++ b/.github/workflows/release-backfill.yml
@@ -48,34 +48,10 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          components: clippy, rustfmt
           rustflags: ""
-
-      - name: Install nightly rustfmt
-        run: rustup toolchain install nightly --profile minimal --component rustfmt
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
-
-      - name: cargo check
-        run: cargo check
-
-      - name: cargo build
-        run: cargo build
-
-      - name: cargo clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
-
-      - name: cargo test (skip client integrations)
-        if: matrix.os != 'windows-2022'
-        run: cargo test -- --skip codex_tui_initial_sandbox_state --skip codex_tui_initial_sandbox_state_windows_stub
-
-      - name: cargo test (windows serial, skip client integrations)
-        if: matrix.os == 'windows-2022'
-        run: cargo test -j 1 -- --test-threads=1 --skip codex_tui_initial_sandbox_state --skip codex_tui_initial_sandbox_state_windows_stub
-
-      - name: cargo +nightly fmt
-        run: cargo +nightly fmt --all -- --check
 
       - name: cargo build --release
         run: cargo build --release --locked

--- a/tests/docs_contracts.rs
+++ b/tests/docs_contracts.rs
@@ -186,6 +186,13 @@ fn release_backfill_workflow_defines_manual_tag_publish_contract() {
         "group: publish-dev",
         "refs/heads/main",
         "github.event_name == 'push'",
+        "name: cargo check",
+        "name: cargo build\n        run: cargo build",
+        "name: cargo clippy",
+        "name: cargo test (skip client integrations)",
+        "name: cargo test (windows serial, skip client integrations)",
+        "name: cargo +nightly fmt",
+        "Install nightly rustfmt",
     ] {
         assert!(
             !workflow.contains(forbidden),


### PR DESCRIPTION
## Summary
Make the manual `Release Backfill` workflow build and publish historical tags without rerunning today's lint, test, and fmt gates.

## Public-facing changes
This keeps the backfill capability working for maintainers who need to publish an existing tag such as `v0.1.0`.

## Internal changes
The backfill workflow now only validates the tag, builds release binaries, smoke-tests them, packages the archives, and publishes the GitHub release.
It no longer runs `cargo check`, non-release `cargo build`, `cargo clippy`, `cargo test`, or nightly `rustfmt`, which can fail on historical tags under newer toolchains.
The docs contract test now enforces that the backfill workflow stays release-only.

## Testing
- `cargo check`
- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo +nightly fmt --all -- --check`