### PR TITLE
Add macOS managed network proxy for sandboxed workers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ Keep this file short. It is a table of contents, not the full manual.
 
 - For multi-phase refactors, redesigns, or other work that spans discovery, iteration, and implementation, keep a living plan under `docs/plans/active/` until the initiative is complete.
 - Use the plan to capture design decisions, rejected options, phase boundaries, unresolved questions, and the next safe slice of work so a later agent does not need to rediscover them.
+- Plans and future-work notes should include a motivating task, use case, or MRE-style scenario before design details. Capture what the agent, MCP client, server, worker, or user should be able to do, then list constraints and options.
 - If you pause or hand off work mid-task, update the plan before stopping.
 - Do not create plan files for routine, obvious, or low-risk changes. Keep the plans area useful, not noisy.
 - Move completed plans to `docs/plans/completed/`.

--- a/docs/futurework/managed-network-follow-up.md
+++ b/docs/futurework/managed-network-follow-up.md
@@ -1,0 +1,257 @@
+# Managed Network Follow-Up
+
+## Motivation
+
+Managed networking should support common agent workflows without making the
+worker's sandbox equivalent to open network access. Package installation is the
+first workflow, but not the only one.
+
+The important future tasks are:
+
+- Install packages from configured repositories such as CRAN, PyPI, or an
+  internal mirror while direct worker egress remains blocked.
+- Let the runtime connect to an explicitly allowed database, for example an R
+  `DBI::dbConnect()` call to `db.example.com:5432` or a local development
+  database on `127.0.0.1:5432`.
+- Let an agent iterate on a Shiny app from the runtime while a separate browser
+  tool, such as Playwright, drives the app. The worker should be able to bind a
+  local app port, the browser tool should be able to open that loopback URL, and
+  unrelated worker network access should remain blocked.
+- Let the runtime call an explicitly allowed local service, such as a local API
+  used by tests or examples, without also allowing arbitrary remote network
+  access.
+
+This note is not a final design. It records the target scenarios, current
+constraints, and implementation tradeoffs so the next slice can choose an
+approach without rediscovering the same boundary conditions.
+
+## Target Scenarios
+
+### Package Repository Access
+
+Minimal task:
+
+1. Start `mcp-repl` with `workspace-write`, network access enabled, and allowed
+   domains for a package repository.
+2. The agent asks the runtime to install or resolve a package.
+3. The worker can reach the configured repository through managed networking.
+4. Direct worker socket egress to unrelated hosts remains blocked.
+
+This is the current macOS happy path for HTTP(S)-aware package tooling.
+
+### Database Access
+
+Minimal task:
+
+1. Start `mcp-repl` with a policy that allows a specific database endpoint such
+   as `db.example.com:5432` or `127.0.0.1:5432`.
+2. The agent asks the runtime to run a small DBI query.
+3. The worker can connect to that endpoint and port.
+4. The worker cannot connect to other database ports or unrelated hosts.
+
+This needs a policy surface that can express TCP host+port intent. Treating all
+database access as HTTP proxy traffic is the wrong abstraction.
+
+### Shiny App Iteration
+
+Minimal task:
+
+1. The agent asks the runtime to start a Shiny app on an explicit loopback
+   address and port, for example `127.0.0.1:3838`.
+2. The server applies a sandbox policy that allows the worker to bind and serve
+   that loopback port.
+3. A browser tool outside the worker, such as Playwright, opens
+   `http://127.0.0.1:3838`.
+4. The agent edits code, restarts or refreshes the app, and inspects behavior in
+   the browser tool.
+5. The worker still cannot bind public interfaces or reach arbitrary remote
+   hosts.
+
+This needs local bind and inbound loopback permissions that are separate from
+general local outbound connect permissions.
+
+### Local Service Access
+
+Minimal task:
+
+1. Start `mcp-repl` with a policy that allows a specific loopback endpoint, for
+   example `127.0.0.1:8000`.
+2. A local service outside the worker is already listening on that endpoint.
+3. The agent asks the runtime to call the local API from R or Python.
+4. The worker can connect to that endpoint and port.
+5. The worker cannot connect to other local services or unrelated remote hosts.
+
+This needs explicit loopback connect permission. It is separate from Shiny app
+iteration, where the worker binds a port and a browser tool connects to it.
+
+## Current Shape
+
+- The server starts a server-owned HTTP/SOCKS proxy when domain allow/deny rules
+  are configured with network access enabled.
+- The worker receives proxy environment variables for common HTTP, HTTPS, and
+  SOCKS-aware tools.
+- macOS Seatbelt permits outbound network traffic only to the proxy's loopback
+  ports while managed networking is active.
+- The proxy validates host/domain patterns before dialing upstream.
+- Host matching supports exact hosts, `*.example.com`, and `**.example.com`.
+- Exact URL/path filtering is intentionally unsupported because normal HTTPS
+  proxying exposes only the `CONNECT host:port` target.
+
+## Research Context
+
+The current macOS slice and review loop established these boundaries. This
+section keeps that reconnaissance visible for future work; it is context, not a
+roadmap.
+
+The direct-egress guarantees below are macOS/Seatbelt-specific. Future Linux or
+Windows slices need equivalent OS-level enforcement before they can make the
+same claims.
+
+Already addressed in the current slice:
+
+- Direct worker egress is blocked by Seatbelt while managed networking is
+  active. Proxy-aware tools use the server-owned loopback proxy, while tools
+  that ignore proxy environment variables still fail closed.
+- Resolved upstream addresses are checked before dialing. Non-public upstreams,
+  including IPv4-mapped IPv6 special ranges, are rejected except for loopback
+  addresses when local binding is explicitly enabled.
+- Plain HTTP proxy requests reject `Host` headers that do not match the checked
+  absolute-form target.
+- Plain HTTP proxy connections are treated as one-request streams, so a later
+  request on a reused client connection cannot silently use the first checked
+  upstream.
+
+Open boundaries found during the same investigation:
+
+- HTTPS `CONNECT` proves only the requested tunnel endpoint. It does not prove
+  the TLS SNI or HTTP authority inside the tunnel.
+- SOCKS support is a generic TCP tunnel. It helps compatibility for tools that
+  only honor `ALL_PROXY`, but it does not provide HTTP URL/path visibility.
+- Domain rules currently do not express port intent. Allowing a host allows
+  every requested port on that host.
+- Wildcards and package repositories are broad trust boundaries. Managed
+  networking constrains worker egress; it does not make downloaded package code
+  safe or turn macOS broad reads into a data-loss-prevention boundary.
+
+## Design Constraints
+
+- Managed package/web access, explicit TCP connect, and local app serving are
+  different capabilities. They may need different policy fields and different
+  enforcement paths.
+- Tools that honor proxy environment variables should work transparently.
+  Tools that ignore them must still be constrained by the OS sandbox.
+- Local database connect does not imply local app bind. Local app bind does not
+  imply remote network access.
+- Specific URL policy entries should be documented carefully. For ordinary
+  HTTPS traffic, the current proxy shape can derive host and optional port
+  intent from a URL, but it cannot enforce path or query rules, and it cannot
+  prove the bytes inside a `CONNECT` tunnel are HTTP for the requested scheme.
+  Enforcing paths such as `https://pypi.org/simple/` requires TLS interception,
+  a controlled mirror, or a package-manager-specific path.
+- Allowing package repositories allows downloaded package code to execute
+  inside the sandbox. Managed networking constrains egress; it does not make
+  untrusted packages safe.
+- On macOS, broad read permissions mean managed networking should not be treated
+  as a data-loss-prevention boundary.
+
+## Known Hardening Gaps
+
+### CONNECT Host Does Not Prove TLS Destination
+
+For HTTPS, the proxy checks the `CONNECT host:port` authority and then tunnels
+bytes unchanged. The worker or a worker child process can ask the proxy to
+connect to an allowlisted host while using TLS SNI and HTTP authority for a
+different host served by the same edge infrastructure.
+
+Example class:
+
+- allowlist contains `pypi.org`,
+- the worker or a worker child process sends `CONNECT pypi.org:443`,
+- TLS ClientHello uses SNI `www.python.org`,
+- the edge serves `www.python.org`.
+
+This is not arbitrary internet access. It works when the allowlisted host's
+resolved address or edge fabric can also serve the other hostname. That can
+still be a large surface for domains hosted on shared CDNs.
+
+Minimal R reproduction:
+
+Start `mcp-repl` with managed networking enabled and only `pypi.org`
+allowlisted. Then run this from the R runtime:
+
+```r
+library(curl)
+
+h <- new_handle()
+handle_setopt(
+  h,
+  connect_to = "www.python.org:443:pypi.org:443"
+)
+
+res <- curl_fetch_memory("https://www.python.org/", h)
+body <- rawToChar(res$content)
+
+stopifnot(res$status_code == 200L)
+stopifnot(grepl("Python", body))
+cat(substr(body, 1, 200))
+```
+
+The important detail is that the request URL and TLS SNI are
+`www.python.org`, while `connect_to` makes the proxy tunnel target
+`pypi.org:443`. If the current managed proxy only checks the `CONNECT` target,
+the request can succeed even though `www.python.org` is not allowlisted.
+
+This concrete `pypi.org` and `www.python.org` pair depends on edge routing that
+may change. If it stops reproducing, the underlying class remains: the
+`CONNECT` authority and the TLS SNI or HTTP authority inside the tunnel can
+diverge unless the proxy checks them.
+
+### SOCKS Is A Generic TCP Tunnel
+
+The managed proxy exposes SOCKS so tools that only honor `ALL_PROXY` can work.
+SOCKS is not HTTP-aware and does not give the proxy URL/path semantics. Without
+additional protocol gates, any allowed host can become a generic TCP endpoint.
+
+### Ports Are Not Currently Part Of The Domain Policy
+
+Allowing a host allows connections to any requested port on that host. That is
+broader than package-manager HTTPS needs, which is usually port 443.
+
+### Domain Rules Are Coarse
+
+Wildcard domains are intentionally convenient but broad. `**.example.com`
+allows the apex and every subdomain, including future or compromised
+subdomains. Domain rules also cannot distinguish package repository paths from
+other services on the same host.
+
+## Possible Directions
+
+These are implementation options, not a prescribed roadmap.
+
+- Add explicit TCP connect allowlists for database and service endpoints, for
+  example `db.example.com:5432`.
+- Split local loopback connect from local loopback bind/inbound permissions, so
+  database workflows and Shiny workflows can be enabled independently.
+- Restrict HTTP `CONNECT` to package-repository-shaped traffic, such as port
+  443 by default, unless an explicit TCP policy grants a different port.
+- Add TLS ClientHello SNI validation for `CONNECT` to reduce host/SNI mismatch
+  risk without terminating TLS.
+- Remove SOCKS from the default managed web path, or gate SOCKS traffic by port
+  and protocol when compatibility requires it.
+- Use controlled package mirrors when package governance needs path or package
+  identity guarantees outside `mcp-repl`.
+- Consider HTTPS MITM only if URL/path policy becomes a first-class requirement;
+  certificate management and trust-store changes make that a much larger
+  feature.
+
+## Next Slice Guidance
+
+Choose the next design by starting from one concrete task. Good first slices are:
+
+- explicit TCP connect for one database endpoint,
+- explicit loopback bind/inbound for Shiny app iteration,
+- explicit loopback connect for one local service endpoint,
+- TLS SNI gating for the existing package-repository proxy path.
+
+Each slice should include a minimal end-to-end scenario that proves the intended
+workflow works and that unrelated network access still fails closed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ checked-in execution plans without relying on stale notes.
 - `docs/futurework/advisory-worker-write-observations.md`: deferred note on emitting best-effort IPC metadata for worker-owned stdout/stderr writes without replacing pipe capture.
 - `docs/futurework/composable-tool-descriptions.md`: deferred design note on replacing the current multi-file `repl` description matrix with one composable template plus runtime interpolation.
 - `docs/futurework/offline-manual-surfaces.md`: deferred design note on exposing R manuals and future Python manuals through better offline model-facing surfaces than the current inline `RShowDoc()` flow.
+- `docs/futurework/managed-network-follow-up.md`: target workflows and tradeoffs for package, database, Shiny, local-app, and managed-network follow-up work.
 - `docs/futurework/per-turn-history-bundles.md`: design brief for always-materialized per-turn REPL history bundles.
 - `docs/futurework/r-embedding-minimal-callbacks.md`: deferred note on reducing custom embedded-R callbacks while keeping readline integration.
 - `docs/futurework/r-graphics-device-for-incremental-plot-emission.md`: deferred design note on replacing hook/replay plot capture with a device-level path that can emit plots before grouped expressions finish.

--- a/docs/plans/active/managed-network-proxy.md
+++ b/docs/plans/active/managed-network-proxy.md
@@ -43,7 +43,7 @@
 
 - Which Linux routing mechanism should become the long-term implementation: the existing internal sandbox helper, a socket bridge, or a separate network namespace path.
 - Whether a future HTTPS MITM mode is worth the certificate-management surface for URL/path-level filtering.
-- Which hardening slice should land first for the current macOS proxy: TLS SNI gating for `CONNECT`, SOCKS removal/gating, explicit TCP allowlists, or split local connect/bind controls. See `docs/futurework/managed-network-hardening.md`.
+- Which managed-network follow-up slice should land first: explicit database TCP connect, local Shiny bind/inbound support, TLS SNI gating for `CONNECT`, SOCKS removal/gating, or split local connect/bind controls. See `docs/futurework/managed-network-follow-up.md`.
 
 ## Next Safe Slice
 
@@ -62,4 +62,4 @@
 - 2026-04-30: Chose a server-owned proxy with environment-variable routing plus OS sandbox egress limits rather than transparent kernel redirection.
 - 2026-04-30: Scoped matching to host/domain patterns after deciding exact HTTPS URL filtering would require a separate MITM design.
 - 2026-04-30: Implemented the macOS slice with a small in-process HTTP/SOCKS proxy in `src/managed_network.rs`, CLI/config validation for host patterns, and worker launch wiring that injects proxy env vars before Seatbelt policy rendering.
-- 2026-05-01: Documented current managed-network hardening gaps and mitigation tradeoffs after demonstrating that an allowlisted `CONNECT` host can be paired with a different TLS SNI on shared edge infrastructure.
+- 2026-05-01: Documented managed-network follow-up scenarios and tradeoffs for package, database, Shiny, local-service, and hardening workflows.

--- a/docs/plans/active/managed-network-proxy.md
+++ b/docs/plans/active/managed-network-proxy.md
@@ -1,0 +1,65 @@
+# Managed Network Proxy
+
+## Summary
+
+- Add a macOS-first managed network proxy for workers.
+- Keep existing full-network sandbox behavior unchanged when no managed domain rules are configured.
+- Keep Linux and Windows as explicit follow-up phases with clear unsupported errors for managed domain enforcement.
+
+## Status
+
+- State: active
+- Last updated: 2026-05-01
+- Current phase: Linux planning
+
+## Current Direction
+
+- Use a server-owned HTTP/SOCKS proxy, proxy environment variables injected into the worker, and macOS Seatbelt egress limited to the proxy's loopback ports.
+- Use host/domain matching only for this slice. Exact URL/path filtering is out of scope because normal HTTPS proxying exposes only the `CONNECT host:port` target unless a MITM certificate flow is added.
+- Keep the code small and local to `mcp-repl`: use a simple proxy runtime tailored to package-install workflows.
+
+## Long-Term Direction
+
+- Linux should route worker traffic through a server-owned proxy from inside the Linux sandbox without allowing direct egress.
+- Windows should use the same policy surface once the Windows sandbox can route worker traffic through a managed proxy.
+- A future UI or approval flow can amend allow/deny rules, but this phase only supports static CLI/config rules.
+
+## Phase Status
+
+- Phase 0: completed - chose the managed proxy shape and enforcement boundary.
+- Phase 1: completed - implemented macOS managed proxy and public tests.
+- Phase 2: pending - Linux enforcement.
+- Phase 3: pending - Windows enforcement.
+
+## Locked Decisions
+
+- macOS enforcement uses Seatbelt loopback-only egress to the managed proxy ports.
+- Domain policy is deny-first and allowlist-based.
+- Supported patterns are exact hosts, `*.example.com`, and `**.example.com`.
+- Exact URLs are rejected instead of being silently reduced to hosts.
+- Proxy-aware tools are the transparency target; tools that ignore proxy env vars fail closed.
+
+## Open Questions
+
+- Which Linux routing mechanism should become the long-term implementation: the existing internal sandbox helper, a socket bridge, or a separate network namespace path.
+- Whether a future HTTPS MITM mode is worth the certificate-management surface for URL/path-level filtering.
+- Which hardening slice should land first for the current macOS proxy: TLS SNI gating for `CONNECT`, SOCKS removal/gating, explicit TCP allowlists, or split local connect/bind controls. See `docs/futurework/managed-network-hardening.md`.
+
+## Next Safe Slice
+
+- Design the Linux routing path for managed domain enforcement.
+- Keep the same public policy surface: exact hosts, `*.example.com`, and `**.example.com`.
+- Preserve fail-closed behavior when domain rules are configured but a platform cannot enforce them.
+
+## Stop Conditions
+
+- Stop and ask if a fix requires broadening this phase beyond macOS enforcement.
+- Stop and ask if package-install support requires HTTPS path filtering instead of host/domain allowlisting.
+- Stop and ask if managed proxy support would weaken existing `network_access=false` behavior.
+
+## Decision Log
+
+- 2026-04-30: Chose a server-owned proxy with environment-variable routing plus OS sandbox egress limits rather than transparent kernel redirection.
+- 2026-04-30: Scoped matching to host/domain patterns after deciding exact HTTPS URL filtering would require a separate MITM design.
+- 2026-04-30: Implemented the macOS slice with a small in-process HTTP/SOCKS proxy in `src/managed_network.rs`, CLI/config validation for host patterns, and worker launch wiring that injects proxy env vars before Seatbelt policy rendering.
+- 2026-05-01: Documented current managed-network hardening gaps and mitigation tradeoffs after demonstrating that an allowlisted `CONNECT` host can be paired with a different TLS SNI on shared edge infrastructure.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -10,13 +10,13 @@ When no CLI sandbox mode is provided, the default is:
 - `workspace-write`
 - `network_access: false`
 
-When `--sandbox inherit` is used for MCP server operation, the client must
+When `--sandbox inherit` is used for MCP server operation, the MCP client must
 attach per-tool-call sandbox metadata in `_meta["codex/sandbox-state-meta"]`.
 That metadata is the source of truth for the tool call that is about to run. If
 it is missing or malformed, `mcp-repl` fails closed with `--sandbox inherit
 requested but no client sandbox state was provided`.
 
-`--debug-repl` is the one local-only exception. Because there is no client
+`--debug-repl` is the one local-only exception. Because there is no MCP client
 metadata channel in that mode, `mcp-repl --debug-repl --sandbox inherit`
 bootstraps one local inherited snapshot from the current default sandbox state
 before the first worker spawn.
@@ -74,7 +74,7 @@ The worker also gets a per-session temp directory, exported as:
 - Add allowed domains (repeatable):
   `mcp-repl --add-allowed-domain <pattern>`
 - Advanced overrides:
-  `mcp-repl --config key=value` with Codex-shaped keys
+  `mcp-repl --config key=value` with documented sandbox/config keys
 - MCP sandbox metadata capability:
   `codex/sandbox-state-meta` (advertised only when the effective CLI sandbox mode still resolves to `inherit` after later overrides)
 
@@ -89,7 +89,7 @@ For `workspace-write`, writable roots include:
 
 - configured `writable_roots` (absolute paths only),
 - current working directory,
-- R cache roots configured in client policy,
+- R cache roots configured in MCP client policy,
 - temp roots (`/tmp`, `TMPDIR` when absolute), and
 - the per-session temp directory.
 
@@ -107,8 +107,35 @@ Proxy-aware network behavior when `network_access: true`:
 - proxy env vars are inspected (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and lowercase variants),
 - loopback proxy endpoints are allowlisted for outbound traffic,
 - proxy configured but no usable loopback endpoint => fail closed (no network),
-- `MCP_REPL_MANAGED_NETWORK=1` enforces proxy-only mode,
+- when allowed or denied domains are configured, the server starts a managed
+  HTTP/SOCKS proxy on loopback, injects proxy env vars into the worker, and
+  permits Seatbelt egress only to that proxy,
+- `MCP_REPL_MANAGED_NETWORK=1` enforces proxy-only mode for an externally
+  configured loopback proxy,
+- domain rules support exact hosts, `*.example.com` subdomains, and
+  `**.example.com` for the apex plus subdomains,
+- exact URLs such as `https://pypi.org/simple/` are rejected; HTTPS proxying
+  can enforce the `CONNECT` host but not URL paths,
 - `ALLOW_LOCAL_BINDING=1` additionally allows localhost bind/inbound operations.
+
+Example PyPI allowlist:
+
+```sh
+mcp-repl --sandbox workspace-write \
+  --config sandbox_workspace_write.network_access=true \
+  --add-allowed-domain pypi.org \
+  --add-allowed-domain files.pythonhosted.org
+```
+
+Example CRAN allowlist:
+
+```sh
+mcp-repl --sandbox workspace-write \
+  --config sandbox_workspace_write.network_access=true \
+  --add-allowed-domain cran.r-project.org \
+  --add-allowed-domain cloud.r-project.org \
+  --add-allowed-domain '**.r-project.org'
+```
 
 ## Linux behavior
 
@@ -117,8 +144,10 @@ Sandboxing is enforced by a Linux sandbox helper that applies seccomp + Landlock
 - `workspace-write` always includes the per-session temp directory in writable roots.
 - `read-only` is translated to a minimal writable setup for the session temp directory only.
 - default Linux worker setup disables network unless explicitly enabled.
-- `mcp-repl` always uses its own internal Linux sandbox launcher; client-provided
-  helper executable paths are ignored.
+- managed domain allowlists are not enforced on Linux yet; configuring allowed
+  or denied domains with enabled network access currently fails closed.
+- `mcp-repl` always uses its own internal Linux sandbox launcher; helper
+  executable paths provided by an MCP client are ignored.
 - Codex sandbox metadata does not control `mcp-repl`'s optional internal
   `bwrap` stage. That remains a local best-effort setting.
 
@@ -133,6 +162,8 @@ Optional `bwrap` stage:
 
 - R backend is supported with the same policy surface (`read-only`, `workspace-write`, `danger-full-access`).
 - Python backend is currently unavailable on Windows (it requires a Unix PTY).
+- managed domain allowlists are not enforced on Windows yet; configuring allowed
+  or denied domains with enabled network access currently fails closed.
 - `read-only` and `workspace-write` use a two-stage Windows sandbox model:
   - the parent prepares and reuses stable filesystem ACL state for the effective sandbox policy,
   - the internal Windows wrapper requires prepared launch state and applies launch-scoped ACLs for the worker run.

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod html_to_markdown;
 mod input_protocol;
 mod install;
 mod ipc;
+mod managed_network;
 mod output_capture;
 mod output_stream;
 mod output_timeline;
@@ -198,6 +199,10 @@ fn parse_cli_args_from(args: Vec<String>) -> Result<CliCommand, Box<dyn std::err
                 if value.is_empty() {
                     return Err("missing value for --add-allowed-domain".into());
                 }
+                crate::managed_network::validate_domain_patterns(
+                    "--add-allowed-domain",
+                    &[value.to_string()],
+                )?;
                 sandbox_args
                     .plan
                     .operations
@@ -208,12 +213,15 @@ fn parse_cli_args_from(args: Vec<String>) -> Result<CliCommand, Box<dyn std::err
                 if value.trim().is_empty() {
                     return Err("missing value for --add-allowed-domain".into());
                 }
+                let value = value.trim();
+                crate::managed_network::validate_domain_patterns(
+                    "--add-allowed-domain",
+                    &[value.to_string()],
+                )?;
                 sandbox_args
                     .plan
                     .operations
-                    .push(SandboxCliOperation::AddAllowedDomain(
-                        value.trim().to_string(),
-                    ));
+                    .push(SandboxCliOperation::AddAllowedDomain(value.to_string()));
             }
             "--config" => {
                 let value = parser.next_value("--config")?;
@@ -665,6 +673,35 @@ mod tests {
             SandboxConfigOperation::SetAllowedDomains(values)
                 if values == vec!["pypi.org".to_string(), "files.pythonhosted.org".to_string()]
         ));
+    }
+
+    #[test]
+    fn parse_config_override_rejects_exact_url_allowed_domains() {
+        let err = parse_sandbox_config_override(
+            "permissions.network.allowed_domains=[\"https://pypi.org/simple/\"]",
+        )
+        .expect_err("exact URL domain entry should be rejected");
+        assert!(
+            err.contains("host patterns"),
+            "expected host-pattern error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_cli_args_rejects_exact_url_allowed_domain() {
+        let err = match parse_cli_args_from(vec![
+            "--sandbox".to_string(),
+            "workspace-write".to_string(),
+            "--add-allowed-domain".to_string(),
+            "https://pypi.org/simple/".to_string(),
+        ]) {
+            Ok(_) => panic!("exact URL domain entry should be rejected"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("host patterns"),
+            "expected host-pattern error, got: {err}"
+        );
     }
 
     #[test]

--- a/src/managed_network.rs
+++ b/src/managed_network.rs
@@ -1,0 +1,817 @@
+use std::collections::HashMap;
+use std::io;
+use std::io::Read;
+use std::io::Write;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::Ipv6Addr;
+use std::net::Shutdown;
+use std::net::SocketAddr;
+use std::net::TcpListener;
+use std::net::TcpStream;
+use std::net::ToSocketAddrs;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use crate::sandbox::ManagedNetworkPolicy;
+
+// Server-owned proxy routing with OS sandbox egress limited to loopback proxy
+// ports. Matching is host-only because HTTPS CONNECT does not expose URL paths.
+const MAX_HTTP_HEADER_BYTES: usize = 64 * 1024;
+const LISTENER_IDLE_SLEEP: Duration = Duration::from_millis(20);
+const PROXY_ACTIVE_ENV_KEY: &str = "MCP_REPL_MANAGED_NETWORK_PROXY_ACTIVE";
+const DEFAULT_NO_PROXY_VALUE: &str =
+    "localhost,127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16";
+
+const HTTP_PROXY_ENV_KEYS: &[&str] = &[
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "YARN_HTTP_PROXY",
+    "YARN_HTTPS_PROXY",
+    "npm_config_http_proxy",
+    "npm_config_https_proxy",
+    "npm_config_proxy",
+    "NPM_CONFIG_HTTP_PROXY",
+    "NPM_CONFIG_HTTPS_PROXY",
+    "NPM_CONFIG_PROXY",
+    "BUNDLE_HTTP_PROXY",
+    "BUNDLE_HTTPS_PROXY",
+    "PIP_PROXY",
+    "DOCKER_HTTP_PROXY",
+    "DOCKER_HTTPS_PROXY",
+    "WS_PROXY",
+    "WSS_PROXY",
+    "ws_proxy",
+    "wss_proxy",
+];
+const SOCKS_PROXY_ENV_KEYS: &[&str] = &["ALL_PROXY", "all_proxy", "FTP_PROXY", "ftp_proxy"];
+const NO_PROXY_ENV_KEYS: &[&str] = &["NO_PROXY", "no_proxy", "npm_config_noproxy"];
+
+#[derive(Debug)]
+pub enum ManagedNetworkError {
+    InvalidDomainPattern(String),
+    Io(io::Error),
+}
+
+impl std::fmt::Display for ManagedNetworkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidDomainPattern(message) => f.write_str(message),
+            Self::Io(err) => write!(f, "managed network proxy I/O error: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for ManagedNetworkError {}
+
+impl From<io::Error> for ManagedNetworkError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedProxyConfig {
+    pub allowed_domains: Vec<String>,
+    pub denied_domains: Vec<String>,
+    pub allow_local_binding: bool,
+}
+
+impl ManagedProxyConfig {
+    pub fn from_policy(policy: &ManagedNetworkPolicy) -> Result<Self, ManagedNetworkError> {
+        validate_domain_patterns(
+            "permissions.network.allowed_domains",
+            &policy.allowed_domains,
+        )
+        .map_err(ManagedNetworkError::InvalidDomainPattern)?;
+        validate_domain_patterns("permissions.network.denied_domains", &policy.denied_domains)
+            .map_err(ManagedNetworkError::InvalidDomainPattern)?;
+        Ok(Self {
+            allowed_domains: policy.allowed_domains.clone(),
+            denied_domains: policy.denied_domains.clone(),
+            allow_local_binding: policy.allow_local_binding,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+enum DomainPattern {
+    Exact(String),
+    SubdomainsOnly(String),
+    ApexAndSubdomains(String),
+}
+
+impl DomainPattern {
+    fn parse(raw: &str) -> Result<Self, String> {
+        validate_domain_pattern(raw)?;
+        let normalized = normalize_host(raw);
+        if let Some(domain) = normalized.strip_prefix("**.") {
+            Ok(Self::ApexAndSubdomains(domain.to_string()))
+        } else if let Some(domain) = normalized.strip_prefix("*.") {
+            Ok(Self::SubdomainsOnly(domain.to_string()))
+        } else {
+            Ok(Self::Exact(normalized))
+        }
+    }
+
+    fn matches(&self, host: &str) -> bool {
+        match self {
+            Self::Exact(pattern) => host == pattern,
+            Self::SubdomainsOnly(domain) => {
+                host.len() > domain.len()
+                    && host.ends_with(domain)
+                    && host.as_bytes().get(host.len() - domain.len() - 1) == Some(&b'.')
+            }
+            Self::ApexAndSubdomains(domain) => {
+                host == domain
+                    || (host.len() > domain.len()
+                        && host.ends_with(domain)
+                        && host.as_bytes().get(host.len() - domain.len() - 1) == Some(&b'.'))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct HostPolicy {
+    allowed: Vec<DomainPattern>,
+    denied: Vec<DomainPattern>,
+    allow_local_binding: bool,
+}
+
+impl HostPolicy {
+    fn new(config: &ManagedProxyConfig) -> Result<Self, ManagedNetworkError> {
+        let allowed = config
+            .allowed_domains
+            .iter()
+            .map(|pattern| DomainPattern::parse(pattern))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(ManagedNetworkError::InvalidDomainPattern)?;
+        let denied = config
+            .denied_domains
+            .iter()
+            .map(|pattern| DomainPattern::parse(pattern))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(ManagedNetworkError::InvalidDomainPattern)?;
+        Ok(Self {
+            allowed,
+            denied,
+            allow_local_binding: config.allow_local_binding,
+        })
+    }
+
+    fn allows(&self, host: &str) -> bool {
+        let host = normalize_host(host);
+        if host.is_empty() || host_contains_control_chars(&host) {
+            return false;
+        }
+        if self.denied.iter().any(|pattern| pattern.matches(&host)) {
+            return false;
+        }
+        if !self.allow_local_binding && is_local_or_private_host(&host) {
+            return false;
+        }
+        !self.allowed.is_empty() && self.allowed.iter().any(|pattern| pattern.matches(&host))
+    }
+
+    fn allows_socket_addr(&self, addr: SocketAddr) -> bool {
+        self.allow_local_binding || !is_non_public_ip(addr.ip())
+    }
+}
+
+pub struct ManagedNetworkProxy {
+    config: ManagedProxyConfig,
+    http_addr: SocketAddr,
+    socks_addr: SocketAddr,
+    shutdown: Arc<AtomicBool>,
+    listener_threads: Vec<thread::JoinHandle<()>>,
+}
+
+impl ManagedNetworkProxy {
+    pub fn start(config: ManagedProxyConfig) -> Result<Self, ManagedNetworkError> {
+        let policy = Arc::new(HostPolicy::new(&config)?);
+        let http_listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))?;
+        let socks_listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))?;
+        let http_addr = http_listener.local_addr()?;
+        let socks_addr = socks_listener.local_addr()?;
+        http_listener.set_nonblocking(true)?;
+        socks_listener.set_nonblocking(true)?;
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let listener_threads = vec![
+            spawn_http_listener(http_listener, Arc::clone(&policy), Arc::clone(&shutdown)),
+            spawn_socks_listener(socks_listener, policy, Arc::clone(&shutdown)),
+        ];
+
+        Ok(Self {
+            config,
+            http_addr,
+            socks_addr,
+            shutdown,
+            listener_threads,
+        })
+    }
+
+    pub fn config(&self) -> &ManagedProxyConfig {
+        &self.config
+    }
+
+    pub fn http_addr(&self) -> SocketAddr {
+        self.http_addr
+    }
+
+    pub fn socks_addr(&self) -> SocketAddr {
+        self.socks_addr
+    }
+
+    pub fn apply_to_env(&self, env: &mut HashMap<String, String>) {
+        let http_proxy_url = format!("http://{}", self.http_addr);
+        let socks_proxy_url = format!("socks5h://{}", self.socks_addr);
+        env.insert(PROXY_ACTIVE_ENV_KEY.to_string(), "1".to_string());
+        set_env_keys(env, HTTP_PROXY_ENV_KEYS, &http_proxy_url);
+        set_env_keys(env, SOCKS_PROXY_ENV_KEYS, &socks_proxy_url);
+        set_env_keys(env, NO_PROXY_ENV_KEYS, DEFAULT_NO_PROXY_VALUE);
+    }
+}
+
+impl Drop for ManagedNetworkProxy {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = TcpStream::connect(self.http_addr);
+        let _ = TcpStream::connect(self.socks_addr);
+        for handle in self.listener_threads.drain(..) {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn set_env_keys(env: &mut HashMap<String, String>, keys: &[&str], value: &str) {
+    for key in keys {
+        env.insert((*key).to_string(), value.to_string());
+    }
+}
+
+pub fn validate_domain_patterns(label: &str, patterns: &[String]) -> Result<(), String> {
+    for pattern in patterns {
+        validate_domain_pattern(pattern)
+            .map_err(|err| format!("{label} entries must be host patterns: {err}"))?;
+    }
+    Ok(())
+}
+
+fn validate_domain_pattern(raw: &str) -> Result<(), String> {
+    let pattern = raw.trim();
+    if pattern.is_empty() {
+        return Err("empty pattern".to_string());
+    }
+    if pattern.contains("://") || pattern.contains('/') || pattern.contains(':') {
+        return Err(format!(
+            "{pattern:?} is not supported; use a host pattern like pypi.org or *.example.com"
+        ));
+    }
+    if pattern == "*" {
+        return Err("global wildcard \"*\" is not supported".to_string());
+    }
+
+    let domain = if let Some(domain) = pattern.strip_prefix("**.") {
+        domain
+    } else if let Some(domain) = pattern.strip_prefix("*.") {
+        domain
+    } else {
+        pattern
+    };
+
+    if domain.contains('*') {
+        return Err(format!("{pattern:?} contains an unsupported wildcard"));
+    }
+    if domain.eq_ignore_ascii_case("localhost") || domain.parse::<Ipv4Addr>().is_ok() {
+        return Ok(());
+    }
+    validate_dns_name(domain).map_err(|err| format!("{pattern:?}: {err}"))
+}
+
+fn validate_dns_name(domain: &str) -> Result<(), &'static str> {
+    if !domain.contains('.') {
+        return Err("domain must contain at least one dot");
+    }
+    if domain.starts_with('.') || domain.ends_with('.') {
+        return Err("domain must not start or end with a dot");
+    }
+    for part in domain.split('.') {
+        if part.is_empty() {
+            return Err("domain labels must not be empty");
+        }
+        if part.starts_with('-') || part.ends_with('-') {
+            return Err("domain labels must not start or end with '-'");
+        }
+        if !part
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        {
+            return Err("domain labels may contain only letters, digits, and '-'");
+        }
+    }
+    Ok(())
+}
+
+fn normalize_host(host: &str) -> String {
+    let host = host.trim().trim_end_matches('.').to_ascii_lowercase();
+    if host.starts_with('[') && host.ends_with(']') && host.len() > 2 {
+        host[1..host.len() - 1].to_string()
+    } else {
+        host
+    }
+}
+
+fn host_contains_control_chars(host: &str) -> bool {
+    host.bytes().any(|byte| byte < 0x20 || byte == 0x7f)
+}
+
+fn is_local_or_private_host(host: &str) -> bool {
+    if host == "localhost" {
+        return true;
+    }
+    match host.parse::<IpAddr>() {
+        Ok(ip) => is_non_public_ip(ip),
+        Err(_) => false,
+    }
+}
+
+fn is_non_public_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => is_non_public_ipv4(ip),
+        IpAddr::V6(ip) => is_non_public_ipv6(ip),
+    }
+}
+
+fn is_non_public_ipv4(ip: Ipv4Addr) -> bool {
+    ip.is_loopback()
+        || ip.is_private()
+        || ip.is_link_local()
+        || ip.is_unspecified()
+        || ip.is_broadcast()
+        || ip.is_multicast()
+}
+
+fn is_non_public_ipv6(ip: Ipv6Addr) -> bool {
+    ip.is_loopback()
+        || ip.is_unspecified()
+        || ip.is_unique_local()
+        || ip.is_unicast_link_local()
+        || ip.is_multicast()
+}
+
+fn spawn_http_listener(
+    listener: TcpListener,
+    policy: Arc<HostPolicy>,
+    shutdown: Arc<AtomicBool>,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || listener_loop(listener, policy, shutdown, handle_http_client))
+}
+
+fn spawn_socks_listener(
+    listener: TcpListener,
+    policy: Arc<HostPolicy>,
+    shutdown: Arc<AtomicBool>,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || listener_loop(listener, policy, shutdown, handle_socks_client))
+}
+
+fn listener_loop(
+    listener: TcpListener,
+    policy: Arc<HostPolicy>,
+    shutdown: Arc<AtomicBool>,
+    handler: fn(TcpStream, Arc<HostPolicy>),
+) {
+    while !shutdown.load(Ordering::SeqCst) {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                let policy = Arc::clone(&policy);
+                thread::spawn(move || handler(stream, policy));
+            }
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                thread::sleep(LISTENER_IDLE_SLEEP);
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+fn handle_http_client(mut client: TcpStream, policy: Arc<HostPolicy>) {
+    if let Err(err) = handle_http_client_impl(&mut client, policy) {
+        let _ = write_http_error(&mut client, 502, &format!("proxy error: {err}"));
+    }
+}
+
+fn handle_http_client_impl(client: &mut TcpStream, policy: Arc<HostPolicy>) -> io::Result<()> {
+    let header = read_http_header(client)?;
+    let first_line_end = header
+        .windows(2)
+        .position(|window| window == b"\r\n")
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing request line"))?;
+    let first_line = std::str::from_utf8(&header[..first_line_end])
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "request line is not UTF-8"))?;
+    let mut parts = first_line.split_whitespace();
+    let method = parts
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing HTTP method"))?;
+    let target = parts
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing HTTP target"))?;
+    let version = parts.next().unwrap_or("HTTP/1.1");
+
+    if method.eq_ignore_ascii_case("CONNECT") {
+        let Some((host, port)) = parse_host_port(target, 443) else {
+            return write_http_error(client, 400, "invalid CONNECT target");
+        };
+        if !policy.allows(&host) {
+            return write_http_error(client, 403, "Connection blocked by network allowlist");
+        }
+        let Some(upstream) = connect_upstream(&host, port, policy.as_ref())? else {
+            return write_http_error(client, 403, "Connection blocked by network allowlist");
+        };
+        client.write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")?;
+        proxy_bidirectional(client.try_clone()?, upstream)?;
+        return Ok(());
+    }
+
+    let Some(absolute) = parse_absolute_http_target(target) else {
+        return write_http_error(client, 400, "expected absolute HTTP proxy request target");
+    };
+    if !policy.allows(&absolute.host) {
+        return write_http_error(client, 403, "Connection blocked by network allowlist");
+    }
+
+    let Some(mut upstream) = connect_upstream(&absolute.host, absolute.port, policy.as_ref())?
+    else {
+        return write_http_error(client, 403, "Connection blocked by network allowlist");
+    };
+    upstream.write_all(format!("{method} {} {version}\r\n", absolute.path).as_bytes())?;
+    upstream.write_all(&header[first_line_end + 2..])?;
+    proxy_bidirectional(client.try_clone()?, upstream)?;
+    Ok(())
+}
+
+fn read_http_header(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
+    let mut header = Vec::new();
+    let mut byte = [0_u8; 1];
+    while header.len() < MAX_HTTP_HEADER_BYTES {
+        let n = stream.read(&mut byte)?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "connection closed before HTTP headers completed",
+            ));
+        }
+        header.push(byte[0]);
+        if header.ends_with(b"\r\n\r\n") {
+            return Ok(header);
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "HTTP headers exceeded proxy limit",
+    ))
+}
+
+struct AbsoluteHttpTarget {
+    host: String,
+    port: u16,
+    path: String,
+}
+
+fn parse_absolute_http_target(target: &str) -> Option<AbsoluteHttpTarget> {
+    let rest = target.strip_prefix("http://")?;
+    let (authority, path) = match rest.find('/') {
+        Some(index) => (&rest[..index], &rest[index..]),
+        None => (rest, "/"),
+    };
+    let (host, port) = parse_host_port(authority, 80)?;
+    Some(AbsoluteHttpTarget {
+        host,
+        port,
+        path: path.to_string(),
+    })
+}
+
+fn parse_host_port(authority: &str, default_port: u16) -> Option<(String, u16)> {
+    if authority.starts_with('[') {
+        let end = authority.find(']')?;
+        let host = &authority[1..end];
+        let port = authority[end + 1..]
+            .strip_prefix(':')
+            .and_then(|port| port.parse::<u16>().ok())
+            .unwrap_or(default_port);
+        return Some((host.to_string(), port));
+    }
+
+    match authority.rsplit_once(':') {
+        Some((host, port)) if !host.is_empty() => {
+            Some((host.to_string(), port.parse::<u16>().ok()?))
+        }
+        _ if !authority.is_empty() => Some((authority.to_string(), default_port)),
+        _ => None,
+    }
+}
+
+fn connect_upstream(host: &str, port: u16, policy: &HostPolicy) -> io::Result<Option<TcpStream>> {
+    let addrs = (host, port).to_socket_addrs()?;
+    let mut last_err = None;
+    for addr in addrs {
+        if !policy.allows_socket_addr(addr) {
+            continue;
+        }
+        match TcpStream::connect(addr) {
+            Ok(stream) => return Ok(Some(stream)),
+            Err(err) => last_err = Some(err),
+        }
+    }
+    match last_err {
+        Some(err) => Err(err),
+        None => Ok(None),
+    }
+}
+
+fn write_http_error(stream: &mut TcpStream, status: u16, message: &str) -> io::Result<()> {
+    let reason = match status {
+        400 => "Bad Request",
+        403 => "Forbidden",
+        502 => "Bad Gateway",
+        _ => "Error",
+    };
+    stream.write_all(
+        format!(
+            "HTTP/1.1 {status} {reason}\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n{message}",
+            message.len()
+        )
+        .as_bytes(),
+    )
+}
+
+fn handle_socks_client(mut client: TcpStream, policy: Arc<HostPolicy>) {
+    let _ = handle_socks_client_impl(&mut client, policy);
+}
+
+fn handle_socks_client_impl(client: &mut TcpStream, policy: Arc<HostPolicy>) -> io::Result<()> {
+    let mut greeting = [0_u8; 2];
+    client.read_exact(&mut greeting)?;
+    if greeting[0] != 5 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "unsupported SOCKS version",
+        ));
+    }
+    let mut methods = vec![0_u8; greeting[1] as usize];
+    client.read_exact(&mut methods)?;
+    client.write_all(&[5, 0])?;
+
+    let mut head = [0_u8; 4];
+    client.read_exact(&mut head)?;
+    if head[0] != 5 || head[1] != 1 {
+        write_socks_reply(client, 7)?;
+        return Ok(());
+    }
+
+    let host = match head[3] {
+        1 => {
+            let mut octets = [0_u8; 4];
+            client.read_exact(&mut octets)?;
+            Ipv4Addr::from(octets).to_string()
+        }
+        3 => {
+            let mut len = [0_u8; 1];
+            client.read_exact(&mut len)?;
+            let mut bytes = vec![0_u8; len[0] as usize];
+            client.read_exact(&mut bytes)?;
+            String::from_utf8(bytes).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidData, "SOCKS domain is not UTF-8")
+            })?
+        }
+        4 => {
+            let mut octets = [0_u8; 16];
+            client.read_exact(&mut octets)?;
+            Ipv6Addr::from(octets).to_string()
+        }
+        _ => {
+            write_socks_reply(client, 8)?;
+            return Ok(());
+        }
+    };
+    let mut port_bytes = [0_u8; 2];
+    client.read_exact(&mut port_bytes)?;
+    let port = u16::from_be_bytes(port_bytes);
+
+    if !policy.allows(&host) {
+        write_socks_reply(client, 2)?;
+        return Ok(());
+    }
+
+    match connect_upstream(&host, port, policy.as_ref()) {
+        Ok(Some(upstream)) => {
+            write_socks_reply(client, 0)?;
+            proxy_bidirectional(client.try_clone()?, upstream)?;
+        }
+        Ok(None) => {
+            write_socks_reply(client, 2)?;
+        }
+        Err(_) => {
+            write_socks_reply(client, 4)?;
+        }
+    }
+    Ok(())
+}
+
+fn write_socks_reply(stream: &mut TcpStream, status: u8) -> io::Result<()> {
+    stream.write_all(&[5, status, 0, 1, 0, 0, 0, 0, 0, 0])
+}
+
+fn proxy_bidirectional(client: TcpStream, upstream: TcpStream) -> io::Result<()> {
+    let mut client_read = client.try_clone()?;
+    let mut upstream_write = upstream.try_clone()?;
+    let client_to_upstream = thread::spawn(move || {
+        let _ = io::copy(&mut client_read, &mut upstream_write);
+        let _ = upstream_write.shutdown(Shutdown::Write);
+    });
+
+    let mut upstream_read = upstream;
+    let mut client_write = client;
+    let result = io::copy(&mut upstream_read, &mut client_write);
+    let _ = client_write.shutdown(Shutdown::Write);
+    let _ = client_to_upstream.join();
+    result.map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_domain_pattern_rejects_exact_url() {
+        let err = validate_domain_pattern("https://pypi.org/simple/").expect_err("url rejected");
+        assert!(err.contains("host pattern"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn host_policy_matches_domain_patterns() {
+        let policy = HostPolicy::new(&ManagedProxyConfig {
+            allowed_domains: vec![
+                "pypi.org".to_string(),
+                "*.pythonhosted.org".to_string(),
+                "**.r-project.org".to_string(),
+            ],
+            denied_domains: Vec::new(),
+            allow_local_binding: false,
+        })
+        .expect("policy");
+
+        assert!(policy.allows("pypi.org"));
+        assert!(policy.allows("files.pythonhosted.org"));
+        assert!(!policy.allows("pythonhosted.org"));
+        assert!(policy.allows("r-project.org"));
+        assert!(policy.allows("cran.r-project.org"));
+        assert!(!policy.allows("evilr-project.org"));
+    }
+
+    #[test]
+    fn host_policy_denied_domains_win() {
+        let policy = HostPolicy::new(&ManagedProxyConfig {
+            allowed_domains: vec!["**.example.com".to_string()],
+            denied_domains: vec!["blocked.example.com".to_string()],
+            allow_local_binding: false,
+        })
+        .expect("policy");
+
+        assert!(policy.allows("api.example.com"));
+        assert!(!policy.allows("blocked.example.com"));
+    }
+
+    #[test]
+    fn host_policy_blocks_private_resolved_addresses_unless_local_binding_is_allowed() {
+        let blocked = HostPolicy::new(&ManagedProxyConfig {
+            allowed_domains: vec!["example.com".to_string()],
+            denied_domains: Vec::new(),
+            allow_local_binding: false,
+        })
+        .expect("policy");
+        let allowed = HostPolicy::new(&ManagedProxyConfig {
+            allowed_domains: vec!["example.com".to_string()],
+            denied_domains: Vec::new(),
+            allow_local_binding: true,
+        })
+        .expect("policy");
+
+        let loopback = SocketAddr::from(([127, 0, 0, 1], 443));
+        assert!(!blocked.allows_socket_addr(loopback));
+        assert!(allowed.allows_socket_addr(loopback));
+    }
+
+    #[test]
+    fn managed_proxy_apply_to_env_overrides_common_proxy_vars() {
+        let proxy = ManagedNetworkProxy::start(ManagedProxyConfig {
+            allowed_domains: vec!["example.com".to_string()],
+            denied_domains: Vec::new(),
+            allow_local_binding: false,
+        })
+        .expect("proxy");
+        let mut env = HashMap::from([(
+            "HTTP_PROXY".to_string(),
+            "http://proxy.example:8080".to_string(),
+        )]);
+
+        proxy.apply_to_env(&mut env);
+
+        assert_eq!(
+            env.get("HTTP_PROXY").map(String::as_str),
+            Some(format!("http://{}", proxy.http_addr()).as_str())
+        );
+        assert_eq!(
+            env.get("HTTPS_PROXY").map(String::as_str),
+            Some(format!("http://{}", proxy.http_addr()).as_str())
+        );
+        assert_eq!(
+            env.get("ALL_PROXY").map(String::as_str),
+            Some(format!("socks5h://{}", proxy.socks_addr()).as_str())
+        );
+    }
+
+    #[test]
+    fn managed_http_proxy_forwards_allowed_absolute_http_request() {
+        let origin = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).expect("origin");
+        let origin_addr = origin.local_addr().expect("origin address");
+        let origin_thread = thread::spawn(move || {
+            let (mut stream, _) = origin.accept().expect("origin accept");
+            let request = read_http_header(&mut stream).expect("request header");
+            let request = String::from_utf8(request).expect("request utf8");
+            assert!(
+                request.starts_with("GET /packages HTTP/1.1\r\n"),
+                "proxy should rewrite absolute-form target: {request}"
+            );
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+                .expect("origin response");
+        });
+        let proxy = ManagedNetworkProxy::start(ManagedProxyConfig {
+            allowed_domains: vec!["127.0.0.1".to_string()],
+            denied_domains: Vec::new(),
+            allow_local_binding: true,
+        })
+        .expect("proxy");
+
+        let mut client = TcpStream::connect(proxy.http_addr()).expect("connect proxy");
+        client
+            .write_all(
+                format!(
+                    "GET http://127.0.0.1:{}/packages HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nConnection: close\r\n\r\n",
+                    origin_addr.port(),
+                    origin_addr.port()
+                )
+                .as_bytes(),
+            )
+            .expect("proxy request");
+        client
+            .shutdown(Shutdown::Write)
+            .expect("finish request body");
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("proxy response");
+
+        assert!(response.contains("HTTP/1.1 200 OK"), "{response}");
+        assert!(response.ends_with("ok"), "{response}");
+        origin_thread.join().expect("origin thread");
+    }
+
+    #[test]
+    fn managed_http_proxy_blocks_disallowed_host_without_dialing() {
+        let proxy = ManagedNetworkProxy::start(ManagedProxyConfig {
+            allowed_domains: vec!["example.com".to_string()],
+            denied_domains: Vec::new(),
+            allow_local_binding: false,
+        })
+        .expect("proxy");
+
+        let mut client = TcpStream::connect(proxy.http_addr()).expect("connect proxy");
+        client
+            .write_all(
+                b"GET http://not-allowed.invalid/packages HTTP/1.1\r\nHost: not-allowed.invalid\r\nConnection: close\r\n\r\n",
+            )
+            .expect("proxy request");
+        client
+            .shutdown(Shutdown::Write)
+            .expect("finish request body");
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("proxy response");
+
+        assert!(response.contains("HTTP/1.1 403 Forbidden"), "{response}");
+        assert!(
+            response.contains("blocked by network allowlist"),
+            "{response}"
+        );
+    }
+}

--- a/src/managed_network.rs
+++ b/src/managed_network.rs
@@ -478,6 +478,9 @@ fn handle_http_client_impl(client: &mut TcpStream, policy: Arc<HostPolicy>) -> i
     if !policy.allows(&absolute.host) {
         return write_http_error(client, 403, "Connection blocked by network allowlist");
     }
+    if !host_headers_match_target(&header[first_line_end + 2..], &absolute.host, absolute.port) {
+        return write_http_error(client, 403, "Host header does not match proxy target");
+    }
 
     let Some(mut upstream) = connect_upstream(&absolute.host, absolute.port, policy.as_ref())?
     else {
@@ -567,6 +570,45 @@ fn connect_upstream(host: &str, port: u16, policy: &HostPolicy) -> io::Result<Op
         Some(err) => Err(err),
         None => Ok(None),
     }
+}
+
+fn host_headers_match_target(header_tail: &[u8], target_host: &str, target_port: u16) -> bool {
+    for line in header_tail.split(|byte| *byte == b'\n') {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        if line.is_empty() {
+            break;
+        }
+        let Some(colon) = line.iter().position(|byte| *byte == b':') else {
+            continue;
+        };
+        if !line[..colon].eq_ignore_ascii_case(b"host") {
+            continue;
+        }
+        let value = trim_ascii_bytes(&line[colon + 1..]);
+        let Ok(authority) = std::str::from_utf8(value) else {
+            return false;
+        };
+        let Some((host, port)) = parse_host_port(authority, target_port) else {
+            return false;
+        };
+        if normalize_host(&host) != normalize_host(target_host) || port != target_port {
+            return false;
+        }
+    }
+    true
+}
+
+fn trim_ascii_bytes(bytes: &[u8]) -> &[u8] {
+    let start = bytes
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .unwrap_or(bytes.len());
+    let end = bytes
+        .iter()
+        .rposition(|byte| !byte.is_ascii_whitespace())
+        .map(|index| index + 1)
+        .unwrap_or(start);
+    &bytes[start..end]
 }
 
 fn write_http_error(stream: &mut TcpStream, status: u16, message: &str) -> io::Result<()> {
@@ -901,5 +943,32 @@ mod tests {
             response.contains("blocked by network allowlist"),
             "{response}"
         );
+    }
+
+    #[test]
+    fn managed_http_proxy_rejects_host_header_mismatch() {
+        let proxy = ManagedNetworkProxy::start(ManagedProxyConfig {
+            allowed_domains: vec!["127.0.0.1".to_string()],
+            denied_domains: Vec::new(),
+            allow_local_binding: true,
+        })
+        .expect("proxy");
+
+        let mut client = TcpStream::connect(proxy.http_addr()).expect("connect proxy");
+        client
+            .write_all(
+                b"GET http://127.0.0.1:9/packages HTTP/1.1\r\nHost: not-allowed.invalid\r\nConnection: close\r\n\r\n",
+            )
+            .expect("proxy request");
+        client
+            .shutdown(Shutdown::Write)
+            .expect("finish request body");
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("proxy response");
+
+        assert!(response.contains("HTTP/1.1 403 Forbidden"), "{response}");
+        assert!(response.contains("Host header"), "{response}");
     }
 }

--- a/src/managed_network.rs
+++ b/src/managed_network.rs
@@ -349,20 +349,44 @@ fn is_non_public_ip(ip: IpAddr) -> bool {
 }
 
 fn is_non_public_ipv4(ip: Ipv4Addr) -> bool {
+    let [a, b, c, _d] = ip.octets();
     ip.is_loopback()
         || ip.is_private()
         || ip.is_link_local()
         || ip.is_unspecified()
         || ip.is_broadcast()
         || ip.is_multicast()
+        || a == 0
+        || (a == 100 && (64..=127).contains(&b))
+        || (a == 192 && b == 0 && c == 0)
+        || (a == 192 && b == 0 && c == 2)
+        || (a == 192 && b == 88 && c == 99)
+        || (a == 198 && (b == 18 || b == 19))
+        || (a == 198 && b == 51 && c == 100)
+        || (a == 203 && b == 0 && c == 113)
+        || a >= 240
 }
 
 fn is_non_public_ipv6(ip: Ipv6Addr) -> bool {
+    if let Some(mapped) = ipv4_mapped_from_ipv6(ip) {
+        return is_non_public_ipv4(mapped);
+    }
     ip.is_loopback()
         || ip.is_unspecified()
         || ip.is_unique_local()
         || ip.is_unicast_link_local()
         || ip.is_multicast()
+}
+
+fn ipv4_mapped_from_ipv6(ip: Ipv6Addr) -> Option<Ipv4Addr> {
+    let octets = ip.octets();
+    if octets[..10] == [0; 10] && octets[10] == 0xff && octets[11] == 0xff {
+        Some(Ipv4Addr::new(
+            octets[12], octets[13], octets[14], octets[15],
+        ))
+    } else {
+        None
+    }
 }
 
 fn spawn_http_listener(
@@ -707,6 +731,46 @@ mod tests {
         let loopback = SocketAddr::from(([127, 0, 0, 1], 443));
         assert!(!blocked.allows_socket_addr(loopback));
         assert!(allowed.allows_socket_addr(loopback));
+    }
+
+    #[test]
+    fn non_public_ipv4_classifier_blocks_special_ranges() {
+        for raw in [
+            "0.1.2.3",
+            "10.0.0.1",
+            "100.64.0.1",
+            "127.0.0.1",
+            "169.254.1.1",
+            "172.16.0.1",
+            "192.0.0.1",
+            "192.0.2.1",
+            "192.88.99.1",
+            "192.168.0.1",
+            "198.18.0.1",
+            "198.51.100.1",
+            "203.0.113.1",
+            "224.0.0.1",
+            "240.0.0.1",
+        ] {
+            let ip = raw.parse::<Ipv4Addr>().expect("IPv4 address");
+            assert!(is_non_public_ipv4(ip), "{raw} should be non-public");
+        }
+
+        assert!(!is_non_public_ipv4(
+            "8.8.8.8".parse::<Ipv4Addr>().expect("IPv4 address")
+        ));
+    }
+
+    #[test]
+    fn non_public_ipv6_classifier_unwraps_ipv4_mapped_addresses() {
+        for raw in ["::ffff:127.0.0.1", "::ffff:100.64.0.1"] {
+            let ip = raw.parse::<Ipv6Addr>().expect("IPv6 address");
+            assert!(is_non_public_ipv6(ip), "{raw} should be non-public");
+        }
+
+        assert!(!is_non_public_ipv6(
+            "::ffff:8.8.8.8".parse::<Ipv6Addr>().expect("IPv6 address")
+        ));
     }
 
     #[test]

--- a/src/managed_network.rs
+++ b/src/managed_network.rs
@@ -487,9 +487,19 @@ fn handle_http_client_impl(client: &mut TcpStream, policy: Arc<HostPolicy>) -> i
     else {
         return write_http_error(client, 403, "Connection blocked by network allowlist");
     };
-    upstream.write_all(format!("{method} {} {version}\r\n", absolute.path).as_bytes())?;
-    upstream.write_all(&header[first_line_end + 2..])?;
-    proxy_bidirectional(client.try_clone()?, upstream)?;
+    let header_tail = &header[first_line_end + 2..];
+    if header_has_name(header_tail, b"transfer-encoding") {
+        return write_http_error(
+            client,
+            400,
+            "chunked HTTP proxy request bodies are not supported",
+        );
+    }
+    let content_length = content_length_from_headers(header_tail)?;
+    write_one_request_http_header(&mut upstream, method, &absolute.path, version, header_tail)?;
+    copy_exact_bytes(client, &mut upstream, content_length)?;
+    let _ = upstream.shutdown(Shutdown::Write);
+    relay_plain_http_response(client, upstream)?;
     Ok(())
 }
 
@@ -597,6 +607,108 @@ fn host_headers_match_target(header_tail: &[u8], target_host: &str, target_port:
         }
     }
     true
+}
+
+fn write_one_request_http_header(
+    upstream: &mut TcpStream,
+    method: &str,
+    path: &str,
+    version: &str,
+    header_tail: &[u8],
+) -> io::Result<()> {
+    upstream.write_all(format!("{method} {path} {version}\r\n").as_bytes())?;
+    let mut wrote_connection_close = false;
+    for line in header_tail.split(|byte| *byte == b'\n') {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        if line.is_empty() {
+            break;
+        }
+        if header_line_has_name(line, b"proxy-connection") {
+            continue;
+        }
+        if header_line_has_name(line, b"connection") {
+            if !wrote_connection_close {
+                upstream.write_all(b"Connection: close\r\n")?;
+                wrote_connection_close = true;
+            }
+            continue;
+        }
+        upstream.write_all(line)?;
+        upstream.write_all(b"\r\n")?;
+    }
+    if !wrote_connection_close {
+        upstream.write_all(b"Connection: close\r\n")?;
+    }
+    upstream.write_all(b"\r\n")
+}
+
+fn content_length_from_headers(header_tail: &[u8]) -> io::Result<u64> {
+    let mut content_length = None;
+    for line in header_tail.split(|byte| *byte == b'\n') {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        if line.is_empty() {
+            break;
+        }
+        let Some(value) = header_line_value(line, b"content-length") else {
+            continue;
+        };
+        let value = std::str::from_utf8(trim_ascii_bytes(value)).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidData, "Content-Length is not UTF-8")
+        })?;
+        let value = value
+            .parse::<u64>()
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Content-Length is invalid"))?;
+        if content_length.is_some_and(|previous| previous != value) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "conflicting Content-Length headers",
+            ));
+        }
+        content_length = Some(value);
+    }
+    Ok(content_length.unwrap_or(0))
+}
+
+fn header_has_name(header_tail: &[u8], name: &[u8]) -> bool {
+    header_tail
+        .split(|byte| *byte == b'\n')
+        .map(|line| line.strip_suffix(b"\r").unwrap_or(line))
+        .take_while(|line| !line.is_empty())
+        .any(|line| header_line_has_name(line, name))
+}
+
+fn header_line_has_name(line: &[u8], name: &[u8]) -> bool {
+    header_line_value(line, name).is_some()
+}
+
+fn header_line_value<'a>(line: &'a [u8], name: &[u8]) -> Option<&'a [u8]> {
+    let colon = line.iter().position(|byte| *byte == b':')?;
+    if trim_ascii_bytes(&line[..colon]).eq_ignore_ascii_case(name) {
+        Some(&line[colon + 1..])
+    } else {
+        None
+    }
+}
+
+fn copy_exact_bytes(
+    reader: &mut TcpStream,
+    writer: &mut TcpStream,
+    mut bytes: u64,
+) -> io::Result<()> {
+    let mut buffer = [0_u8; 8192];
+    while bytes > 0 {
+        let chunk_size = buffer.len().min(bytes as usize);
+        reader.read_exact(&mut buffer[..chunk_size])?;
+        writer.write_all(&buffer[..chunk_size])?;
+        bytes -= chunk_size as u64;
+    }
+    Ok(())
+}
+
+fn relay_plain_http_response(client: &mut TcpStream, mut upstream: TcpStream) -> io::Result<()> {
+    let result = io::copy(&mut upstream, &mut *client);
+    let _ = client.shutdown(Shutdown::Write);
+    result.map(|_| ())
 }
 
 fn trim_ascii_bytes(bytes: &[u8]) -> &[u8] {
@@ -910,6 +1022,60 @@ mod tests {
         client
             .read_to_string(&mut response)
             .expect("proxy response");
+
+        assert!(response.contains("HTTP/1.1 200 OK"), "{response}");
+        assert!(response.ends_with("ok"), "{response}");
+        origin_thread.join().expect("origin thread");
+    }
+
+    #[test]
+    fn managed_http_proxy_closes_plain_http_after_one_request() {
+        let origin = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).expect("origin");
+        let origin_addr = origin.local_addr().expect("origin address");
+        let origin_thread = thread::spawn(move || {
+            let (mut stream, _) = origin.accept().expect("origin accept");
+            let request = read_http_header(&mut stream).expect("request header");
+            let request = String::from_utf8(request).expect("request utf8");
+            assert!(
+                request.starts_with("GET /packages HTTP/1.1\r\n"),
+                "proxy should rewrite absolute-form target: {request}"
+            );
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+                .expect("origin response");
+            if request.contains("\r\nConnection: close\r\n") {
+                return;
+            }
+            stream
+                .set_read_timeout(Some(Duration::from_secs(1)))
+                .expect("origin read timeout");
+            let _ = stream.read(&mut [0_u8; 1]);
+        });
+        let proxy = ManagedNetworkProxy::start(ManagedProxyConfig {
+            allowed_domains: vec!["127.0.0.1".to_string()],
+            denied_domains: Vec::new(),
+            allow_local_binding: true,
+        })
+        .expect("proxy");
+
+        let mut client = TcpStream::connect(proxy.http_addr()).expect("connect proxy");
+        client
+            .set_read_timeout(Some(Duration::from_millis(500)))
+            .expect("client read timeout");
+        client
+            .write_all(
+                format!(
+                    "GET http://127.0.0.1:{}/packages HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nConnection: keep-alive\r\n\r\n",
+                    origin_addr.port(),
+                    origin_addr.port()
+                )
+                .as_bytes(),
+            )
+            .expect("proxy request");
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("proxy should close one-request HTTP connection");
 
         assert!(response.contains("HTTP/1.1 200 OK"), "{response}");
         assert!(response.ends_with("ok"), "{response}");

--- a/src/managed_network.rs
+++ b/src/managed_network.rs
@@ -423,6 +423,7 @@ fn listener_loop(
     while !shutdown.load(Ordering::SeqCst) {
         match listener.accept() {
             Ok((stream, _)) => {
+                let _ = stream.set_nonblocking(false);
                 let policy = Arc::clone(&policy);
                 thread::spawn(move || handler(stream, policy));
             }

--- a/src/managed_network.rs
+++ b/src/managed_network.rs
@@ -179,7 +179,7 @@ impl HostPolicy {
     }
 
     fn allows_socket_addr(&self, addr: SocketAddr) -> bool {
-        self.allow_local_binding || !is_non_public_ip(addr.ip())
+        !is_non_public_ip(addr.ip()) || (self.allow_local_binding && is_loopback_ip(addr.ip()))
     }
 }
 
@@ -345,6 +345,15 @@ fn is_non_public_ip(ip: IpAddr) -> bool {
     match ip {
         IpAddr::V4(ip) => is_non_public_ipv4(ip),
         IpAddr::V6(ip) => is_non_public_ipv6(ip),
+    }
+}
+
+fn is_loopback_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => ip.is_loopback(),
+        IpAddr::V6(ip) => {
+            ipv4_mapped_from_ipv6(ip).is_some_and(|mapped| mapped.is_loopback()) || ip.is_loopback()
+        }
     }
 }
 
@@ -729,8 +738,11 @@ mod tests {
         .expect("policy");
 
         let loopback = SocketAddr::from(([127, 0, 0, 1], 443));
+        let private = SocketAddr::from(([10, 0, 0, 1], 443));
         assert!(!blocked.allows_socket_addr(loopback));
         assert!(allowed.allows_socket_addr(loopback));
+        assert!(!blocked.allows_socket_addr(private));
+        assert!(!allowed.allows_socket_addr(private));
     }
 
     #[test]
@@ -771,6 +783,18 @@ mod tests {
         assert!(!is_non_public_ipv6(
             "::ffff:8.8.8.8".parse::<Ipv6Addr>().expect("IPv6 address")
         ));
+    }
+
+    #[test]
+    fn loopback_classifier_unwraps_ipv4_mapped_addresses() {
+        assert!(is_loopback_ip(IpAddr::V6(
+            "::ffff:127.0.0.1"
+                .parse::<Ipv6Addr>()
+                .expect("IPv6 address")
+        )));
+        assert!(!is_loopback_ip(IpAddr::V6(
+            "::ffff:10.0.0.1".parse::<Ipv6Addr>().expect("IPv6 address")
+        )));
     }
 
     #[test]

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -596,10 +596,20 @@ fn prepend_env_path(env: &mut HashMap<String, String>, key: &str, prefix: &Path)
     env.insert(key.to_string(), value);
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn prepare_worker_command(
     program: &Path,
     args: Vec<String>,
     state: &SandboxState,
+) -> Result<PreparedCommand, SandboxError> {
+    prepare_worker_command_with_managed_network(program, args, state, None)
+}
+
+pub fn prepare_worker_command_with_managed_network(
+    program: &Path,
+    args: Vec<String>,
+    state: &SandboxState,
+    managed_network_proxy: Option<&crate::managed_network::ManagedNetworkProxy>,
 ) -> Result<PreparedCommand, SandboxError> {
     let mut env = HashMap::new();
     if !state.sandbox_policy.has_full_network_access() {
@@ -632,6 +642,9 @@ pub fn prepare_worker_command(
             "0".to_string()
         },
     );
+    if let Some(proxy) = managed_network_proxy {
+        proxy.apply_to_env(&mut env);
+    }
 
     ensure_session_temp_dir(&state.session_temp_dir)?;
     {
@@ -675,6 +688,12 @@ pub fn prepare_worker_command(
 
         let mut network_env = sandbox_network_env_snapshot();
         for key in [
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "ALL_PROXY",
+            "http_proxy",
+            "https_proxy",
+            "all_proxy",
             ALLOW_LOCAL_BINDING_ENV_KEY,
             MANAGED_NETWORK_ENV_KEY,
             MANAGED_ALLOWED_DOMAINS_ENV_KEY,
@@ -2513,6 +2532,64 @@ mod tests {
         let rendered = dynamic_network_policy(&policy, false, false, &proxy);
         assert!(rendered.contains("localhost:8080"));
         assert!(!rendered.contains("(allow network-inbound)\n"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn prepare_worker_command_with_managed_proxy_injects_proxy_env_and_seatbelt_ports() {
+        let proxy = crate::managed_network::ManagedNetworkProxy::start(
+            crate::managed_network::ManagedProxyConfig {
+                allowed_domains: vec!["example.com".to_string()],
+                denied_domains: Vec::new(),
+                allow_local_binding: false,
+            },
+        )
+        .expect("managed proxy");
+        let mut state = SandboxState {
+            sandbox_policy: SandboxPolicy::WorkspaceWrite {
+                writable_roots: Vec::new(),
+                network_access: true,
+                exclude_tmpdir_env_var: false,
+                exclude_slash_tmp: false,
+            },
+            ..SandboxState::default()
+        };
+        state.managed_network_policy.allowed_domains = vec!["example.com".to_string()];
+
+        let prepared = prepare_worker_command_with_managed_network(
+            Path::new("/bin/echo"),
+            vec!["ok".to_string()],
+            &state,
+            Some(&proxy),
+        )
+        .expect("prepare worker command");
+
+        assert_eq!(
+            prepared.env.get("HTTP_PROXY").map(String::as_str),
+            Some(format!("http://{}", proxy.http_addr()).as_str())
+        );
+        assert_eq!(
+            prepared.env.get("ALL_PROXY").map(String::as_str),
+            Some(format!("socks5h://{}", proxy.socks_addr()).as_str())
+        );
+        let policy = prepared
+            .args
+            .windows(2)
+            .find(|pair| pair[0] == "-p")
+            .map(|pair| pair[1].as_str())
+            .expect("seatbelt policy argument");
+        assert!(
+            policy.contains(&format!("localhost:{}", proxy.http_addr().port())),
+            "{policy}"
+        );
+        assert!(
+            policy.contains(&format!("localhost:{}", proxy.socks_addr().port())),
+            "{policy}"
+        );
+        assert!(
+            !policy.contains("(allow network-outbound)\n(allow network-inbound)\n"),
+            "{policy}"
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/src/sandbox_cli.rs
+++ b/src/sandbox_cli.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use crate::managed_network::validate_domain_patterns;
 use crate::sandbox::{SandboxPolicy, SandboxState};
 
 pub const MISSING_INHERITED_SANDBOX_STATE_MESSAGE: &str =
@@ -134,12 +135,16 @@ pub fn parse_sandbox_config_override(raw: &str) -> Result<SandboxConfigOperation
         "sandbox_workspace_write.exclude_slash_tmp" => Ok(
             SandboxConfigOperation::SetWorkspaceExcludeSlashTmp(parse_bool_value(value)?),
         ),
-        "permissions.network.allowed_domains" => Ok(SandboxConfigOperation::SetAllowedDomains(
-            parse_string_array_value(value)?,
-        )),
-        "permissions.network.denied_domains" => Ok(SandboxConfigOperation::SetDeniedDomains(
-            parse_string_array_value(value)?,
-        )),
+        "permissions.network.allowed_domains" => {
+            let values = parse_string_array_value(value)?;
+            validate_domain_patterns("permissions.network.allowed_domains", &values)?;
+            Ok(SandboxConfigOperation::SetAllowedDomains(values))
+        }
+        "permissions.network.denied_domains" => {
+            let values = parse_string_array_value(value)?;
+            validate_domain_patterns("permissions.network.denied_domains", &values)?;
+            Ok(SandboxConfigOperation::SetDeniedDomains(values))
+        }
         "permissions.network.allow_local_binding" => Ok(
             SandboxConfigOperation::SetAllowLocalBinding(parse_bool_value(value)?),
         ),
@@ -290,6 +295,7 @@ fn validate_sandbox_plan_operations(
                 if domain.trim().is_empty() {
                     return Err("--add-allowed-domain requires a non-empty value".to_string());
                 }
+                validate_domain_patterns("--add-allowed-domain", std::slice::from_ref(domain))?;
             }
             SandboxCliOperation::Config(config_op) => match config_op {
                 SandboxConfigOperation::SetMode(next_mode) => {

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -39,7 +39,8 @@ use crate::oversized_output::OversizedOutputMode;
 use crate::pager::{self, Pager};
 use crate::pending_output_tape::{FormattedPendingOutput, PendingOutputTape, PendingSidebandKind};
 use crate::sandbox::{
-    R_SESSION_TMPDIR_ENV, SandboxState, SandboxStateUpdate, prepare_worker_command,
+    R_SESSION_TMPDIR_ENV, SandboxState, SandboxStateUpdate,
+    prepare_worker_command_with_managed_network,
 };
 use crate::sandbox_cli::{
     MISSING_INHERITED_SANDBOX_STATE_MESSAGE, SandboxCliPlan,
@@ -619,6 +620,7 @@ pub struct WorkerManager {
     inherited_sandbox_state: Option<SandboxState>,
     sandbox_defaults: SandboxState,
     sandbox_state: SandboxState,
+    managed_network_proxy: Option<crate::managed_network::ManagedNetworkProxy>,
     #[cfg(target_os = "windows")]
     windows_sandbox_launch: Option<crate::windows_sandbox::PreparedSandboxLaunch>,
     oversized_output: OversizedOutputMode,
@@ -699,6 +701,7 @@ impl WorkerManager {
             inherited_sandbox_state: None,
             sandbox_defaults,
             sandbox_state,
+            managed_network_proxy: None,
             #[cfg(target_os = "windows")]
             windows_sandbox_launch: None,
             oversized_output,
@@ -740,6 +743,60 @@ impl WorkerManager {
             return Ok(());
         }
         self.ensure_process()
+    }
+
+    fn ensure_managed_network_proxy(&mut self) -> Result<(), WorkerError> {
+        let Some(config) = Self::managed_network_proxy_config_for_state(&self.sandbox_state)?
+        else {
+            self.managed_network_proxy = None;
+            return Ok(());
+        };
+
+        if self
+            .managed_network_proxy
+            .as_ref()
+            .is_some_and(|proxy| proxy.config() == &config)
+        {
+            return Ok(());
+        }
+
+        let proxy = crate::managed_network::ManagedNetworkProxy::start(config)
+            .map_err(|err| WorkerError::Sandbox(err.to_string()))?;
+        crate::event_log::log(
+            "worker_managed_network_proxy_started",
+            serde_json::json!({
+                "http_addr": proxy.http_addr().to_string(),
+                "socks_addr": proxy.socks_addr().to_string(),
+            }),
+        );
+        self.managed_network_proxy = Some(proxy);
+        Ok(())
+    }
+
+    fn managed_network_proxy_config_for_state(
+        state: &SandboxState,
+    ) -> Result<Option<crate::managed_network::ManagedProxyConfig>, WorkerError> {
+        if !state.managed_network_policy.has_domain_restrictions() {
+            return Ok(None);
+        }
+        if !state.sandbox_policy.has_full_network_access() {
+            return Ok(None);
+        }
+        if !state.sandbox_policy.requires_sandbox() {
+            return Err(WorkerError::Sandbox(
+                "managed network domain restrictions require built-in sandbox enforcement"
+                    .to_string(),
+            ));
+        }
+        if !cfg!(target_os = "macos") {
+            return Err(WorkerError::Sandbox(
+                "managed network domain restrictions are currently supported only on macOS"
+                    .to_string(),
+            ));
+        }
+        crate::managed_network::ManagedProxyConfig::from_policy(&state.managed_network_policy)
+            .map(Some)
+            .map_err(|err| WorkerError::Sandbox(err.to_string()))
     }
 
     pub fn bootstrap_local_inherited_sandbox_state(&mut self) -> Result<bool, WorkerError> {
@@ -3374,6 +3431,7 @@ impl WorkerManager {
         crate::event_log::log_lazy("worker_spawn_begin", || {
             worker_context_event_payload(self.backend, &self.sandbox_state)
         });
+        self.ensure_managed_network_proxy()?;
         #[cfg(target_os = "windows")]
         let prepared_windows_launch = self.ensure_windows_sandbox_launch()?;
         let process = WorkerProcess::spawn(
@@ -3385,6 +3443,7 @@ impl WorkerManager {
                 pending_output_tape: self.pending_output_tape.clone(),
                 output_timeline: self.output_timeline.clone(),
                 guardrail: self.guardrail.clone(),
+                managed_network_proxy: self.managed_network_proxy.as_ref(),
                 #[cfg(target_os = "windows")]
                 prepared_windows_launch,
             },
@@ -3450,6 +3509,7 @@ impl WorkerManager {
         crate::event_log::log_lazy("worker_spawn_begin", || {
             worker_context_event_payload(self.backend, &self.sandbox_state)
         });
+        self.ensure_managed_network_proxy()?;
         #[cfg(target_os = "windows")]
         let prepared_windows_launch = self.ensure_windows_sandbox_launch()?;
         let process = WorkerProcess::spawn(
@@ -3461,6 +3521,7 @@ impl WorkerManager {
                 pending_output_tape: self.pending_output_tape.clone(),
                 output_timeline: self.output_timeline.clone(),
                 guardrail: self.guardrail.clone(),
+                managed_network_proxy: self.managed_network_proxy.as_ref(),
                 #[cfg(target_os = "windows")]
                 prepared_windows_launch,
             },
@@ -4723,11 +4784,12 @@ struct SpawnedWorker {
     denial_logger: Option<crate::sandbox::DenialLogger>,
 }
 
-struct WorkerSpawnContext {
+struct WorkerSpawnContext<'a> {
     oversized_output: OversizedOutputMode,
     pending_output_tape: PendingOutputTape,
     output_timeline: OutputTimeline,
     guardrail: GuardrailShared,
+    managed_network_proxy: Option<&'a crate::managed_network::ManagedNetworkProxy>,
     #[cfg(target_os = "windows")]
     prepared_windows_launch: Option<crate::windows_sandbox::PreparedSandboxLaunch>,
 }
@@ -4852,13 +4914,14 @@ impl WorkerProcess {
         backend: Backend,
         exe_path: &Path,
         sandbox_state: &SandboxState,
-        context: WorkerSpawnContext,
+        context: WorkerSpawnContext<'_>,
     ) -> Result<Self, WorkerError> {
         let WorkerSpawnContext {
             oversized_output,
             pending_output_tape,
             output_timeline,
             guardrail,
+            managed_network_proxy,
             #[cfg(target_os = "windows")]
             prepared_windows_launch,
         } = context;
@@ -4884,14 +4947,18 @@ impl WorkerProcess {
             Backend::R => Self::spawn_r_worker(
                 exe_path,
                 sandbox_state,
+                managed_network_proxy,
                 live_output.clone(),
                 &mut ipc_server,
                 #[cfg(target_os = "windows")]
                 prepared_windows_launch.as_ref(),
             )?,
-            Backend::Python => {
-                Self::spawn_python_worker(sandbox_state, live_output.clone(), &mut ipc_server)?
-            }
+            Backend::Python => Self::spawn_python_worker(
+                sandbox_state,
+                managed_network_proxy,
+                live_output.clone(),
+                &mut ipc_server,
+            )?,
         };
         #[allow(unused_mut)]
         let mut child = child;
@@ -4973,15 +5040,20 @@ impl WorkerProcess {
     fn spawn_r_worker(
         exe_path: &Path,
         sandbox_state: &SandboxState,
+        managed_network_proxy: Option<&crate::managed_network::ManagedNetworkProxy>,
         live_output: LiveOutputCapture,
         ipc_server: &mut IpcServer,
         #[cfg(target_os = "windows")] prepared_windows_launch: Option<
             &crate::windows_sandbox::PreparedSandboxLaunch,
         >,
     ) -> Result<SpawnedWorker, WorkerError> {
-        let prepared =
-            prepare_worker_command(exe_path, vec![WORKER_MODE_ARG.to_string()], sandbox_state)
-                .map_err(|err| WorkerError::Sandbox(err.to_string()))?;
+        let prepared = prepare_worker_command_with_managed_network(
+            exe_path,
+            vec![WORKER_MODE_ARG.to_string()],
+            sandbox_state,
+            managed_network_proxy,
+        )
+        .map_err(|err| WorkerError::Sandbox(err.to_string()))?;
         #[cfg(target_os = "windows")]
         let mut prepared = prepared;
         #[cfg(target_os = "windows")]
@@ -5091,12 +5163,14 @@ impl WorkerProcess {
 
     fn spawn_python_worker(
         sandbox_state: &SandboxState,
+        managed_network_proxy: Option<&crate::managed_network::ManagedNetworkProxy>,
         live_output: LiveOutputCapture,
         ipc_server: &mut IpcServer,
     ) -> Result<SpawnedWorker, WorkerError> {
         #[cfg(not(target_family = "unix"))]
         {
             let _ = sandbox_state;
+            let _ = managed_network_proxy;
             let _ = live_output;
             let _ = ipc_server;
             Err(WorkerError::Protocol(
@@ -5106,9 +5180,13 @@ impl WorkerProcess {
         #[cfg(target_family = "unix")]
         {
             let python_program = Self::resolve_python_program();
-            let prepared =
-                prepare_worker_command(&python_program, Self::python_command_args(), sandbox_state)
-                    .map_err(|err| WorkerError::Sandbox(err.to_string()))?;
+            let prepared = prepare_worker_command_with_managed_network(
+                &python_program,
+                Self::python_command_args(),
+                sandbox_state,
+                managed_network_proxy,
+            )
+            .map_err(|err| WorkerError::Sandbox(err.to_string()))?;
             let session_tmpdir = prepared
                 .env
                 .get(R_SESSION_TMPDIR_ENV)

--- a/tests/codex_approvals_tui.rs
+++ b/tests/codex_approvals_tui.rs
@@ -1655,6 +1655,9 @@ tryCatch({
                         if normalized_key == "permissionProfile" {
                             continue;
                         }
+                        if normalized_key == "turn_started_at_unix_ms" {
+                            continue;
+                        }
                         path.push(normalized_key.clone());
                         normalize_inner(&mut child, path, workspace, codex_home);
                         path.pop();
@@ -1718,6 +1721,30 @@ tryCatch({
                 "codexLinuxSandboxExe": null
             }),
             "wire snapshots should preserve a null Codex Linux helper path"
+        );
+    }
+
+    #[test]
+    fn normalize_wire_snapshot_drops_volatile_turn_started_timestamp() {
+        let workspace = std::env::temp_dir().join("mcp-repl-wire-workspace");
+        let codex_home = std::env::temp_dir().join("mcp-repl-wire-codex-home");
+        let mut value = serde_json::json!({
+            "x-codex-turn-metadata": {
+                "sandbox": "seatbelt",
+                "turn_started_at_unix_ms": 1777651972182_i64
+            }
+        });
+
+        normalize_wire_snapshot_value(&mut value, &workspace, &codex_home);
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "x-codex-turn-metadata": {
+                    "sandbox": "<SANDBOX_BACKEND>"
+                }
+            }),
+            "wire snapshots should not retain per-run turn timestamps"
         );
     }
 


### PR DESCRIPTION
## Summary

Adds a macOS-first managed network proxy for sandboxed worker processes. When managed domain rules are configured with network access enabled, the server starts a loopback HTTP/SOCKS proxy, injects proxy environment variables into the worker, and renders macOS Seatbelt rules that permit worker egress only to the proxy ports.

Public-facing changes:
- Supports host/domain allow and deny rules for managed network access.
- Supports exact hosts, `*.example.com`, and `**.example.com`.
- Rejects exact URL/path entries instead of silently reducing them to hosts.
- Documents PyPI and CRAN allowlist examples.
- Fails closed on Linux and Windows when managed domain rules are configured, leaving those platforms for later slices.

Internal changes:
- Adds `src/managed_network.rs`, a small in-process HTTP/SOCKS proxy tailored to package-install workflows.
- Wires managed proxy lifecycle into `WorkerManager`.
- Injects proxy env vars through worker command preparation.
- Restricts macOS sandbox egress to managed proxy loopback ports.
- Adds proxy hardening for non-public resolved addresses, Host-header mismatch, and reused plain-HTTP proxy connections.

## Scope Notes

This slice is intentionally host/domain based. URL path filtering is out of scope because normal HTTPS proxying only exposes the `CONNECT host:port` target unless a future MITM or package-manager-specific design is added.

The follow-up note in `docs/futurework/managed-network-follow-up.md` captures next-slice options for database TCP endpoints, Shiny/local service workflows, port policy, SOCKS gating, and TLS SNI validation.

## Diff Composition

Measured against `origin/main`, this PR is `1749` insertions and `28` deletions across `11` files.

- runtime `src/`: `+968/-21` (`55.7%` of churn)
- inline tests inside `src/`: `+392/-0` (`22.1%` of churn)
- tests in `tests/`: `+27/-0` (`1.5%` of churn)
- docs: `+361/-7` (`20.7%` of churn)
- other: `+1/-0` (`0.1%` of churn)

Largest files:
- `src/managed_network.rs`: `+1141/-0`
- `docs/futurework/managed-network-follow-up.md`: `+257/-0`
- `src/worker_process.rs`: `+90/-12`
- `src/sandbox.rs`: `+77/-0`
- `docs/plans/active/managed-network-proxy.md`: `+65/-0`
