### PR TITLE
Refactor request completion and plot image ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ mcp-repl-startup.log
 .Rproj.user
 .venv
 /eval
+.agents

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,11 +14,16 @@ The repository is organized around a few concrete subsystems rather than deep pa
 
 - `src/server.rs` owns the MCP surface, request handling, timeout model, and worker lifecycle.
 - `src/server/timeouts.rs` and `src/server/response.rs` keep the public `repl`/`repl_reset` behavior stable.
+- During steady-state requests, the server should treat the worker as a generic
+  runtime endpoint: stdin carries accepted input, stdout/stderr carry visible
+  text, and sideband events carry structural facts. Backend-specific runtime
+  semantics belong in the worker or in explicitly advertised worker metadata.
 
 ### Worker and backends
 
 - `src/worker.rs`, `src/worker_process.rs`, and `src/worker_protocol.rs` manage the child runtime and the server-to-worker contract.
-- `src/backend.rs` selects between the R and Python implementations.
+- `src/backend.rs` selects between the R and Python implementations at launch
+  and install/configuration boundaries.
 - The IPC sideband is single-owner by design: startup env vars only bootstrap the main worker, then they are scrubbed before user code runs. Descendants must not emit sideband messages.
 - R-specific behavior lives in `src/r_session.rs`, `src/r_controls.rs`, `src/r_graphics.rs`, and `src/r_htmd.rs`.
 - Python startup is driven by the worker plus the files under `python/`.

--- a/docs/futurework/r-worker-simplification-and-server-inferred-completion.md
+++ b/docs/futurework/r-worker-simplification-and-server-inferred-completion.md
@@ -11,15 +11,19 @@ This future work item covers the larger simplification goal behind the current o
 
 This is intentionally broader than the current branch milestone.
 
-## Why This Is Deferred
+## Status
 
-The immediate milestone is narrower:
+This simplification has started: request completion is now inferred by the
+server from prompt/readline sideband facts instead of a worker-emitted
+request-boundary message. The remaining work is to simplify worker code around
+that contract and broaden the design where needed.
 
-- fix the reported bug where an R plot image can appear after later stdout text,
-- do the refactoring required to fix that ordering correctly,
-- avoid expanding the branch into a full completion-model redesign.
+The original motivation was broader than one bug fix:
 
-The current server and both backends still depend on `request_end` in multiple places. Removing or redefining that contract safely needs a dedicated phase.
+- keep the worker thin and factual,
+- keep timeline interpretation in the server,
+- avoid expanding plot/image ordering code with worker-owned request-boundary
+  state.
 
 ## Intended Direction
 
@@ -29,13 +33,11 @@ The current server and both backends still depend on `request_end` in multiple p
 
 ## Likely Follow-On Work
 
-- Revisit whether `request_end` is needed for R once server-side completion inference is well-defined.
 - Separate top-level idle-prompt detection from nested prompt flows such as `browser()` and `readline()`.
 - Decide whether the same simplification should apply to Python or whether Python should keep a different completion contract.
 - Re-evaluate the current R plot-capture mechanism independently from request-completion semantics.
 
 ## Non-Goals For The Current Branch
 
-- Removing `request_end` across the whole system.
 - Redesigning Python completion.
 - Landing a broader R worker architecture rewrite.

--- a/docs/futurework/server-backend-boundary.md
+++ b/docs/futurework/server-backend-boundary.md
@@ -37,6 +37,33 @@ teaching the server backend-specific behavior.
 Some of this may be necessary during launch or documentation rendering, but it
 should not leak into steady-state server request semantics.
 
+## Backend Branching Audit
+
+As of 2026-05-06, production server-side backend branching falls into these
+buckets:
+
+- `src/main.rs` parses `Backend` from CLI/env and renders install-time config.
+  This is expected user-facing interpreter selection.
+- `src/server.rs` selects one RMCP tool server per `(Backend,
+  OversizedOutputMode)` so each `repl` tool can have a static doc string. This
+  is documentation wiring, not request execution policy, and should move with
+  `docs/futurework/composable-tool-descriptions.md`.
+- `src/worker_process.rs` selects a `BackendDriver` at `WorkerManager`
+  creation. The driver owns request payload framing, Python's request-start
+  sideband nudge, interrupt behavior, completion waiting, and backend-info
+  startup tolerance. This is acceptable only as a server-side adapter until the
+  worker can advertise these narrow capabilities.
+- `src/worker_process.rs` also branches at spawn time between the in-binary R
+  worker and the Python PTY process. This is launch-time configuration.
+- On Windows, `src/worker_process.rs` prepares a sandbox launch only for R
+  because the Python backend currently reports a Unix-PTY requirement. This is
+  launch/platform gating, not steady-state request semantics.
+- The main steady-state leak found by this audit was the former
+  `WorkerManager::should_settle_multiline_r_timeout()` branch. The behavior now
+  sits behind the backend driver as timeout-output-settle policy; a later
+  cleanup should replace that adapter method with worker-advertised metadata or
+  move the need behind the worker protocol.
+
 ## Intended Direction
 
 - Treat `--interpreter r|python` as user-facing worker selection.
@@ -47,6 +74,29 @@ should not leak into steady-state server request semantics.
   server-side branching on backend.
 - Coordinate tool-description cleanup with
   `docs/futurework/composable-tool-descriptions.md`.
+
+## Narrow Capability Metadata
+
+If the server needs to preserve a backend-specific behavior while removing a
+direct R/Python branch, the worker should advertise the smallest capability that
+explains that behavior. Capability names should describe server-visible protocol
+semantics, not implementation language.
+
+Initial candidates:
+
+- `supports_images`: already present in `backend_info`; controls whether image
+  events are expected.
+- `input_framing`: whether server stdin payloads are raw text or length-framed
+  records.
+- `stdin_write_control`: whether a request-start sideband message is needed
+  before stdin bytes are written.
+- `backend_info_startup_timeout`: whether startup may continue after a short
+  backend-info timeout.
+- `timeout_output_settle`: whether a timed-out request needs an additional
+  output-settle window before the server returns the timeout reply.
+
+This metadata should stay startup-only. Request handling should branch on the
+capability value it already received, not on the selected backend.
 
 ## Non-Goals
 

--- a/docs/output_timeline.md
+++ b/docs/output_timeline.md
@@ -64,7 +64,8 @@ only as a later presentation step.
 
 Echo matching must be driven by the sideband facts themselves:
 
-- `readline_start` supplies the prompt text the worker actually showed
+- `readline_start` supplies prompt text and whether the prompt is waiting for
+  new client input
 - `readline_result` is emitted by the worker, but it describes the exact
   prompt text and input line that `readline` consumed and echoed
 - the server should match and collapse those exact sideband facts

--- a/docs/output_timeline.md
+++ b/docs/output_timeline.md
@@ -88,6 +88,8 @@ That matching is only opportunistic:
 - The server is responsible for timeline reconstruction.
 - The worker must not try to solve cross-channel ordering by pretending to know
   exactly when stdout bytes became visible to the server.
+- The worker also must not delay stdout/stderr on sideband responses. Sideband
+  IPC reports facts; it is not backpressure for the visible text streams.
 
 In practice, that means image-vs-stdout ordering fixes belong in server timeline
 resolution, not in the wire protocol.
@@ -99,8 +101,9 @@ resolution, not in the wire protocol.
   consumed.
 - Sideband `plot_image` events define when plot updates happened relative to
   other sideband events.
-- Visible replies must preserve evaluation order even when text-pipe delivery and
-  sideband delivery race.
+- Visible replies must preserve evaluation order when that order is represented
+  by sideband facts. They must not invent a strict order between unframed
+  stdout/stderr bytes and sideband events that the server did not observe.
 
 The important consequence is that "arrival order at the server" is not always
 the same thing as "execution order in the backend".

--- a/docs/output_timeline.md
+++ b/docs/output_timeline.md
@@ -9,7 +9,7 @@ The worker emits different kinds of information on different channels:
 
 - stdout/stderr bytes travel on the normal process pipes.
 - Sideband IPC carries structural events such as `readline_start`,
-  `readline_result`, `plot_image`, `request_end`, and `session_end`.
+  `readline_result`, `plot_image`, and `session_end`.
 
 Those channels do not arrive at the server in one globally ordered stream.
 The server therefore maintains its own output timeline and resolves it into the

--- a/docs/worker_sideband_protocol.md
+++ b/docs/worker_sideband_protocol.md
@@ -65,6 +65,7 @@ Worker-to-server messages are strict: unknown fields are protocol errors.
   device or figure slot. It is not a response image ID; the server owns response
   image IDs and uses `source` only to keep distinct plot sources from collapsing
   into one response image.
+- There is no plot-image acknowledgement message. Workers must not delay stdout/stderr output waiting for sideband responses.
 - If an update is the first image event for a new server request, the server
   treats it as a new response image and includes a server notice that it updates
   the previously sent image.

--- a/docs/worker_sideband_protocol.md
+++ b/docs/worker_sideband_protocol.md
@@ -35,9 +35,14 @@ The channel is a JSON-lines stream (one JSON object per line) carried over an IP
 
 ## Direction: worker -> server
 
+Worker-to-server messages are strict: unknown fields are protocol errors.
+
 `backend_info`
-- `{ "type": "backend_info", "language": <string>, "supports_images": <bool> }`
+- `{ "type": "backend_info", "supports_images": <bool> }`
 - Sent once on startup after the sideband connection is established.
+- This is startup metadata. It may describe narrow worker capabilities, but it
+  must not turn steady-state server request handling into language-specific
+  policy.
 
 `readline_start`
 - `{ "type": "readline_start", "prompt": <string> }`
@@ -50,13 +55,12 @@ The channel is a JSON-lines stream (one JSON object per line) carried over an IP
 - The server can reconstruct echoed readline bytes as `prompt + line` for conservative
   echo suppression. Output streams remain unframed.
 
-`request_end`
-- `{ "type": "request_end" }`
-- Marks the end of output for the request. This is the primary completion signal.
-
 `plot_image`
-- `{ "type": "plot_image", "id": <string>, "mime_type": <string>, "data": <base64>, "is_new": <bool> }`
+- `{ "type": "plot_image", "mime_type": <string>, "data": <base64>, "is_update": <bool> }`
 - Image payload for plot updates.
+- If an update is the first image event for a new server request, the server
+  treats it as a new response image and includes a server notice that it updates
+  the previously sent image.
 
 `session_end`
 - `{ "type": "session_end" }`
@@ -65,8 +69,13 @@ The channel is a JSON-lines stream (one JSON object per line) carried over an IP
 ## Notes
 
 - Output streams (stdout/stderr) remain on the main pipes and are captured separately.
-- The server uses `request_end` as the logical completion signal for a request.
-- To reduce IPC-vs-output capture races, the server applies a short post-`request_end` settle
-  window so output reader threads can drain final bytes before snapshotting output.
-- On timeout, a request may remain pending; later polls can observe the delayed `request_end`
-  and finish the request.
+- The server infers request completion when prompt/readline sideband facts show
+  that the worker is waiting for the next input.
+- To reduce IPC-vs-output capture races, the server applies a short
+  post-completion settle window so output reader threads can drain final bytes
+  before snapshotting output.
+- On timeout, a request may remain pending; later polls can observe the inferred
+  completion state and finish the request.
+- Backend-specific execution rules should be implemented by the worker. Server
+  branching on backend is reserved for interpreter selection, launch setup, tool
+  description selection, or narrow capabilities reported at startup.

--- a/docs/worker_sideband_protocol.md
+++ b/docs/worker_sideband_protocol.md
@@ -45,9 +45,12 @@ Worker-to-server messages are strict: unknown fields are protocol errors.
   policy.
 
 `readline_start`
-- `{ "type": "readline_start", "prompt": <string> }`
-- Emitted before each readline call to indicate the prompt that will be shown.
-  The prompt string is required; use an empty string if the backend did not supply one.
+- `{ "type": "readline_start", "prompt": <string>, "client_waiting": <bool> }`
+- Emitted for readline prompts. The prompt string is required; use an empty string
+  if the backend did not supply one.
+- `client_waiting` is true only when the backend knows the prompt is waiting for
+  new client input. Prompts that will immediately consume buffered input should
+  use false.
 
 `readline_result`
 - `{ "type": "readline_result", "prompt": <string>, "line": <string> }`
@@ -56,8 +59,12 @@ Worker-to-server messages are strict: unknown fields are protocol errors.
   echo suppression. Output streams remain unframed.
 
 `plot_image`
-- `{ "type": "plot_image", "mime_type": <string>, "data": <base64>, "is_update": <bool> }`
+- `{ "type": "plot_image", "mime_type": <string>, "data": <base64>, "is_update": <bool>, "source": <string|null> }`
 - Image payload for plot updates.
+- `source` is optional worker-local plot source identity, such as a graphics
+  device or figure slot. It is not a response image ID; the server owns response
+  image IDs and uses `source` only to keep distinct plot sources from collapsing
+  into one response image.
 - If an update is the first image event for a new server request, the server
   treats it as a new response image and includes a server notice that it updates
   the previously sent image.

--- a/python/driver.py
+++ b/python/driver.py
@@ -191,10 +191,9 @@ def _emit_plots():
         _send(
             {
                 "type": "plot_image",
-                "id": f"plot-{_plot_pid}-{fig_num}",
                 "mime_type": "image/png",
                 "data": encoded,
-                "is_new": bool(is_new),
+                "is_update": not bool(is_new),
             }
         )
     with _plot_lock:
@@ -227,7 +226,6 @@ def _emit_backend_info():
     _send(
         {
             "type": "backend_info",
-            "language": "python",
             "supports_images": _plot_capable,
         }
     )
@@ -242,9 +240,9 @@ class _Prompt(str):
     def __str__(self):
         global _last_prompt
         _last_prompt = super().__str__()
-        # Emit prompt + request_end even if readline pre_input_hook is not invoked (e.g. after some
-        # interrupts). Only emit for the primary prompt; continuation prompts are handled by the
-        # pre_input hook and emitting from sys.ps2 can interfere with prompt selection.
+        # Emit prompt even if readline pre_input_hook is not invoked (e.g. after some interrupts).
+        # Only emit for the primary prompt; continuation prompts are handled by the pre_input hook
+        # and emitting from sys.ps2 can interfere with prompt selection.
         if self.emit:
             _emit_prompt(_last_prompt)
         return _last_prompt
@@ -265,7 +263,7 @@ def _stdin_has_data():
     # We only want to end a request when Python is about to block waiting on input.
     # When the server sends a multi-line chunk, the interpreter may produce prompts
     # between internal reads while stdin still has buffered data. In that case we
-    # must NOT emit request_end yet.
+    # must NOT finish the request yet.
     try:
         readable, _, _ = select.select([0], [], [], 0)
         return bool(readable)
@@ -363,7 +361,7 @@ def _discard_pending_request_input():
             _interrupt_pending = False
 
 
-def _emit_request_end_if_idle():
+def _finish_request_if_idle():
     if not _has_request_active():
         return
     if _stdin_has_data():
@@ -371,23 +369,22 @@ def _emit_request_end_if_idle():
     _emit_plots()
     if not _take_request_active():
         return
-    # Best-effort: ensure the client observes all output written for the request before the
-    # request_end event. The Rust side uses a short "settle" window after request_end too.
+    # Best-effort: ensure the client observes output written before the prompt that marks the
+    # request as complete. The Rust side also uses a short settle window after completion.
     try:
         sys.stdout.flush()
         sys.stderr.flush()
     except Exception:
         pass
-    _send({"type": "request_end"})
 
 
-def _emit_prompt(prompt=None, emit_request_end=True):
+def _emit_prompt(prompt=None, finish_request=True):
     _discard_pending_request_input()
     if prompt is None:
         prompt = _last_prompt or _primary_prompt or getattr(sys, "ps1", ">>> ")
     _send({"type": "readline_start", "prompt": str(prompt)})
-    if emit_request_end:
-        _emit_request_end_if_idle()
+    if finish_request:
+        _finish_request_if_idle()
 
 
 def _pydoc_plainpager(text, title=""):

--- a/python/driver.py
+++ b/python/driver.py
@@ -51,6 +51,9 @@ _plot_hooks_installed = False
 _plot_emit_in_progress = False
 _plot_axes_plot = None
 _plot_show = None
+_plot_next_sequence = 0
+_plot_acks = set()
+_plot_ack_condition = threading.Condition()
 
 
 def _close_ipc_in_fork_child():
@@ -86,6 +89,32 @@ def _send(obj):
             readline.set_pre_input_hook(None)
         except Exception:
             pass
+
+
+def _flush_stdio():
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except Exception:
+        pass
+
+
+def _next_plot_sequence():
+    global _plot_next_sequence
+    with _plot_ack_condition:
+        _plot_next_sequence += 1
+        return _plot_next_sequence
+
+
+def _wait_for_plot_ack(sequence, timeout_seconds=1.0):
+    deadline = time.monotonic() + timeout_seconds
+    with _plot_ack_condition:
+        while sequence not in _plot_acks:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            _plot_ack_condition.wait(remaining)
+        _plot_acks.discard(sequence)
 
 
 def _ensure_plot_modules():
@@ -183,6 +212,8 @@ def _emit_plots():
             _plot_hashes[fig_num] = digest
         encoded = base64.b64encode(data).decode("ascii")
         is_new = fig_num not in prev_known
+        sequence = _next_plot_sequence()
+        _flush_stdio()
         _send(
             {
                 "type": "plot_image",
@@ -190,8 +221,10 @@ def _emit_plots():
                 "data": encoded,
                 "is_update": not bool(is_new),
                 "source": str(fig_num),
+                "sequence": sequence,
             }
         )
+        _wait_for_plot_ack(sequence)
     with _plot_lock:
         _plot_known_figures = new_known
     _plot_emit_in_progress = False
@@ -376,11 +409,7 @@ def _finish_request_if_idle():
         return True
     # Best-effort: ensure the client observes output written before the prompt that marks the
     # request as complete. The Rust side also uses a short settle window after completion.
-    try:
-        sys.stdout.flush()
-        sys.stderr.flush()
-    except Exception:
-        pass
+    _flush_stdio()
     return True
 
 
@@ -456,6 +485,12 @@ def _ipc_reader():
         msg_type = msg.get("type")
         if msg_type == "stdin_write":
             _set_request_active()
+        elif msg_type == "plot_image_ack":
+            sequence = msg.get("sequence")
+            if isinstance(sequence, int):
+                with _plot_ack_condition:
+                    _plot_acks.add(sequence)
+                    _plot_ack_condition.notify_all()
         elif msg_type == "interrupt":
             with _request_lock:
                 _interrupt_pending = True

--- a/python/driver.py
+++ b/python/driver.py
@@ -51,9 +51,7 @@ _plot_hooks_installed = False
 _plot_emit_in_progress = False
 _plot_axes_plot = None
 _plot_show = None
-_plot_next_sequence = 0
-_plot_acks = set()
-_plot_ack_condition = threading.Condition()
+_plot_emitted_this_request = {}
 
 
 def _close_ipc_in_fork_child():
@@ -99,24 +97,6 @@ def _flush_stdio():
         pass
 
 
-def _next_plot_sequence():
-    global _plot_next_sequence
-    with _plot_ack_condition:
-        _plot_next_sequence += 1
-        return _plot_next_sequence
-
-
-def _wait_for_plot_ack(sequence, timeout_seconds=1.0):
-    deadline = time.monotonic() + timeout_seconds
-    with _plot_ack_condition:
-        while sequence not in _plot_acks:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            _plot_ack_condition.wait(remaining)
-        _plot_acks.discard(sequence)
-
-
 def _ensure_plot_modules():
     global _plot_modules_loaded, _plot_pyplot, _plot_capable, _plot_hooks_installed, _plot_axes_plot, _plot_show
     if not _plot_capable:
@@ -138,7 +118,9 @@ def _ensure_plot_modules():
 
             def _wrapped_plot(self, *args, **kwargs):
                 result = _plot_axes_plot(self, *args, **kwargs)
-                _maybe_emit_plots()
+                fig_num = getattr(getattr(self, "figure", None), "number", None)
+                force_figures = {fig_num} if fig_num is not None else None
+                _maybe_emit_plots(force_figures=force_figures)
                 return result
 
             Axes.plot = _wrapped_plot
@@ -146,7 +128,7 @@ def _ensure_plot_modules():
 
             def _wrapped_show(*args, **kwargs):
                 result = _plot_show(*args, **kwargs)
-                _maybe_emit_plots()
+                _maybe_emit_plots(force_all=True)
                 return result
 
             plt.show = _wrapped_show
@@ -158,14 +140,14 @@ def _ensure_plot_modules():
         return False
 
 
-def _maybe_emit_plots():
+def _maybe_emit_plots(force_figures=None, force_all=False):
     if not _has_request_active():
         return
-    _emit_plots()
+    _emit_plots(force_figures=force_figures, force_all=force_all)
 
 
-def _emit_plots():
-    global _plot_known_figures, _plot_hashes, _plot_emit_in_progress
+def _emit_plots(force_figures=None, force_all=False):
+    global _plot_known_figures, _plot_hashes, _plot_emitted_this_request, _plot_emit_in_progress
     if not _plot_capable:
         return
     if _plot_emit_in_progress:
@@ -188,14 +170,17 @@ def _emit_plots():
         with _plot_lock:
             _plot_known_figures = set()
             _plot_hashes = {}
+            _plot_emitted_this_request = {}
         _plot_emit_in_progress = False
         return
     fig_nums = sorted(fig_nums)
     new_known = set(fig_nums)
+    force_figures = set() if force_figures is None else set(force_figures)
     with _plot_lock:
         prev_known = set(_plot_known_figures)
         for stale_num in set(_plot_hashes) - new_known:
             _plot_hashes.pop(stale_num, None)
+            _plot_emitted_this_request.pop(stale_num, None)
     for fig_num in fig_nums:
         try:
             fig = plt.figure(fig_num)
@@ -206,13 +191,17 @@ def _emit_plots():
         except Exception:
             continue
         digest = hashlib.sha256(data).hexdigest()
+        force_current = force_all or fig_num in force_figures
         with _plot_lock:
-            if _plot_hashes.get(fig_num) == digest:
+            emitted_this_request = _plot_emitted_this_request.get(fig_num) == digest
+            if emitted_this_request:
+                continue
+            if _plot_hashes.get(fig_num) == digest and not force_current:
                 continue
             _plot_hashes[fig_num] = digest
+            _plot_emitted_this_request[fig_num] = digest
         encoded = base64.b64encode(data).decode("ascii")
         is_new = fig_num not in prev_known
-        sequence = _next_plot_sequence()
         _flush_stdio()
         _send(
             {
@@ -221,20 +210,20 @@ def _emit_plots():
                 "data": encoded,
                 "is_update": not bool(is_new),
                 "source": str(fig_num),
-                "sequence": sequence,
             }
         )
-        _wait_for_plot_ack(sequence)
     with _plot_lock:
         _plot_known_figures = new_known
     _plot_emit_in_progress = False
 
 
 def _set_request_active():
-    global _request_active, _interrupt_pending
+    global _request_active, _interrupt_pending, _plot_emitted_this_request
     with _request_lock:
         _request_active = True
         _interrupt_pending = False
+    with _plot_lock:
+        _plot_emitted_this_request = {}
 
 
 def _take_request_active():
@@ -485,12 +474,6 @@ def _ipc_reader():
         msg_type = msg.get("type")
         if msg_type == "stdin_write":
             _set_request_active()
-        elif msg_type == "plot_image_ack":
-            sequence = msg.get("sequence")
-            if isinstance(sequence, int):
-                with _plot_ack_condition:
-                    _plot_acks.add(sequence)
-                    _plot_ack_condition.notify_all()
         elif msg_type == "interrupt":
             with _request_lock:
                 _interrupt_pending = True

--- a/python/driver.py
+++ b/python/driver.py
@@ -129,14 +129,6 @@ def _ensure_plot_modules():
         return False
 
 
-def _reset_plot_hashes():
-    global _plot_hashes
-    if not _plot_capable:
-        return
-    with _plot_lock:
-        _plot_hashes = {}
-
-
 def _maybe_emit_plots():
     if not _has_request_active():
         return
@@ -166,12 +158,15 @@ def _emit_plots():
     if not fig_nums:
         with _plot_lock:
             _plot_known_figures = set()
+            _plot_hashes = {}
         _plot_emit_in_progress = False
         return
     fig_nums = sorted(fig_nums)
+    new_known = set(fig_nums)
     with _plot_lock:
         prev_known = set(_plot_known_figures)
-    new_known = set(fig_nums)
+        for stale_num in set(_plot_hashes) - new_known:
+            _plot_hashes.pop(stale_num, None)
     for fig_num in fig_nums:
         try:
             fig = plt.figure(fig_num)
@@ -194,6 +189,7 @@ def _emit_plots():
                 "mime_type": "image/png",
                 "data": encoded,
                 "is_update": not bool(is_new),
+                "source": str(fig_num),
             }
         )
     with _plot_lock:
@@ -269,6 +265,15 @@ def _stdin_has_data():
         return bool(readable)
     except Exception:
         return False
+
+
+def _stdin_has_data_soon(timeout_seconds=0.05):
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if _stdin_has_data():
+            return True
+        time.sleep(0.001)
+    return _stdin_has_data()
 
 
 def _wait_for_request_active(timeout_seconds=0.05):
@@ -363,12 +368,12 @@ def _discard_pending_request_input():
 
 def _finish_request_if_idle():
     if not _has_request_active():
-        return
-    if _stdin_has_data():
-        return
+        return False
+    if _stdin_has_data_soon():
+        return False
     _emit_plots()
     if not _take_request_active():
-        return
+        return True
     # Best-effort: ensure the client observes output written before the prompt that marks the
     # request as complete. The Rust side also uses a short settle window after completion.
     try:
@@ -376,15 +381,23 @@ def _finish_request_if_idle():
         sys.stderr.flush()
     except Exception:
         pass
+    return True
 
 
 def _emit_prompt(prompt=None, finish_request=True):
     _discard_pending_request_input()
     if prompt is None:
         prompt = _last_prompt or _primary_prompt or getattr(sys, "ps1", ">>> ")
-    _send({"type": "readline_start", "prompt": str(prompt)})
-    if finish_request:
-        _finish_request_if_idle()
+    # Buffered stdin means this prompt is an internal interpreter prompt, not a client-waiting
+    # prompt. Do not emit the completion sideband until Python is actually idle.
+    client_waiting = bool(finish_request and _finish_request_if_idle())
+    _send(
+        {
+            "type": "readline_start",
+            "prompt": str(prompt),
+            "client_waiting": client_waiting,
+        }
+    )
 
 
 def _pydoc_plainpager(text, title=""):
@@ -443,7 +456,6 @@ def _ipc_reader():
         msg_type = msg.get("type")
         if msg_type == "stdin_write":
             _set_request_active()
-            _reset_plot_hashes()
         elif msg_type == "interrupt":
             with _request_lock:
                 _interrupt_pending = True

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -85,10 +85,9 @@ pub enum ServerToWorkerIpcMessage {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum WorkerToServerIpcMessage {
     BackendInfo {
-        language: String,
         #[serde(default)]
         supports_images: bool,
     },
@@ -100,14 +99,10 @@ pub enum WorkerToServerIpcMessage {
         line: String,
     },
     PlotImage {
-        id: String,
         mime_type: String,
         data: String,
-        is_new: bool,
+        is_update: bool,
     },
-    /// Emitted exactly when the backend knows the logical request has consumed all queued input.
-    /// No later `ReadlineResult` should follow for that same request.
-    RequestEnd,
     SessionEnd,
 }
 
@@ -120,7 +115,9 @@ struct ServerIpcInbox {
     readline_result_count: u64,
     readline_unmatched_starts: usize,
     readline_unmatched_since: Option<Instant>,
-    request_end_seen: bool,
+    next_image_id: u64,
+    current_image_id: Option<String>,
+    request_image_id: Option<String>,
     protocol_warnings: VecDeque<String>,
     session_end: bool,
     disconnected: bool,
@@ -144,6 +141,7 @@ pub struct IpcPlotImage {
     pub mime_type: String,
     pub data: String,
     pub is_new: bool,
+    pub updates_previous_image: bool,
     pub readline_results_seen: usize,
 }
 
@@ -152,7 +150,6 @@ pub struct IpcHandlers {
     pub on_plot_image: Option<Arc<dyn Fn(IpcPlotImage) + Send + Sync>>,
     pub on_readline_start: Option<Arc<dyn Fn(String) + Send + Sync>>,
     pub on_readline_result: Option<Arc<dyn Fn(IpcEchoEvent) + Send + Sync>>,
-    pub on_request_end: Option<Arc<dyn Fn() + Send + Sync>>,
     pub on_session_end: Option<Arc<dyn Fn() + Send + Sync>>,
 }
 
@@ -204,7 +201,6 @@ impl ServerIpcConnection {
         let plot_handler = handlers.on_plot_image.clone();
         let readline_start_handler = handlers.on_readline_start.clone();
         let readline_result_handler = handlers.on_readline_result.clone();
-        let request_end_handler = handlers.on_request_end.clone();
         let session_end_handler = handlers.on_session_end.clone();
         let IpcTransport { reader, writer } = transport;
         let handle = thread::spawn(move || {
@@ -236,9 +232,6 @@ impl ServerIpcConnection {
                         WorkerToServerIpcMessage::ReadlineStart { prompt } => {
                             let prompt_for_handler = prompt.clone();
                             let mut guard = reader_inbox.lock().unwrap();
-                            if guard.request_end_seen {
-                                reset_after_completed_request(&mut guard);
-                            }
                             guard.readline_unmatched_starts =
                                 guard.readline_unmatched_starts.saturating_add(1);
                             if guard.readline_unmatched_starts == 1 {
@@ -267,12 +260,6 @@ impl ServerIpcConnection {
                                 line: line.clone(),
                             };
                             let mut guard = reader_inbox.lock().unwrap();
-                            if guard.request_end_seen {
-                                guard.protocol_warnings.push_back(
-                                    "protocol warning: worker emitted ReadlineResult after RequestEnd"
-                                        .to_string(),
-                                );
-                            }
                             guard.readline_result_count =
                                 guard.readline_result_count.saturating_add(1);
                             if guard.readline_unmatched_starts > 0 {
@@ -299,14 +286,37 @@ impl ServerIpcConnection {
                             }
                         }
                         WorkerToServerIpcMessage::PlotImage {
-                            id,
                             mime_type,
                             data,
-                            is_new,
+                            is_update,
                         } => {
-                            let readline_results_seen = {
-                                let guard = reader_inbox.lock().unwrap();
-                                guard.readline_result_count as usize
+                            let (id, is_new, updates_previous_image, readline_results_seen) = {
+                                let mut guard = reader_inbox.lock().unwrap();
+                                let updates_previous_image = is_update
+                                    && guard.current_image_id.is_some()
+                                    && guard.request_image_id.is_none();
+                                let is_new = !is_update
+                                    || guard.current_image_id.is_none()
+                                    || updates_previous_image;
+                                let id = if is_new {
+                                    guard.next_image_id = guard.next_image_id.saturating_add(1);
+                                    let id = format!("image-{}", guard.next_image_id);
+                                    guard.request_image_id = Some(id.clone());
+                                    guard.current_image_id = Some(id.clone());
+                                    id
+                                } else {
+                                    guard
+                                        .request_image_id
+                                        .clone()
+                                        .or_else(|| guard.current_image_id.clone())
+                                        .expect("current image id must exist for updates")
+                                };
+                                (
+                                    id,
+                                    is_new,
+                                    updates_previous_image,
+                                    guard.readline_result_count as usize,
+                                )
                             };
                             if let Some(handler) = plot_handler.as_ref() {
                                 handler(IpcPlotImage {
@@ -314,32 +324,23 @@ impl ServerIpcConnection {
                                     mime_type,
                                     data,
                                     is_new,
+                                    updates_previous_image,
                                     readline_results_seen,
                                 });
                             } else {
                                 let mut guard = reader_inbox.lock().unwrap();
                                 guard.queue.push_back(WorkerToServerIpcMessage::PlotImage {
-                                    id,
                                     mime_type,
                                     data,
-                                    is_new,
+                                    is_update,
                                 });
                                 reader_cvar.notify_all();
                             }
                         }
                         other => {
                             let mut guard = reader_inbox.lock().unwrap();
-                            let is_request_end =
-                                matches!(other, WorkerToServerIpcMessage::RequestEnd);
-                            if is_request_end {
-                                guard.request_end_seen = true;
-                            }
                             guard.queue.push_back(other);
                             reader_cvar.notify_all();
-                            drop(guard);
-                            if is_request_end && let Some(handler) = request_end_handler.as_ref() {
-                                handler();
-                            }
                         }
                     }
                 }
@@ -377,24 +378,10 @@ impl ServerIpcConnection {
 
     pub fn begin_request(&self) {
         let mut guard = self.inbox.lock().unwrap();
-        guard
-            .queue
-            .retain(|msg| !matches!(msg, WorkerToServerIpcMessage::RequestEnd));
         reset_after_completed_request(&mut guard);
         guard.echo_events.clear();
         guard.prompt_history.clear();
         guard.protocol_warnings.clear();
-    }
-
-    pub fn waiting_for_next_input(&self, min_wait: Duration) -> bool {
-        let guard = self.inbox.lock().unwrap();
-        if guard.readline_result_count == 0 || guard.readline_unmatched_starts == 0 {
-            return false;
-        }
-        let Some(since) = guard.readline_unmatched_since else {
-            return false;
-        };
-        since.elapsed() >= min_wait
     }
 
     pub fn take_prompt_history(&self) -> Vec<String> {
@@ -417,18 +404,19 @@ impl ServerIpcConnection {
         guard.protocol_warnings.drain(..).collect()
     }
 
-    pub fn wait_for_request_end(&self, timeout: Duration) -> Result<(), IpcWaitError> {
+    pub fn wait_for_request_completion(
+        &self,
+        timeout: Duration,
+        stable_wait: Duration,
+    ) -> Result<(), IpcWaitError> {
         let deadline = Instant::now() + timeout;
         let mut guard = self.inbox.lock().unwrap();
         loop {
-            if take_request_end(&mut guard) {
-                if take_session_end(&mut guard) {
-                    return Err(IpcWaitError::SessionEnd);
-                }
-                return Ok(());
-            }
             if take_session_end(&mut guard) {
                 return Err(IpcWaitError::SessionEnd);
+            }
+            if take_request_completion(&mut guard, stable_wait) {
+                return Ok(());
             }
             if guard.disconnected {
                 return Err(IpcWaitError::Disconnected);
@@ -438,11 +426,19 @@ impl ServerIpcConnection {
             if now >= deadline {
                 return Err(IpcWaitError::Timeout);
             }
-            let remaining = deadline.saturating_duration_since(now);
+            let remaining = completion_wait_duration(&guard, deadline, stable_wait);
             let (next_guard, timeout_res) = self.cvar.wait_timeout(guard, remaining).unwrap();
             guard = next_guard;
             if timeout_res.timed_out() {
-                return Err(IpcWaitError::Timeout);
+                if take_session_end(&mut guard) {
+                    return Err(IpcWaitError::SessionEnd);
+                }
+                if take_request_completion(&mut guard, stable_wait) {
+                    return Ok(());
+                }
+                if Instant::now() >= deadline {
+                    return Err(IpcWaitError::Timeout);
+                }
             }
         }
     }
@@ -508,11 +504,6 @@ impl ServerIpcConnection {
                 return Err(IpcWaitError::Timeout);
             }
         }
-    }
-
-    pub fn try_take_request_end(&self) -> bool {
-        let mut guard = self.inbox.lock().unwrap();
-        take_request_end(&mut guard)
     }
 }
 
@@ -1329,29 +1320,19 @@ pub fn emit_readline_result(prompt: &str, line: &str) {
     }
 }
 
-pub fn emit_plot_image(id: &str, mime_type: &str, data: &str, is_new: bool) {
+pub fn emit_plot_image(mime_type: &str, data: &str, is_update: bool) {
     if let Some(ipc) = global_ipc() {
         let _ = ipc.send(WorkerToServerIpcMessage::PlotImage {
-            id: id.to_string(),
             mime_type: mime_type.to_string(),
             data: data.to_string(),
-            is_new,
+            is_update,
         });
     }
 }
 
-pub fn emit_backend_info(language: &str, supports_images: bool) {
+pub fn emit_backend_info(supports_images: bool) {
     if let Some(ipc) = global_ipc() {
-        let _ = ipc.send(WorkerToServerIpcMessage::BackendInfo {
-            language: language.to_string(),
-            supports_images,
-        });
-    }
-}
-
-pub fn emit_request_end() {
-    if let Some(ipc) = global_ipc() {
-        let _ = ipc.send(WorkerToServerIpcMessage::RequestEnd);
+        let _ = ipc.send(WorkerToServerIpcMessage::BackendInfo { supports_images });
     }
 }
 
@@ -1394,23 +1375,48 @@ fn take_session_end(guard: &mut ServerIpcInbox) -> bool {
     true
 }
 
-fn take_request_end(guard: &mut ServerIpcInbox) -> bool {
-    let idx = guard
-        .queue
-        .iter()
-        .position(|msg| matches!(msg, WorkerToServerIpcMessage::RequestEnd));
-    let Some(idx) = idx else {
+fn request_completion_ready(guard: &ServerIpcInbox, stable_wait: Duration) -> bool {
+    let Some(since) = guard.readline_unmatched_since else {
         return false;
     };
-    guard.queue.remove(idx);
+    guard.readline_unmatched_starts > 0 && since.elapsed() >= stable_wait
+}
+
+fn take_request_completion(guard: &mut ServerIpcInbox, stable_wait: Duration) -> bool {
+    if !request_completion_ready(guard, stable_wait) {
+        return false;
+    }
+    reset_request_progress(guard);
     true
 }
 
-fn reset_after_completed_request(guard: &mut ServerIpcInbox) {
-    guard.request_end_seen = false;
+fn completion_wait_duration(
+    guard: &ServerIpcInbox,
+    deadline: Instant,
+    stable_wait: Duration,
+) -> Duration {
+    let now = Instant::now();
+    let until_deadline = deadline.saturating_duration_since(now);
+    let Some(since) = guard.readline_unmatched_since else {
+        return until_deadline;
+    };
+    let elapsed = since.elapsed();
+    if elapsed >= stable_wait {
+        Duration::from_millis(0)
+    } else {
+        until_deadline.min(stable_wait.saturating_sub(elapsed))
+    }
+}
+
+fn reset_request_progress(guard: &mut ServerIpcInbox) {
     guard.readline_result_count = 0;
     guard.readline_unmatched_starts = 0;
     guard.readline_unmatched_since = None;
+}
+
+fn reset_after_completed_request(guard: &mut ServerIpcInbox) {
+    reset_request_progress(guard);
+    guard.request_image_id = None;
     guard.last_prompt = None;
 }
 
@@ -1420,6 +1426,141 @@ fn take_backend_info(guard: &mut ServerIpcInbox) -> Option<WorkerToServerIpcMess
         .iter()
         .position(|msg| matches!(msg, WorkerToServerIpcMessage::BackendInfo { .. }))?;
     guard.queue.remove(idx)
+}
+
+#[cfg(test)]
+mod protocol_tests {
+    use super::{
+        IpcHandlers, IpcTransport, ServerIpcConnection, WorkerIpcConnection,
+        WorkerToServerIpcMessage,
+    };
+    use serde_json::json;
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn backend_info_protocol_does_not_include_language() {
+        let parsed = serde_json::from_value::<WorkerToServerIpcMessage>(json!({
+            "type": "backend_info",
+            "supports_images": true
+        }));
+
+        assert!(parsed.is_ok(), "backend_info should not require language");
+    }
+
+    #[test]
+    fn backend_info_protocol_rejects_language() {
+        let parsed = serde_json::from_value::<WorkerToServerIpcMessage>(json!({
+            "type": "backend_info",
+            "language": "r",
+            "supports_images": true
+        }));
+
+        assert!(parsed.is_err(), "backend_info should reject language");
+    }
+
+    #[test]
+    fn plot_image_protocol_uses_update_flag_without_worker_id() {
+        let parsed = serde_json::from_value::<WorkerToServerIpcMessage>(json!({
+            "type": "plot_image",
+            "mime_type": "image/png",
+            "data": "abc",
+            "is_update": true
+        }));
+
+        assert!(
+            parsed.is_ok(),
+            "plot_image should not require worker image id"
+        );
+    }
+
+    #[test]
+    fn plot_image_protocol_rejects_worker_id_and_is_new() {
+        let parsed = serde_json::from_value::<WorkerToServerIpcMessage>(json!({
+            "type": "plot_image",
+            "id": "plot-1",
+            "mime_type": "image/png",
+            "data": "abc",
+            "is_new": true,
+            "is_update": false
+        }));
+
+        assert!(
+            parsed.is_err(),
+            "plot_image should reject old worker-owned image fields"
+        );
+    }
+
+    #[test]
+    fn request_end_is_not_part_of_worker_to_server_protocol() {
+        let parsed = serde_json::from_value::<WorkerToServerIpcMessage>(json!({
+            "type": "request_end"
+        }));
+
+        assert!(parsed.is_err(), "request_end should not deserialize");
+    }
+
+    #[test]
+    fn plot_image_updates_reuse_current_server_image_id() {
+        let (server_read, worker_write) = std::io::pipe().expect("server pipe");
+        let (worker_read, server_write) = std::io::pipe().expect("worker pipe");
+        let images = Arc::new(Mutex::new(Vec::new()));
+        let handler_images = images.clone();
+        let _server = ServerIpcConnection::new(
+            IpcTransport {
+                reader: Box::new(server_read),
+                writer: Box::new(server_write),
+            },
+            IpcHandlers {
+                on_plot_image: Some(Arc::new(move |image| {
+                    handler_images.lock().expect("image mutex").push(image);
+                })),
+                ..IpcHandlers::default()
+            },
+        )
+        .expect("server connection");
+        let worker = WorkerIpcConnection::new(IpcTransport {
+            reader: Box::new(worker_read),
+            writer: Box::new(worker_write),
+        })
+        .expect("worker connection");
+        let first = json!({
+            "type": "plot_image",
+            "mime_type": "image/png",
+            "data": "first",
+            "is_update": false
+        })
+        .to_string();
+        let second = json!({
+            "type": "plot_image",
+            "mime_type": "image/png",
+            "data": "second",
+            "is_update": true
+        })
+        .to_string();
+
+        worker
+            .send(serde_json::from_str(&first).expect("first image message"))
+            .expect("send first image");
+        worker
+            .send(serde_json::from_str(&second).expect("second image message"))
+            .expect("send second image");
+
+        let deadline = Instant::now() + Duration::from_millis(200);
+        while Instant::now() < deadline {
+            if images.lock().expect("image mutex").len() >= 2 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        let images = images.lock().expect("image mutex");
+        assert_eq!(images.len(), 2);
+        assert_eq!(images[0].id, images[1].id);
+        assert!(images[0].is_new);
+        assert!(!images[1].is_new);
+        assert_eq!(images[0].data, "first");
+        assert_eq!(images[1].data, "second");
+    }
 }
 
 #[cfg(all(test, target_family = "windows"))]

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -73,7 +73,6 @@ static WORKER_IPC_FORK_CLOSE_READ_FD: AtomicI32 = AtomicI32::new(-1);
 #[cfg(target_family = "unix")]
 static WORKER_IPC_FORK_CLOSE_WRITE_FD: AtomicI32 = AtomicI32::new(-1);
 static NEXT_SERVER_IMAGE_ID: AtomicU64 = AtomicU64::new(0);
-static NEXT_WORKER_PLOT_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 #[cfg(target_family = "unix")]
 static WORKER_IPC_ATFORK_REGISTER_RESULT: OnceLock<i32> = OnceLock::new();
 
@@ -81,7 +80,6 @@ static WORKER_IPC_ATFORK_REGISTER_RESULT: OnceLock<i32> = OnceLock::new();
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServerToWorkerIpcMessage {
     StdinWrite { text: String },
-    PlotImageAck { sequence: u64 },
     Interrupt,
     SessionEnd,
 }
@@ -107,8 +105,6 @@ pub enum WorkerToServerIpcMessage {
         is_update: bool,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        sequence: Option<u64>,
     },
     SessionEnd,
 }
@@ -210,7 +206,6 @@ impl ServerIpcConnection {
         let readline_start_handler = handlers.on_readline_start.clone();
         let readline_result_handler = handlers.on_readline_result.clone();
         let session_end_handler = handlers.on_session_end.clone();
-        let server_sender = tx.clone();
         let IpcTransport { reader, writer } = transport;
         let handle = thread::spawn(move || {
             let mut reader = BufReader::new(reader);
@@ -311,7 +306,6 @@ impl ServerIpcConnection {
                         data,
                         is_update,
                         source,
-                        sequence,
                     } => {
                         let (id, is_new, updates_previous_image, readline_results_seen) = {
                             let mut guard = reader_inbox.lock().unwrap();
@@ -340,15 +334,8 @@ impl ServerIpcConnection {
                                 data,
                                 is_update,
                                 source,
-                                sequence,
                             });
                             reader_cvar.notify_all();
-                        }
-                        if let Some(sequence) = sequence {
-                            let _ = send_ipc_message(
-                                &server_sender,
-                                ServerToWorkerIpcMessage::PlotImageAck { sequence },
-                            );
                         }
                     }
                     other => {
@@ -604,7 +591,7 @@ impl WorkerIpcConnection {
 
     pub fn recv(&self, timeout: Option<Duration>) -> Option<ServerToWorkerIpcMessage> {
         let mut guard = self.inbox.lock().unwrap();
-        if let Some(message) = pop_non_ack_message(&mut guard.queue) {
+        if let Some(message) = guard.queue.pop_front() {
             return Some(message);
         }
         if guard.disconnected {
@@ -614,7 +601,7 @@ impl WorkerIpcConnection {
         match timeout {
             None => loop {
                 guard = self.cvar.wait(guard).unwrap();
-                if let Some(message) = pop_non_ack_message(&mut guard.queue) {
+                if let Some(message) = guard.queue.pop_front() {
                     return Some(message);
                 }
                 if guard.disconnected {
@@ -632,7 +619,7 @@ impl WorkerIpcConnection {
                     let (next_guard, timeout_res) =
                         self.cvar.wait_timeout(guard, remaining).unwrap();
                     guard = next_guard;
-                    if let Some(message) = pop_non_ack_message(&mut guard.queue) {
+                    if let Some(message) = guard.queue.pop_front() {
                         return Some(message);
                     }
                     if guard.disconnected {
@@ -645,51 +632,6 @@ impl WorkerIpcConnection {
             }
         }
     }
-
-    pub fn wait_for_plot_image_ack(&self, sequence: u64, timeout: Duration) -> bool {
-        let deadline = Instant::now() + timeout;
-        let mut guard = self.inbox.lock().unwrap();
-        loop {
-            if let Some(idx) = guard.queue.iter().position(|message| {
-                matches!(
-                    message,
-                    ServerToWorkerIpcMessage::PlotImageAck { sequence: seen }
-                        if *seen == sequence
-                )
-            }) {
-                guard.queue.remove(idx);
-                return true;
-            }
-            if guard.disconnected {
-                return false;
-            }
-            let now = Instant::now();
-            if now >= deadline {
-                return false;
-            }
-            let remaining = deadline.saturating_duration_since(now);
-            let (next_guard, timeout_res) = self.cvar.wait_timeout(guard, remaining).unwrap();
-            guard = next_guard;
-            if timeout_res.timed_out() {
-                return false;
-            }
-        }
-    }
-}
-
-fn pop_non_ack_message(
-    queue: &mut VecDeque<ServerToWorkerIpcMessage>,
-) -> Option<ServerToWorkerIpcMessage> {
-    let idx = queue
-        .iter()
-        .position(|message| !matches!(message, ServerToWorkerIpcMessage::PlotImageAck { .. }))?;
-    queue.remove(idx)
-}
-
-fn send_ipc_message<T>(sender: &mpsc::Sender<T>, message: T) -> io::Result<()> {
-    sender
-        .send(message)
-        .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "ipc writer disconnected"))
 }
 
 fn spawn_writer<T>(rx: mpsc::Receiver<T>, mut writer: Box<dyn Write + Send>)
@@ -1406,17 +1348,12 @@ pub fn emit_readline_result(prompt: &str, line: &str) {
 
 pub fn emit_plot_image(mime_type: &str, data: &str, is_update: bool, source: Option<&str>) {
     if let Some(ipc) = global_ipc() {
-        let sequence = NEXT_WORKER_PLOT_SEQUENCE
-            .fetch_add(1, AtomicOrdering::Relaxed)
-            .saturating_add(1);
         let _ = ipc.send(WorkerToServerIpcMessage::PlotImage {
             mime_type: mime_type.to_string(),
             data: data.to_string(),
             is_update,
             source: source.map(ToString::to_string),
-            sequence: Some(sequence),
         });
-        let _ = ipc.wait_for_plot_image_ack(sequence, Duration::from_secs(1));
     }
 }
 
@@ -1585,8 +1522,8 @@ fn take_backend_info(guard: &mut ServerIpcInbox) -> Option<WorkerToServerIpcMess
 #[cfg(test)]
 mod protocol_tests {
     use super::{
-        IpcHandlers, IpcTransport, ServerIpcConnection, WorkerIpcConnection,
-        WorkerToServerIpcMessage,
+        IpcHandlers, IpcTransport, ServerIpcConnection, ServerToWorkerIpcMessage,
+        WorkerIpcConnection, WorkerToServerIpcMessage,
     };
     use serde_json::json;
     use std::io::Write;
@@ -1643,6 +1580,30 @@ mod protocol_tests {
         assert!(
             parsed.is_err(),
             "plot_image should reject old worker-owned image fields"
+        );
+    }
+
+    #[test]
+    fn plot_image_protocol_rejects_sequence_ack_handshake() {
+        let worker_to_server = serde_json::from_value::<WorkerToServerIpcMessage>(json!({
+            "type": "plot_image",
+            "mime_type": "image/png",
+            "data": "abc",
+            "is_update": false,
+            "sequence": 1
+        }));
+        assert!(
+            worker_to_server.is_err(),
+            "plot_image should not expose worker-side ack sequencing"
+        );
+
+        let server_to_worker = serde_json::from_value::<ServerToWorkerIpcMessage>(json!({
+            "type": "plot_image_ack",
+            "sequence": 1
+        }));
+        assert!(
+            server_to_worker.is_err(),
+            "server-to-worker protocol should not include plot_image_ack"
         );
     }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -73,6 +73,7 @@ static WORKER_IPC_FORK_CLOSE_READ_FD: AtomicI32 = AtomicI32::new(-1);
 #[cfg(target_family = "unix")]
 static WORKER_IPC_FORK_CLOSE_WRITE_FD: AtomicI32 = AtomicI32::new(-1);
 static NEXT_SERVER_IMAGE_ID: AtomicU64 = AtomicU64::new(0);
+static NEXT_WORKER_PLOT_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 #[cfg(target_family = "unix")]
 static WORKER_IPC_ATFORK_REGISTER_RESULT: OnceLock<i32> = OnceLock::new();
 
@@ -80,6 +81,7 @@ static WORKER_IPC_ATFORK_REGISTER_RESULT: OnceLock<i32> = OnceLock::new();
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServerToWorkerIpcMessage {
     StdinWrite { text: String },
+    PlotImageAck { sequence: u64 },
     Interrupt,
     SessionEnd,
 }
@@ -105,6 +107,8 @@ pub enum WorkerToServerIpcMessage {
         is_update: bool,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sequence: Option<u64>,
     },
     SessionEnd,
 }
@@ -206,6 +210,7 @@ impl ServerIpcConnection {
         let readline_start_handler = handlers.on_readline_start.clone();
         let readline_result_handler = handlers.on_readline_result.clone();
         let session_end_handler = handlers.on_session_end.clone();
+        let server_sender = tx.clone();
         let IpcTransport { reader, writer } = transport;
         let handle = thread::spawn(move || {
             let mut reader = BufReader::new(reader);
@@ -231,111 +236,125 @@ impl ServerIpcConnection {
                 if trimmed.is_empty() {
                     continue;
                 }
-                if let Ok(message) = serde_json::from_str::<WorkerToServerIpcMessage>(trimmed) {
-                    match message {
-                        WorkerToServerIpcMessage::ReadlineStart {
-                            prompt,
-                            client_waiting,
-                        } => {
-                            let prompt_for_handler = prompt.clone();
+                let message = match serde_json::from_str::<WorkerToServerIpcMessage>(trimmed) {
+                    Ok(message) => message,
+                    Err(_) => {
+                        let mut guard = reader_inbox.lock().unwrap();
+                        guard.disconnected = true;
+                        reader_cvar.notify_all();
+                        break;
+                    }
+                };
+                match message {
+                    WorkerToServerIpcMessage::ReadlineStart {
+                        prompt,
+                        client_waiting,
+                    } => {
+                        let prompt_for_handler = prompt.clone();
+                        let mut guard = reader_inbox.lock().unwrap();
+                        if client_waiting {
+                            guard.readline_unmatched_starts =
+                                guard.readline_unmatched_starts.saturating_add(1);
+                            if guard.readline_unmatched_starts == 1 {
+                                guard.readline_unmatched_since = Some(Instant::now());
+                            }
+                        }
+                        if guard
+                            .prompt_history
+                            .back()
+                            .is_none_or(|last| last != &prompt)
+                        {
+                            guard.prompt_history.push_back(prompt.clone());
+                            if guard.prompt_history.len() > MAX_PROMPT_HISTORY {
+                                guard.prompt_history.pop_front();
+                            }
+                        }
+                        guard.last_prompt = Some(prompt);
+                        reader_cvar.notify_all();
+                        drop(guard);
+                        if let Some(handler) = readline_start_handler.as_ref() {
+                            handler(prompt_for_handler);
+                        }
+                    }
+                    WorkerToServerIpcMessage::ReadlineResult { prompt, line } => {
+                        let echo_event = IpcEchoEvent {
+                            prompt: prompt.clone(),
+                            line: line.clone(),
+                        };
+                        let mut guard = reader_inbox.lock().unwrap();
+                        guard.readline_result_count = guard.readline_result_count.saturating_add(1);
+                        if guard.readline_unmatched_starts > 0 {
+                            guard.readline_unmatched_starts -= 1;
+                            if guard.readline_unmatched_starts == 0 {
+                                guard.readline_unmatched_since = None;
+                            }
+                        }
+                        guard.echo_events.push_back(echo_event.clone());
+                        reader_cvar.notify_all();
+                        drop(guard);
+                        if let Some(handler) = readline_result_handler.as_ref() {
+                            handler(echo_event);
+                        }
+                    }
+                    WorkerToServerIpcMessage::SessionEnd => {
+                        let mut guard = reader_inbox.lock().unwrap();
+                        guard.session_end = true;
+                        guard.queue.push_back(WorkerToServerIpcMessage::SessionEnd);
+                        reader_cvar.notify_all();
+                        drop(guard);
+                        if let Some(handler) = session_end_handler.as_ref() {
+                            handler();
+                        }
+                    }
+                    WorkerToServerIpcMessage::PlotImage {
+                        mime_type,
+                        data,
+                        is_update,
+                        source,
+                        sequence,
+                    } => {
+                        let (id, is_new, updates_previous_image, readline_results_seen) = {
                             let mut guard = reader_inbox.lock().unwrap();
-                            if client_waiting {
-                                guard.readline_unmatched_starts =
-                                    guard.readline_unmatched_starts.saturating_add(1);
-                                if guard.readline_unmatched_starts == 1 {
-                                    guard.readline_unmatched_since = Some(Instant::now());
-                                }
-                            }
-                            if guard
-                                .prompt_history
-                                .back()
-                                .is_none_or(|last| last != &prompt)
-                            {
-                                guard.prompt_history.push_back(prompt.clone());
-                                if guard.prompt_history.len() > MAX_PROMPT_HISTORY {
-                                    guard.prompt_history.pop_front();
-                                }
-                            }
-                            guard.last_prompt = Some(prompt);
-                            reader_cvar.notify_all();
-                            drop(guard);
-                            if let Some(handler) = readline_start_handler.as_ref() {
-                                handler(prompt_for_handler);
-                            }
-                        }
-                        WorkerToServerIpcMessage::ReadlineResult { prompt, line } => {
-                            let echo_event = IpcEchoEvent {
-                                prompt: prompt.clone(),
-                                line: line.clone(),
-                            };
+                            let (id, is_new, updates_previous_image) =
+                                assign_plot_image_id(&mut guard, source.as_deref(), is_update);
+                            (
+                                id,
+                                is_new,
+                                updates_previous_image,
+                                guard.readline_result_count as usize,
+                            )
+                        };
+                        if let Some(handler) = plot_handler.as_ref() {
+                            handler(IpcPlotImage {
+                                id,
+                                mime_type,
+                                data,
+                                is_new,
+                                updates_previous_image,
+                                readline_results_seen,
+                            });
+                        } else {
                             let mut guard = reader_inbox.lock().unwrap();
-                            guard.readline_result_count =
-                                guard.readline_result_count.saturating_add(1);
-                            if guard.readline_unmatched_starts > 0 {
-                                guard.readline_unmatched_starts -= 1;
-                                if guard.readline_unmatched_starts == 0 {
-                                    guard.readline_unmatched_since = None;
-                                }
-                            }
-                            guard.echo_events.push_back(echo_event.clone());
-                            reader_cvar.notify_all();
-                            drop(guard);
-                            if let Some(handler) = readline_result_handler.as_ref() {
-                                handler(echo_event);
-                            }
-                        }
-                        WorkerToServerIpcMessage::SessionEnd => {
-                            let mut guard = reader_inbox.lock().unwrap();
-                            guard.session_end = true;
-                            guard.queue.push_back(WorkerToServerIpcMessage::SessionEnd);
-                            reader_cvar.notify_all();
-                            drop(guard);
-                            if let Some(handler) = session_end_handler.as_ref() {
-                                handler();
-                            }
-                        }
-                        WorkerToServerIpcMessage::PlotImage {
-                            mime_type,
-                            data,
-                            is_update,
-                            source,
-                        } => {
-                            let (id, is_new, updates_previous_image, readline_results_seen) = {
-                                let mut guard = reader_inbox.lock().unwrap();
-                                let (id, is_new, updates_previous_image) =
-                                    assign_plot_image_id(&mut guard, source.as_deref(), is_update);
-                                (
-                                    id,
-                                    is_new,
-                                    updates_previous_image,
-                                    guard.readline_result_count as usize,
-                                )
-                            };
-                            if let Some(handler) = plot_handler.as_ref() {
-                                handler(IpcPlotImage {
-                                    id,
-                                    mime_type,
-                                    data,
-                                    is_new,
-                                    updates_previous_image,
-                                    readline_results_seen,
-                                });
-                            } else {
-                                let mut guard = reader_inbox.lock().unwrap();
-                                guard.queue.push_back(WorkerToServerIpcMessage::PlotImage {
-                                    mime_type,
-                                    data,
-                                    is_update,
-                                    source,
-                                });
-                                reader_cvar.notify_all();
-                            }
-                        }
-                        other => {
-                            let mut guard = reader_inbox.lock().unwrap();
-                            guard.queue.push_back(other);
+                            guard.queue.push_back(WorkerToServerIpcMessage::PlotImage {
+                                mime_type,
+                                data,
+                                is_update,
+                                source,
+                                sequence,
+                            });
                             reader_cvar.notify_all();
                         }
+                        if let Some(sequence) = sequence {
+                            let _ = send_ipc_message(
+                                &server_sender,
+                                ServerToWorkerIpcMessage::PlotImageAck { sequence },
+                            );
+                        }
+                    }
+                    other => {
+                        let mut guard = reader_inbox.lock().unwrap();
+                        guard.queue.push_back(other);
+                        reader_cvar.notify_all();
                     }
                 }
             }
@@ -552,11 +571,18 @@ impl WorkerIpcConnection {
                 if trimmed.is_empty() {
                     continue;
                 }
-                if let Ok(message) = serde_json::from_str::<ServerToWorkerIpcMessage>(trimmed) {
-                    let mut guard = reader_inbox.lock().unwrap();
-                    guard.queue.push_back(message);
-                    reader_cvar.notify_all();
-                }
+                let message = match serde_json::from_str::<ServerToWorkerIpcMessage>(trimmed) {
+                    Ok(message) => message,
+                    Err(_) => {
+                        let mut guard = reader_inbox.lock().unwrap();
+                        guard.disconnected = true;
+                        reader_cvar.notify_all();
+                        break;
+                    }
+                };
+                let mut guard = reader_inbox.lock().unwrap();
+                guard.queue.push_back(message);
+                reader_cvar.notify_all();
             }
         });
 
@@ -578,7 +604,7 @@ impl WorkerIpcConnection {
 
     pub fn recv(&self, timeout: Option<Duration>) -> Option<ServerToWorkerIpcMessage> {
         let mut guard = self.inbox.lock().unwrap();
-        if let Some(message) = guard.queue.pop_front() {
+        if let Some(message) = pop_non_ack_message(&mut guard.queue) {
             return Some(message);
         }
         if guard.disconnected {
@@ -588,7 +614,7 @@ impl WorkerIpcConnection {
         match timeout {
             None => loop {
                 guard = self.cvar.wait(guard).unwrap();
-                if let Some(message) = guard.queue.pop_front() {
+                if let Some(message) = pop_non_ack_message(&mut guard.queue) {
                     return Some(message);
                 }
                 if guard.disconnected {
@@ -606,7 +632,7 @@ impl WorkerIpcConnection {
                     let (next_guard, timeout_res) =
                         self.cvar.wait_timeout(guard, remaining).unwrap();
                     guard = next_guard;
-                    if let Some(message) = guard.queue.pop_front() {
+                    if let Some(message) = pop_non_ack_message(&mut guard.queue) {
                         return Some(message);
                     }
                     if guard.disconnected {
@@ -619,6 +645,51 @@ impl WorkerIpcConnection {
             }
         }
     }
+
+    pub fn wait_for_plot_image_ack(&self, sequence: u64, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        let mut guard = self.inbox.lock().unwrap();
+        loop {
+            if let Some(idx) = guard.queue.iter().position(|message| {
+                matches!(
+                    message,
+                    ServerToWorkerIpcMessage::PlotImageAck { sequence: seen }
+                        if *seen == sequence
+                )
+            }) {
+                guard.queue.remove(idx);
+                return true;
+            }
+            if guard.disconnected {
+                return false;
+            }
+            let now = Instant::now();
+            if now >= deadline {
+                return false;
+            }
+            let remaining = deadline.saturating_duration_since(now);
+            let (next_guard, timeout_res) = self.cvar.wait_timeout(guard, remaining).unwrap();
+            guard = next_guard;
+            if timeout_res.timed_out() {
+                return false;
+            }
+        }
+    }
+}
+
+fn pop_non_ack_message(
+    queue: &mut VecDeque<ServerToWorkerIpcMessage>,
+) -> Option<ServerToWorkerIpcMessage> {
+    let idx = queue
+        .iter()
+        .position(|message| !matches!(message, ServerToWorkerIpcMessage::PlotImageAck { .. }))?;
+    queue.remove(idx)
+}
+
+fn send_ipc_message<T>(sender: &mpsc::Sender<T>, message: T) -> io::Result<()> {
+    sender
+        .send(message)
+        .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "ipc writer disconnected"))
 }
 
 fn spawn_writer<T>(rx: mpsc::Receiver<T>, mut writer: Box<dyn Write + Send>)
@@ -1335,12 +1406,17 @@ pub fn emit_readline_result(prompt: &str, line: &str) {
 
 pub fn emit_plot_image(mime_type: &str, data: &str, is_update: bool, source: Option<&str>) {
     if let Some(ipc) = global_ipc() {
+        let sequence = NEXT_WORKER_PLOT_SEQUENCE
+            .fetch_add(1, AtomicOrdering::Relaxed)
+            .saturating_add(1);
         let _ = ipc.send(WorkerToServerIpcMessage::PlotImage {
             mime_type: mime_type.to_string(),
             data: data.to_string(),
             is_update,
             source: source.map(ToString::to_string),
+            sequence: Some(sequence),
         });
+        let _ = ipc.wait_for_plot_image_ack(sequence, Duration::from_secs(1));
     }
 }
 
@@ -1513,6 +1589,7 @@ mod protocol_tests {
         WorkerToServerIpcMessage,
     };
     use serde_json::json;
+    use std::io::Write;
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
 
@@ -1576,6 +1653,38 @@ mod protocol_tests {
         }));
 
         assert!(parsed.is_err(), "request_end should not deserialize");
+    }
+
+    #[test]
+    fn invalid_worker_message_disconnects_server_ipc() {
+        let (server_read, mut worker_write) = std::io::pipe().expect("server pipe");
+        let (_worker_read, server_write) = std::io::pipe().expect("worker pipe");
+        let server = ServerIpcConnection::new(
+            IpcTransport {
+                reader: Box::new(server_read),
+                writer: Box::new(server_write),
+            },
+            IpcHandlers::default(),
+        )
+        .expect("server connection");
+
+        writeln!(
+            worker_write,
+            "{}",
+            json!({
+                "type": "backend_info",
+                "language": "r",
+                "supports_images": true
+            })
+        )
+        .expect("invalid worker message");
+
+        let result = server.wait_for_backend_info(Duration::from_millis(200));
+
+        assert!(
+            matches!(result, Err(super::IpcWaitError::Disconnected)),
+            "invalid worker message should disconnect server IPC, got: {result:?}"
+        );
     }
 
     #[test]

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -3,7 +3,7 @@
     allow(dead_code)
 )]
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 #[cfg(target_family = "windows")]
 use std::ffi::c_void;
 #[cfg(any(target_family = "unix", target_family = "windows"))]
@@ -16,9 +16,8 @@ use std::os::windows::ffi::OsStrExt;
 #[cfg(target_family = "windows")]
 use std::os::windows::io::{AsRawHandle, FromRawHandle};
 #[cfg(target_family = "unix")]
-use std::sync::atomic::{AtomicBool, AtomicI32, Ordering as AtomicOrdering};
-#[cfg(target_family = "windows")]
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32};
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -73,6 +72,7 @@ static WORKER_IPC_ALLOWED: AtomicBool = AtomicBool::new(true);
 static WORKER_IPC_FORK_CLOSE_READ_FD: AtomicI32 = AtomicI32::new(-1);
 #[cfg(target_family = "unix")]
 static WORKER_IPC_FORK_CLOSE_WRITE_FD: AtomicI32 = AtomicI32::new(-1);
+static NEXT_SERVER_IMAGE_ID: AtomicU64 = AtomicU64::new(0);
 #[cfg(target_family = "unix")]
 static WORKER_IPC_ATFORK_REGISTER_RESULT: OnceLock<i32> = OnceLock::new();
 
@@ -93,6 +93,7 @@ pub enum WorkerToServerIpcMessage {
     },
     ReadlineStart {
         prompt: String,
+        client_waiting: bool,
     },
     ReadlineResult {
         prompt: String,
@@ -102,6 +103,8 @@ pub enum WorkerToServerIpcMessage {
         mime_type: String,
         data: String,
         is_update: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
     },
     SessionEnd,
 }
@@ -115,9 +118,10 @@ struct ServerIpcInbox {
     readline_result_count: u64,
     readline_unmatched_starts: usize,
     readline_unmatched_since: Option<Instant>,
-    next_image_id: u64,
     current_image_id: Option<String>,
     request_image_id: Option<String>,
+    plot_source_image_ids: HashMap<String, String>,
+    request_plot_source_image_ids: HashMap<String, String>,
     protocol_warnings: VecDeque<String>,
     session_end: bool,
     disconnected: bool,
@@ -229,13 +233,18 @@ impl ServerIpcConnection {
                 }
                 if let Ok(message) = serde_json::from_str::<WorkerToServerIpcMessage>(trimmed) {
                     match message {
-                        WorkerToServerIpcMessage::ReadlineStart { prompt } => {
+                        WorkerToServerIpcMessage::ReadlineStart {
+                            prompt,
+                            client_waiting,
+                        } => {
                             let prompt_for_handler = prompt.clone();
                             let mut guard = reader_inbox.lock().unwrap();
-                            guard.readline_unmatched_starts =
-                                guard.readline_unmatched_starts.saturating_add(1);
-                            if guard.readline_unmatched_starts == 1 {
-                                guard.readline_unmatched_since = Some(Instant::now());
+                            if client_waiting {
+                                guard.readline_unmatched_starts =
+                                    guard.readline_unmatched_starts.saturating_add(1);
+                                if guard.readline_unmatched_starts == 1 {
+                                    guard.readline_unmatched_since = Some(Instant::now());
+                                }
                             }
                             if guard
                                 .prompt_history
@@ -289,28 +298,12 @@ impl ServerIpcConnection {
                             mime_type,
                             data,
                             is_update,
+                            source,
                         } => {
                             let (id, is_new, updates_previous_image, readline_results_seen) = {
                                 let mut guard = reader_inbox.lock().unwrap();
-                                let updates_previous_image = is_update
-                                    && guard.current_image_id.is_some()
-                                    && guard.request_image_id.is_none();
-                                let is_new = !is_update
-                                    || guard.current_image_id.is_none()
-                                    || updates_previous_image;
-                                let id = if is_new {
-                                    guard.next_image_id = guard.next_image_id.saturating_add(1);
-                                    let id = format!("image-{}", guard.next_image_id);
-                                    guard.request_image_id = Some(id.clone());
-                                    guard.current_image_id = Some(id.clone());
-                                    id
-                                } else {
-                                    guard
-                                        .request_image_id
-                                        .clone()
-                                        .or_else(|| guard.current_image_id.clone())
-                                        .expect("current image id must exist for updates")
-                                };
+                                let (id, is_new, updates_previous_image) =
+                                    assign_plot_image_id(&mut guard, source.as_deref(), is_update);
                                 (
                                     id,
                                     is_new,
@@ -333,6 +326,7 @@ impl ServerIpcConnection {
                                     mime_type,
                                     data,
                                     is_update,
+                                    source,
                                 });
                                 reader_cvar.notify_all();
                             }
@@ -410,6 +404,7 @@ impl ServerIpcConnection {
         stable_wait: Duration,
     ) -> Result<(), IpcWaitError> {
         let deadline = Instant::now() + timeout;
+        let allow_completion_settle_after_deadline = !timeout.is_zero();
         let mut guard = self.inbox.lock().unwrap();
         loop {
             if take_session_end(&mut guard) {
@@ -423,10 +418,21 @@ impl ServerIpcConnection {
             }
 
             let now = Instant::now();
-            if now >= deadline {
+            if now >= deadline
+                && !request_completion_observed_before_deadline(
+                    &guard,
+                    deadline,
+                    allow_completion_settle_after_deadline,
+                )
+            {
                 return Err(IpcWaitError::Timeout);
             }
-            let remaining = completion_wait_duration(&guard, deadline, stable_wait);
+            let remaining = completion_wait_duration(
+                &guard,
+                deadline,
+                stable_wait,
+                allow_completion_settle_after_deadline,
+            );
             let (next_guard, timeout_res) = self.cvar.wait_timeout(guard, remaining).unwrap();
             guard = next_guard;
             if timeout_res.timed_out() {
@@ -436,7 +442,13 @@ impl ServerIpcConnection {
                 if take_request_completion(&mut guard, stable_wait) {
                     return Ok(());
                 }
-                if Instant::now() >= deadline {
+                if Instant::now() >= deadline
+                    && !request_completion_observed_before_deadline(
+                        &guard,
+                        deadline,
+                        allow_completion_settle_after_deadline,
+                    )
+                {
                     return Err(IpcWaitError::Timeout);
                 }
             }
@@ -831,7 +843,7 @@ fn random_pipe_suffix() -> io::Result<String> {
 
 #[cfg(target_family = "windows")]
 fn next_pipe_name() -> io::Result<String> {
-    let nonce = PIPE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nonce = PIPE_COUNTER.fetch_add(1, AtomicOrdering::Relaxed);
     let random = random_pipe_suffix()?;
     Ok(format!(
         r"\\.\pipe\mcp-repl-ipc-{}-{nonce}-{random}",
@@ -1303,10 +1315,11 @@ fn register_worker_ipc_fork_contract(read_fd: RawFd, write_fd: RawFd) -> io::Res
     Ok(())
 }
 
-pub fn emit_readline_start(prompt: &str) {
+pub fn emit_readline_start(prompt: &str, client_waiting: bool) {
     if let Some(ipc) = global_ipc() {
         let _ = ipc.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: prompt.to_string(),
+            client_waiting,
         });
     }
 }
@@ -1320,12 +1333,13 @@ pub fn emit_readline_result(prompt: &str, line: &str) {
     }
 }
 
-pub fn emit_plot_image(mime_type: &str, data: &str, is_update: bool) {
+pub fn emit_plot_image(mime_type: &str, data: &str, is_update: bool, source: Option<&str>) {
     if let Some(ipc) = global_ipc() {
         let _ = ipc.send(WorkerToServerIpcMessage::PlotImage {
             mime_type: mime_type.to_string(),
             data: data.to_string(),
             is_update,
+            source: source.map(ToString::to_string),
         });
     }
 }
@@ -1390,10 +1404,23 @@ fn take_request_completion(guard: &mut ServerIpcInbox, stable_wait: Duration) ->
     true
 }
 
+fn request_completion_observed_before_deadline(
+    guard: &ServerIpcInbox,
+    deadline: Instant,
+    allow_completion_settle_after_deadline: bool,
+) -> bool {
+    allow_completion_settle_after_deadline
+        && guard.readline_unmatched_starts > 0
+        && guard
+            .readline_unmatched_since
+            .is_some_and(|since| since <= deadline)
+}
+
 fn completion_wait_duration(
     guard: &ServerIpcInbox,
     deadline: Instant,
     stable_wait: Duration,
+    allow_completion_settle_after_deadline: bool,
 ) -> Duration {
     let now = Instant::now();
     let until_deadline = deadline.saturating_duration_since(now);
@@ -1403,9 +1430,59 @@ fn completion_wait_duration(
     let elapsed = since.elapsed();
     if elapsed >= stable_wait {
         Duration::from_millis(0)
+    } else if allow_completion_settle_after_deadline && since <= deadline {
+        stable_wait.saturating_sub(elapsed)
     } else {
         until_deadline.min(stable_wait.saturating_sub(elapsed))
     }
+}
+
+fn allocate_plot_image_id() -> String {
+    let id = NEXT_SERVER_IMAGE_ID
+        .fetch_add(1, AtomicOrdering::Relaxed)
+        .saturating_add(1);
+    format!("image-{id}")
+}
+
+fn assign_plot_image_id(
+    guard: &mut ServerIpcInbox,
+    source: Option<&str>,
+    is_update: bool,
+) -> (String, bool, bool) {
+    if let Some(source) = source {
+        if is_update && let Some(id) = guard.request_plot_source_image_ids.get(source) {
+            guard.current_image_id = Some(id.clone());
+            return (id.clone(), false, false);
+        }
+
+        let updates_previous_image = is_update && guard.plot_source_image_ids.contains_key(source);
+        let id = allocate_plot_image_id();
+        guard
+            .plot_source_image_ids
+            .insert(source.to_string(), id.clone());
+        guard
+            .request_plot_source_image_ids
+            .insert(source.to_string(), id.clone());
+        guard.current_image_id = Some(id.clone());
+        return (id, true, updates_previous_image);
+    }
+
+    let updates_previous_image =
+        is_update && guard.current_image_id.is_some() && guard.request_image_id.is_none();
+    let is_new = !is_update || guard.current_image_id.is_none() || updates_previous_image;
+    let id = if is_new {
+        let id = allocate_plot_image_id();
+        guard.request_image_id = Some(id.clone());
+        guard.current_image_id = Some(id.clone());
+        id
+    } else {
+        guard
+            .request_image_id
+            .clone()
+            .or_else(|| guard.current_image_id.clone())
+            .expect("current image id must exist for updates")
+    };
+    (id, is_new, updates_previous_image)
 }
 
 fn reset_request_progress(guard: &mut ServerIpcInbox) {
@@ -1417,6 +1494,7 @@ fn reset_request_progress(guard: &mut ServerIpcInbox) {
 fn reset_after_completed_request(guard: &mut ServerIpcInbox) {
     reset_request_progress(guard);
     guard.request_image_id = None;
+    guard.request_plot_source_image_ids.clear();
     guard.last_prompt = None;
 }
 
@@ -1560,6 +1638,62 @@ mod protocol_tests {
         assert!(!images[1].is_new);
         assert_eq!(images[0].data, "first");
         assert_eq!(images[1].data, "second");
+    }
+
+    #[test]
+    fn plot_image_ids_do_not_repeat_across_server_connections() {
+        fn next_connection_image_id() -> String {
+            let (server_read, worker_write) = std::io::pipe().expect("server pipe");
+            let (worker_read, server_write) = std::io::pipe().expect("worker pipe");
+            let images = Arc::new(Mutex::new(Vec::new()));
+            let handler_images = images.clone();
+            let _server = ServerIpcConnection::new(
+                IpcTransport {
+                    reader: Box::new(server_read),
+                    writer: Box::new(server_write),
+                },
+                IpcHandlers {
+                    on_plot_image: Some(Arc::new(move |image| {
+                        handler_images.lock().expect("image mutex").push(image);
+                    })),
+                    ..IpcHandlers::default()
+                },
+            )
+            .expect("server connection");
+            let worker = WorkerIpcConnection::new(IpcTransport {
+                reader: Box::new(worker_read),
+                writer: Box::new(worker_write),
+            })
+            .expect("worker connection");
+            let image = json!({
+                "type": "plot_image",
+                "mime_type": "image/png",
+                "data": "image",
+                "is_update": false
+            })
+            .to_string();
+
+            worker
+                .send(serde_json::from_str(&image).expect("image message"))
+                .expect("send image");
+
+            let deadline = Instant::now() + Duration::from_millis(200);
+            while Instant::now() < deadline {
+                if let Some(image) = images.lock().expect("image mutex").first() {
+                    return image.id.clone();
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            panic!("timed out waiting for image");
+        }
+
+        let first = next_connection_image_id();
+        let second = next_connection_image_id();
+
+        assert_ne!(
+            first, second,
+            "server-generated image IDs must stay unique across worker IPC connections"
+        );
     }
 }
 

--- a/src/output_capture.rs
+++ b/src/output_capture.rs
@@ -112,6 +112,17 @@ impl OutputTimeline {
         self.ring
             .append_image_event(id, mime_type, data, is_new, readline_results_seen);
     }
+
+    pub(crate) fn append_text_event(
+        &self,
+        text: String,
+        is_stderr: bool,
+        origin: ContentOrigin,
+        readline_results_seen: Option<usize>,
+    ) {
+        self.ring
+            .append_text_event(text, is_stderr, origin, readline_results_seen);
+    }
 }
 
 #[derive(Clone, Default)]
@@ -283,6 +294,7 @@ pub(crate) enum OutputEventKind {
         text: String,
         is_stderr: bool,
         origin: ContentOrigin,
+        readline_results_seen: Option<usize>,
     },
 }
 
@@ -411,6 +423,38 @@ impl OutputRing {
             data,
             mime_type,
             is_new,
+            readline_results_seen,
+        };
+        let event_bytes = event_size_bytes(&kind);
+        if event_bytes > self.capacity_bytes {
+            return;
+        }
+
+        let dropped = guard.make_room_for(event_bytes, self.capacity_bytes);
+        let mut event_offset = guard.end_offset.max(guard.start_offset);
+        if dropped.dropped_any() {
+            self.append_truncation_notice_locked(&mut guard, event_offset, event_bytes);
+            event_offset = event_offset.max(guard.start_offset);
+        }
+        guard.buffered_event_bytes = guard.buffered_event_bytes.saturating_add(event_bytes);
+        guard.events.push_back(OutputEvent {
+            offset: event_offset,
+            kind,
+        });
+    }
+
+    pub(crate) fn append_text_event(
+        &self,
+        text: String,
+        is_stderr: bool,
+        origin: ContentOrigin,
+        readline_results_seen: Option<usize>,
+    ) {
+        let mut guard = self.inner.lock().unwrap();
+        let kind = OutputEventKind::Text {
+            text,
+            is_stderr,
+            origin,
             readline_results_seen,
         };
         let event_bytes = event_size_bytes(&kind);
@@ -596,6 +640,7 @@ impl OutputRing {
             text: "[repl] output truncated (older output dropped)\n".to_string(),
             is_stderr: false,
             origin: ContentOrigin::Server,
+            readline_results_seen: None,
         };
         let notice_bytes = event_size_bytes(&notice_kind);
         if notice_bytes.saturating_add(extra_bytes) > self.capacity_bytes {
@@ -920,6 +965,7 @@ mod tests {
                         text,
                         is_stderr: false,
                         origin: ContentOrigin::Worker,
+                        readline_results_seen: None,
                     },
                 );
             }

--- a/src/output_timeline.rs
+++ b/src/output_timeline.rs
@@ -40,7 +40,18 @@ pub(crate) fn collapse_echo_with_attribution(
     let bytes = range.bytes;
     let text_spans = range.text_spans;
 
-    let mut anchored_images: BTreeMap<usize, Vec<OutputEventKind>> = BTreeMap::new();
+    let mut anchored_events: BTreeMap<usize, Vec<OutputEventKind>> = BTreeMap::new();
+    let saw_event_output = Cell::new(false);
+    let anchor_idx_for_readline_count = |readline_results_seen: usize| {
+        if echo_event_base > 0 && readline_results_seen <= echo_event_base {
+            // If the matching echo was drained earlier, anchor before the
+            // first remaining echo when there is one. Otherwise keep the event
+            // at its rendered offset in the current snapshot.
+            return (!echo_events.is_empty()).then_some(0);
+        }
+        let anchor_idx = readline_results_seen.saturating_sub(echo_event_base);
+        (!echo_events.is_empty() && anchor_idx <= echo_events.len()).then_some(anchor_idx)
+    };
 
     let mut events: Vec<(usize, OutputEventKind)> = range
         .events
@@ -50,35 +61,42 @@ pub(crate) fn collapse_echo_with_attribution(
                 return None;
             }
             let rel = event.offset.saturating_sub(base_offset) as usize;
-            match event.kind {
+            let anchor_idx = match &event.kind {
                 OutputEventKind::Image {
                     readline_results_seen,
                     ..
-                } if (echo_event_base > 0 && readline_results_seen <= echo_event_base)
-                    || readline_results_seen.saturating_sub(echo_event_base)
-                        < echo_events.len() =>
-                {
-                    let anchor_idx = readline_results_seen.saturating_sub(echo_event_base);
-                    anchored_images
-                        .entry(anchor_idx)
-                        .or_default()
-                        .push(event.kind);
-                    None
-                }
-                kind => Some((rel.min(bytes.len()), kind)),
+                } => anchor_idx_for_readline_count(*readline_results_seen),
+                OutputEventKind::Text {
+                    readline_results_seen: Some(readline_results_seen),
+                    ..
+                } => anchor_idx_for_readline_count(*readline_results_seen),
+                OutputEventKind::Text {
+                    readline_results_seen: None,
+                    ..
+                } => None,
+            };
+            if let Some(anchor_idx) = anchor_idx {
+                anchored_events
+                    .entry(anchor_idx)
+                    .or_default()
+                    .push(event.kind);
+                None
+            } else {
+                Some((rel.min(bytes.len()), event.kind))
             }
         })
         .collect();
     events.sort_by_key(|(offset, _)| *offset);
 
-    let flush_anchored_images =
+    let flush_anchored_events =
         |anchor_idx: usize,
-         anchored_images: &mut BTreeMap<usize, Vec<OutputEventKind>>,
+         anchored_events: &mut BTreeMap<usize, Vec<OutputEventKind>>,
          out_bytes: &Vec<u8>,
          out_events: &mut Vec<(u64, OutputEventKind)>| {
-            if let Some(images) = anchored_images.remove(&anchor_idx) {
-                for image in images {
-                    out_events.push((out_bytes.len() as u64, image));
+            if let Some(events) = anchored_events.remove(&anchor_idx) {
+                for event in events {
+                    saw_event_output.set(true);
+                    out_events.push((out_bytes.len() as u64, event));
                 }
             }
         };
@@ -121,12 +139,19 @@ pub(crate) fn collapse_echo_with_attribution(
     };
 
     let discard_pending_for_event = |pending: &mut PendingEchoRun| {
+        saw_event_output.set(true);
         if pending.is_empty() {
             saw_substantive_output.set(true);
             return;
         }
         pending.take();
         saw_substantive_output.set(true);
+    };
+    let discard_pending_for_ordered_event = |pending: &mut PendingEchoRun| {
+        saw_event_output.set(true);
+        if !pending.is_empty() {
+            pending.take();
+        }
     };
 
     let mut cursor = 0usize;
@@ -144,19 +169,25 @@ pub(crate) fn collapse_echo_with_attribution(
                 &saw_substantive_output,
                 mode,
                 &mut flush_pending,
-                &mut anchored_images,
+                &mut anchored_events,
                 &mut out_bytes,
                 &mut out_text_spans,
                 &mut out_events,
-                &flush_anchored_images,
+                &flush_anchored_events,
             );
             cursor = event_offset;
         }
 
         match &kind {
-            OutputEventKind::Text { .. } => {
+            OutputEventKind::Text {
+                readline_results_seen: None,
+                ..
+            } => {
                 saw_substantive_output.set(true);
                 flush_pending(&mut out_bytes, &mut out_text_spans, &mut pending);
+            }
+            kind if event_has_readline_ordering(kind) => {
+                discard_pending_for_ordered_event(&mut pending);
             }
             _ => discard_pending_for_event(&mut pending),
         }
@@ -175,18 +206,19 @@ pub(crate) fn collapse_echo_with_attribution(
             &saw_substantive_output,
             mode,
             &mut flush_pending,
-            &mut anchored_images,
+            &mut anchored_events,
             &mut out_bytes,
             &mut out_text_spans,
             &mut out_events,
-            &flush_anchored_images,
+            &flush_anchored_events,
         );
     }
 
-    while let Some((_, images)) = anchored_images.pop_first() {
-        discard_pending_for_event(&mut pending);
-        for image in images {
-            out_events.push((out_bytes.len() as u64, image));
+    while let Some((_, events)) = anchored_events.pop_first() {
+        discard_pending_for_ordered_event(&mut pending);
+        for event in events {
+            saw_event_output.set(true);
+            out_events.push((out_bytes.len() as u64, event));
         }
     }
 
@@ -196,6 +228,7 @@ pub(crate) fn collapse_echo_with_attribution(
     if matches!(mode, EchoCollapseMode::Preserve)
         && !pending.is_empty()
         && !saw_substantive_output.get()
+        && !saw_event_output.get()
     {
         let pending = pending.take();
         append_text_with_span(
@@ -212,6 +245,17 @@ pub(crate) fn collapse_echo_with_attribution(
         events: out_events,
         text_spans: out_text_spans,
     }
+}
+
+fn event_has_readline_ordering(kind: &OutputEventKind) -> bool {
+    matches!(
+        kind,
+        OutputEventKind::Image { .. }
+            | OutputEventKind::Text {
+                readline_results_seen: Some(_),
+                ..
+            }
+    )
 }
 
 #[derive(Default)]
@@ -378,11 +422,11 @@ fn consume_text_segment_with_spans(
     saw_substantive_output: &Cell<bool>,
     mode: EchoCollapseMode,
     flush_pending: &mut impl FnMut(&mut Vec<u8>, &mut Vec<OutputTextSpan>, &mut PendingEchoRun),
-    anchored_images: &mut BTreeMap<usize, Vec<OutputEventKind>>,
+    anchored_events: &mut BTreeMap<usize, Vec<OutputEventKind>>,
     out_bytes: &mut Vec<u8>,
     out_text_spans: &mut Vec<OutputTextSpan>,
     out_events: &mut Vec<(u64, OutputEventKind)>,
-    flush_anchored_images: &impl Fn(
+    flush_anchored_events: &impl Fn(
         usize,
         &mut BTreeMap<usize, Vec<OutputEventKind>>,
         &Vec<u8>,
@@ -412,11 +456,11 @@ fn consume_text_segment_with_spans(
                 saw_substantive_output,
                 mode,
                 flush_pending,
-                anchored_images,
+                anchored_events,
                 out_bytes,
                 out_text_spans,
                 out_events,
-                flush_anchored_images,
+                flush_anchored_events,
             );
         }
         consume_text_segment(
@@ -430,11 +474,11 @@ fn consume_text_segment_with_spans(
             saw_substantive_output,
             mode,
             flush_pending,
-            anchored_images,
+            anchored_events,
             out_bytes,
             out_text_spans,
             out_events,
-            flush_anchored_images,
+            flush_anchored_events,
         );
         cursor = end;
     }
@@ -450,11 +494,11 @@ fn consume_text_segment_with_spans(
             saw_substantive_output,
             mode,
             flush_pending,
-            anchored_images,
+            anchored_events,
             out_bytes,
             out_text_spans,
             out_events,
-            flush_anchored_images,
+            flush_anchored_events,
         );
     }
 }
@@ -471,11 +515,11 @@ fn consume_text_segment(
     saw_substantive_output: &Cell<bool>,
     mode: EchoCollapseMode,
     flush_pending: &mut impl FnMut(&mut Vec<u8>, &mut Vec<OutputTextSpan>, &mut PendingEchoRun),
-    anchored_images: &mut BTreeMap<usize, Vec<OutputEventKind>>,
+    anchored_events: &mut BTreeMap<usize, Vec<OutputEventKind>>,
     out_bytes: &mut Vec<u8>,
     out_text_spans: &mut Vec<OutputTextSpan>,
     out_events: &mut Vec<(u64, OutputEventKind)>,
-    flush_anchored_images: &impl Fn(
+    flush_anchored_events: &impl Fn(
         usize,
         &mut BTreeMap<usize, Vec<OutputEventKind>>,
         &Vec<u8>,
@@ -500,7 +544,7 @@ fn consume_text_segment(
             None
         };
         if let Some(prefix_len) = echo_prefix {
-            flush_anchored_images(*echo_idx, anchored_images, out_bytes, out_events);
+            flush_anchored_events(*echo_idx, anchored_events, out_bytes, out_events);
             match mode {
                 EchoCollapseMode::Preserve | EchoCollapseMode::CollapseForFinalReply => {
                     if !saw_substantive_output.get() {
@@ -517,6 +561,7 @@ fn consume_text_segment(
                 }
             }
             *echo_idx = echo_idx.saturating_add(1);
+            flush_anchored_events(*echo_idx, anchored_events, out_bytes, out_events);
             if prefix_len == line.len() {
                 continue;
             }
@@ -795,6 +840,7 @@ mod tests {
                     text: "[repl] output truncated (older output dropped)\n".to_string(),
                     is_stderr: false,
                     origin: ContentOrigin::Server,
+                    readline_results_seen: None,
                 },
             }],
             text_spans: vec![OutputTextSpan {
@@ -824,6 +870,120 @@ mod tests {
             vec![
                 WorkerContent::stdout("> y500 <- 500\n"),
                 WorkerContent::server_stdout("[repl] output truncated (older output dropped)\n"),
+            ]
+        );
+    }
+
+    #[test]
+    fn event_after_final_echo_stays_before_later_output() {
+        let echo = b"> input(); plot(1:10); cat('done\\n')\n";
+        let output = b"done\n";
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(echo);
+        bytes.extend_from_slice(output);
+        let range = OutputRange {
+            start_offset: 0,
+            end_offset: bytes.len() as u64,
+            bytes,
+            events: vec![OutputEvent {
+                offset: echo.len() as u64,
+                kind: OutputEventKind::Image {
+                    data: "img".to_string(),
+                    mime_type: "image/png".to_string(),
+                    id: "plot-1".to_string(),
+                    is_new: true,
+                    readline_results_seen: 1,
+                },
+            }],
+            text_spans: vec![OutputTextSpan {
+                start_byte: 0,
+                end_byte: echo.len() + output.len(),
+                is_stderr: false,
+                origin: ContentOrigin::Worker,
+            }],
+        };
+
+        let collapsed = collapse_echo_with_attribution(
+            range,
+            &[echo_event("> ", "input(); plot(1:10); cat('done\\n')\n")],
+            0,
+            &["> ".to_string()],
+            EchoCollapseMode::CollapseForFinalReply,
+        );
+        let contents = pager::contents_from_collapsed_output(
+            collapsed.bytes,
+            collapsed.events,
+            collapsed.text_spans,
+            (echo.len() + output.len()) as u64,
+        );
+
+        assert_eq!(
+            contents,
+            vec![
+                WorkerContent::ContentImage {
+                    data: "img".to_string(),
+                    mime_type: "image/png".to_string(),
+                    id: "plot-1".to_string(),
+                    is_new: true,
+                },
+                WorkerContent::stdout("done\n"),
+            ]
+        );
+    }
+
+    #[test]
+    fn event_after_final_echo_anchors_before_later_output_when_raw_offset_is_late() {
+        let echo = b"> input(); plot(1:10); cat('done\\n')\n";
+        let output = b"done\n";
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(echo);
+        bytes.extend_from_slice(output);
+        let range = OutputRange {
+            start_offset: 0,
+            end_offset: bytes.len() as u64,
+            bytes,
+            events: vec![OutputEvent {
+                offset: (echo.len() + output.len()) as u64,
+                kind: OutputEventKind::Image {
+                    data: "img".to_string(),
+                    mime_type: "image/png".to_string(),
+                    id: "plot-1".to_string(),
+                    is_new: true,
+                    readline_results_seen: 1,
+                },
+            }],
+            text_spans: vec![OutputTextSpan {
+                start_byte: 0,
+                end_byte: echo.len() + output.len(),
+                is_stderr: false,
+                origin: ContentOrigin::Worker,
+            }],
+        };
+
+        let collapsed = collapse_echo_with_attribution(
+            range,
+            &[echo_event("> ", "input(); plot(1:10); cat('done\\n')\n")],
+            0,
+            &["> ".to_string()],
+            EchoCollapseMode::CollapseForFinalReply,
+        );
+        let contents = pager::contents_from_collapsed_output(
+            collapsed.bytes,
+            collapsed.events,
+            collapsed.text_spans,
+            (echo.len() + output.len()) as u64,
+        );
+
+        assert_eq!(
+            contents,
+            vec![
+                WorkerContent::ContentImage {
+                    data: "img".to_string(),
+                    mime_type: "image/png".to_string(),
+                    id: "plot-1".to_string(),
+                    is_new: true,
+                },
+                WorkerContent::stdout("done\n"),
             ]
         );
     }

--- a/src/output_timeline.rs
+++ b/src/output_timeline.rs
@@ -50,7 +50,7 @@ pub(crate) fn collapse_echo_with_attribution(
             return (!echo_events.is_empty()).then_some(0);
         }
         let anchor_idx = readline_results_seen.saturating_sub(echo_event_base);
-        (!echo_events.is_empty() && anchor_idx <= echo_events.len()).then_some(anchor_idx)
+        (!echo_events.is_empty() && anchor_idx < echo_events.len()).then_some(anchor_idx)
     };
 
     let mut events: Vec<(usize, OutputEventKind)> = range
@@ -561,7 +561,6 @@ fn consume_text_segment(
                 }
             }
             *echo_idx = echo_idx.saturating_add(1);
-            flush_anchored_events(*echo_idx, anchored_events, out_bytes, out_events);
             if prefix_len == line.len() {
                 continue;
             }
@@ -887,63 +886,6 @@ mod tests {
             bytes,
             events: vec![OutputEvent {
                 offset: echo.len() as u64,
-                kind: OutputEventKind::Image {
-                    data: "img".to_string(),
-                    mime_type: "image/png".to_string(),
-                    id: "plot-1".to_string(),
-                    is_new: true,
-                    readline_results_seen: 1,
-                },
-            }],
-            text_spans: vec![OutputTextSpan {
-                start_byte: 0,
-                end_byte: echo.len() + output.len(),
-                is_stderr: false,
-                origin: ContentOrigin::Worker,
-            }],
-        };
-
-        let collapsed = collapse_echo_with_attribution(
-            range,
-            &[echo_event("> ", "input(); plot(1:10); cat('done\\n')\n")],
-            0,
-            &["> ".to_string()],
-            EchoCollapseMode::CollapseForFinalReply,
-        );
-        let contents = pager::contents_from_collapsed_output(
-            collapsed.bytes,
-            collapsed.events,
-            collapsed.text_spans,
-            (echo.len() + output.len()) as u64,
-        );
-
-        assert_eq!(
-            contents,
-            vec![
-                WorkerContent::ContentImage {
-                    data: "img".to_string(),
-                    mime_type: "image/png".to_string(),
-                    id: "plot-1".to_string(),
-                    is_new: true,
-                },
-                WorkerContent::stdout("done\n"),
-            ]
-        );
-    }
-
-    #[test]
-    fn event_after_final_echo_anchors_before_later_output_when_raw_offset_is_late() {
-        let echo = b"> input(); plot(1:10); cat('done\\n')\n";
-        let output = b"done\n";
-        let mut bytes = Vec::new();
-        bytes.extend_from_slice(echo);
-        bytes.extend_from_slice(output);
-        let range = OutputRange {
-            start_offset: 0,
-            end_offset: bytes.len() as u64,
-            bytes,
-            events: vec![OutputEvent {
-                offset: (echo.len() + output.len()) as u64,
                 kind: OutputEventKind::Image {
                     data: "img".to_string(),
                     mime_type: "image/png".to_string(),

--- a/src/pager/mod.rs
+++ b/src/pager/mod.rs
@@ -1664,6 +1664,7 @@ fn output_event_to_content(kind: &OutputEventKind) -> WorkerContent {
             text,
             is_stderr,
             origin,
+            ..
         } => {
             if *is_stderr {
                 match origin {
@@ -3989,6 +3990,7 @@ mod tests {
                     text: "[repl] output truncated (older output dropped)\n".to_string(),
                     is_stderr: false,
                     origin: ContentOrigin::Server,
+                    readline_results_seen: None,
                 },
             )],
             vec![

--- a/src/pending_output_tape.rs
+++ b/src/pending_output_tape.rs
@@ -49,6 +49,13 @@ pub(crate) enum PendingOutputEvent {
         is_new: bool,
         readline_results_seen: usize,
     },
+    TextEvent {
+        seq: u64,
+        text: String,
+        is_stderr: bool,
+        origin: ContentOrigin,
+        readline_results_seen: Option<usize>,
+    },
     Sideband {
         seq: u64,
         kind: PendingSidebandKind,
@@ -60,6 +67,7 @@ impl PendingOutputEvent {
         match self {
             Self::TextFragment { seq, .. }
             | Self::Image { seq, .. }
+            | Self::TextEvent { seq, .. }
             | Self::Sideband { seq, .. } => *seq,
         }
     }
@@ -179,6 +187,30 @@ impl PendingOutputTape {
         );
     }
 
+    pub(crate) fn append_stdout_status_event(&self, text: String, readline_results_seen: usize) {
+        if text.is_empty() {
+            return;
+        }
+        let mut guard = self
+            .inner
+            .lock()
+            .expect("pending output tape mutex poisoned");
+        note_progress(&mut guard);
+        flush_tail(&mut guard, TextStream::Stdout, false);
+        flush_tail(&mut guard, TextStream::Stderr, false);
+        let seq = next_seq(&mut guard);
+        append_event(
+            &mut guard,
+            PendingOutputEvent::TextEvent {
+                seq,
+                text,
+                is_stderr: false,
+                origin: ContentOrigin::Server,
+                readline_results_seen: Some(readline_results_seen),
+            },
+        );
+    }
+
     pub(crate) fn append_image(
         &self,
         id: String,
@@ -228,7 +260,9 @@ impl PendingOutputTape {
         guard.events.iter().any(|event| {
             matches!(
                 event,
-                PendingOutputEvent::TextFragment { .. } | PendingOutputEvent::Image { .. }
+                PendingOutputEvent::TextFragment { .. }
+                    | PendingOutputEvent::Image { .. }
+                    | PendingOutputEvent::TextEvent { .. }
             )
         }) || tail_has_flushable_bytes(&guard.stdout_tail)
             || tail_has_flushable_bytes(&guard.stderr_tail)
@@ -480,6 +514,24 @@ impl PendingOutputSnapshot {
                     });
                     last_rendered_text = None;
                 }
+                PendingOutputEvent::TextEvent {
+                    text,
+                    is_stderr,
+                    origin,
+                    readline_results_seen,
+                    ..
+                } => {
+                    events.push(OutputEvent {
+                        offset: bytes.len() as u64,
+                        kind: OutputEventKind::Text {
+                            text: text.clone(),
+                            is_stderr: *is_stderr,
+                            origin: *origin,
+                            readline_results_seen: *readline_results_seen,
+                        },
+                    });
+                    last_rendered_text = None;
+                }
                 PendingOutputEvent::Sideband { kind, .. } => match kind {
                     PendingSidebandKind::ReadlineStart { prompt } => {
                         push_prompt_variant(&mut prompt_variants, prompt);
@@ -541,9 +593,13 @@ fn is_trim_eligible_carryover_prompt(prompt: &str) -> bool {
 }
 
 fn snapshot_has_no_visible_text(events: &[PendingOutputEvent]) -> bool {
-    events
-        .iter()
-        .all(|event| !matches!(event, PendingOutputEvent::TextFragment { bytes, .. } if !render_bytes(bytes).is_empty()))
+    events.iter().all(|event| {
+        !matches!(
+            event,
+            PendingOutputEvent::TextFragment { bytes, .. } if !render_bytes(bytes).is_empty()
+        ) && !matches!(event, PendingOutputEvent::TextEvent { text, .. } if !text.is_empty())
+            && !matches!(event, PendingOutputEvent::Image { .. })
+    })
 }
 
 fn snapshot_crossed_request_boundary(events: &[PendingOutputEvent]) -> bool {
@@ -577,7 +633,9 @@ fn leading_echo_match_progress(events: &[PendingOutputEvent], echo_prefix: &str)
         else {
             if matches!(
                 event,
-                PendingOutputEvent::Sideband { .. } | PendingOutputEvent::Image { .. }
+                PendingOutputEvent::Sideband { .. }
+                    | PendingOutputEvent::Image { .. }
+                    | PendingOutputEvent::TextEvent { .. }
             ) {
                 continue;
             }
@@ -916,7 +974,12 @@ fn append_event(inner: &mut PendingOutputTapeInner, event: PendingOutputEvent) {
 fn last_text_fragment_bytes(events: &VecDeque<PendingOutputEvent>) -> Option<&[u8]> {
     match events.back() {
         Some(PendingOutputEvent::TextFragment { bytes, .. }) => Some(bytes.as_slice()),
-        Some(PendingOutputEvent::Image { .. } | PendingOutputEvent::Sideband { .. }) | None => None,
+        Some(
+            PendingOutputEvent::Image { .. }
+            | PendingOutputEvent::TextEvent { .. }
+            | PendingOutputEvent::Sideband { .. },
+        )
+        | None => None,
     }
 }
 
@@ -941,7 +1004,7 @@ fn rendered_text_state_after<'a>(
                     });
                 }
             }
-            PendingOutputEvent::Image { .. } => state = None,
+            PendingOutputEvent::Image { .. } | PendingOutputEvent::TextEvent { .. } => state = None,
             PendingOutputEvent::Sideband { .. } => {}
         }
     }
@@ -1268,6 +1331,68 @@ mod tests {
         assert!(
             guard.pending_echo_prefix.is_empty(),
             "request boundary should clear unmatched carried echo"
+        );
+    }
+
+    #[test]
+    fn text_event_keeps_pending_echo_prefix_across_request_boundary() {
+        let tape = PendingOutputTape::new();
+        let status = "[repl] previous plot updated\n".to_string();
+
+        tape.append_sideband(PendingSidebandKind::ReadlineResult {
+            prompt: "> ".to_string(),
+            line: "plot(1:10)\n".to_string(),
+        });
+        tape.append_stdout_status_event(status.clone(), 1);
+        tape.append_sideband(PendingSidebandKind::RequestBoundary);
+
+        let first = tape.drain_snapshot();
+        assert_eq!(
+            first.format_contents().contents,
+            vec![WorkerContent::server_stdout(status)]
+        );
+
+        tape.append_stdout_bytes(b"> plot(1:10)\n");
+        let second = tape.drain_snapshot();
+        assert!(
+            second.format_contents().contents.is_empty(),
+            "expected late echo to be trimmed after visible status event"
+        );
+    }
+
+    #[test]
+    fn image_event_keeps_pending_echo_prefix_across_request_boundary() {
+        let tape = PendingOutputTape::new();
+
+        tape.append_sideband(PendingSidebandKind::ReadlineResult {
+            prompt: "> ".to_string(),
+            line: "plot(1:10)\n".to_string(),
+        });
+        tape.append_image(
+            "img-1".to_string(),
+            "image/png".to_string(),
+            "AA==".to_string(),
+            true,
+            1,
+        );
+        tape.append_sideband(PendingSidebandKind::RequestBoundary);
+
+        let first = tape.drain_snapshot();
+        assert_eq!(
+            first.format_contents().contents,
+            vec![WorkerContent::ContentImage {
+                data: "AA==".to_string(),
+                mime_type: "image/png".to_string(),
+                id: "img-1".to_string(),
+                is_new: true,
+            }]
+        );
+
+        tape.append_stdout_bytes(b"> plot(1:10)\n");
+        let second = tape.drain_snapshot();
+        assert!(
+            second.format_contents().contents.is_empty(),
+            "expected late echo to be trimmed after image event"
         );
     }
 

--- a/src/pending_output_tape.rs
+++ b/src/pending_output_tape.rs
@@ -69,7 +69,7 @@ impl PendingOutputEvent {
 pub(crate) enum PendingSidebandKind {
     ReadlineStart { prompt: String },
     ReadlineResult { prompt: String, line: String },
-    RequestEnd,
+    RequestBoundary,
     SessionEnd,
 }
 
@@ -491,7 +491,7 @@ impl PendingOutputSnapshot {
                             line: line.clone(),
                         });
                     }
-                    PendingSidebandKind::RequestEnd | PendingSidebandKind::SessionEnd => {}
+                    PendingSidebandKind::RequestBoundary | PendingSidebandKind::SessionEnd => {}
                 },
             }
         }
@@ -551,7 +551,7 @@ fn snapshot_crossed_request_boundary(events: &[PendingOutputEvent]) -> bool {
         matches!(
             event,
             PendingOutputEvent::Sideband {
-                kind: PendingSidebandKind::RequestEnd | PendingSidebandKind::SessionEnd,
+                kind: PendingSidebandKind::RequestBoundary | PendingSidebandKind::SessionEnd,
                 ..
             }
         )
@@ -1163,7 +1163,7 @@ mod tests {
         let tape = PendingOutputTape::new();
 
         tape.append_stdout_bytes(&[0xC3]);
-        tape.append_sideband(PendingSidebandKind::RequestEnd);
+        tape.append_sideband(PendingSidebandKind::RequestBoundary);
         let first = tape.drain_snapshot();
         assert!(
             first.format_contents().contents.is_empty(),
@@ -1183,7 +1183,7 @@ mod tests {
         let tape = PendingOutputTape::new();
 
         tape.append_stdout_bytes(&[0xC3]);
-        tape.append_sideband(PendingSidebandKind::RequestEnd);
+        tape.append_sideband(PendingSidebandKind::RequestBoundary);
         let first = tape.drain_final_snapshot();
         assert!(
             first.format_contents().contents.is_empty(),
@@ -1246,14 +1246,14 @@ mod tests {
     }
 
     #[test]
-    fn request_end_clears_pending_echo_prefix_after_sideband_only_snapshot() {
+    fn request_boundary_clears_pending_echo_prefix_after_sideband_only_snapshot() {
         let tape = PendingOutputTape::new();
 
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "> ".to_string(),
             line: "x <- 1\n".to_string(),
         });
-        tape.append_sideband(PendingSidebandKind::RequestEnd);
+        tape.append_sideband(PendingSidebandKind::RequestBoundary);
 
         let first = tape.drain_snapshot();
         assert!(

--- a/src/r_session.rs
+++ b/src/r_session.rs
@@ -789,9 +789,6 @@ fn complete_active_request(
     emit_session_end: bool,
 ) {
     if let Some(active) = active {
-        // Keep the request boundary coupled to the same R-thread decision that
-        // drained the final queued input line.
-        ipc::emit_request_end();
         let _ = active.reply.send(RequestCompleted);
         state.cvar.notify_all();
     }
@@ -1005,7 +1002,7 @@ pub(crate) fn push_plot_image(
         mime_type
     };
     let data = STANDARD.encode(bytes);
-    ipc::emit_plot_image(&plot_id, &mime_type, &data, is_new);
+    ipc::emit_plot_image(&mime_type, &data, !is_new);
 
     Ok(())
 }

--- a/src/r_session.rs
+++ b/src/r_session.rs
@@ -163,10 +163,15 @@ pub(crate) fn complete_active_request_if_idle() -> bool {
     if !guard.input_queue.is_empty() {
         return false;
     }
+    let prompt = guard
+        .last_prompt
+        .clone()
+        .unwrap_or_else(|| "> ".to_string());
     let active = guard.active_request.take();
     let had_active = active.is_some();
     drop(guard);
     if had_active {
+        ipc::emit_readline_start(&prompt, true);
         complete_active_request(state, active, false);
     }
     had_active
@@ -218,6 +223,7 @@ struct SessionState {
 struct SessionStateInner {
     input_queue: VecDeque<String>,
     active_request: Option<ActiveRequest>,
+    last_prompt: Option<String>,
     shutdown: bool,
     session_end_emitted: bool,
 }
@@ -233,6 +239,7 @@ impl SessionState {
             inner: Mutex::new(SessionStateInner {
                 input_queue: VecDeque::new(),
                 active_request: None,
+                last_prompt: None,
                 shutdown: false,
                 session_end_emitted: false,
             }),
@@ -882,6 +889,10 @@ pub extern "C-unwind" fn r_read_console(
         .map(|text| text.to_ascii_lowercase().contains("save workspace image"))
         .unwrap_or(false);
     let state = session_state();
+    {
+        let mut guard = state.inner.lock().unwrap();
+        guard.last_prompt = Some(prompt.to_string());
+    }
 
     loop {
         let mut guard = state.inner.lock().unwrap();

--- a/src/r_session.rs
+++ b/src/r_session.rs
@@ -874,7 +874,9 @@ pub extern "C-unwind" fn r_read_console(
                 .to_string(),
         )
     };
-    ipc::emit_readline_start(prompt_text.as_deref().unwrap_or(""));
+    let prompt = prompt_text.as_deref().unwrap_or("");
+    ipc::emit_readline_start(prompt, false);
+    let mut client_waiting_start_emitted = false;
     let is_save_prompt = prompt_text
         .as_deref()
         .map(|text| text.to_ascii_lowercase().contains("save workspace image"))
@@ -942,7 +944,6 @@ pub extern "C-unwind" fn r_read_console(
             }
             drop(guard);
 
-            let prompt = prompt_text.as_deref().unwrap_or("");
             let line_text = String::from_utf8_lossy(head).to_string();
             let mut echoed = String::with_capacity(prompt.len() + line_text.len());
             echoed.push_str(prompt);
@@ -960,6 +961,11 @@ pub extern "C-unwind" fn r_read_console(
             }
 
             return 1;
+        }
+
+        if !client_waiting_start_emitted && guard.active_request.is_some() {
+            ipc::emit_readline_start(prompt, true);
+            client_waiting_start_emitted = true;
         }
 
         if let Some(active) = guard.active_request.take() {
@@ -1002,7 +1008,7 @@ pub(crate) fn push_plot_image(
         mime_type
     };
     let data = STANDARD.encode(bytes);
-    ipc::emit_plot_image(&mime_type, &data, !is_new);
+    ipc::emit_plot_image(&mime_type, &data, !is_new, Some(&plot_id));
 
     Ok(())
 }

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -683,33 +683,27 @@ impl ResponseState {
         mut active: ActiveOutputBundle,
         spill_worker_text_chars: usize,
     ) -> FollowUpDetachedPrefix {
-        let contents = if material.detached_prefix_items.is_empty() {
-            Vec::new()
-        } else {
-            match render_active_bundle_contents(
-                &mut self.output_store,
-                &mut active,
-                &material.detached_prefix_items,
-                &material.detached_prefix_inline_items,
-                spill_worker_text_chars,
-            ) {
-                Ok(contents) => contents,
-                Err(err) => {
-                    eprintln!("dropping timeout bundle content after output-bundle error: {err}");
-                    let protected_bundle_id = active.was_disclosed().then_some(active.id);
-                    if let Err(err) = self.finish_bundle(active) {
-                        eprintln!(
-                            "dropping closed timeout bundle after output-bundle error: {err}"
-                        );
-                    }
-                    return FollowUpDetachedPrefix {
-                        contents: compact_detached_prefix_without_output_bundle(material),
-                        protected_bundle_id,
-                        retained_active_timeout_bundle: None,
-                        retained_staged_timeout_output: None,
-                        retained_bundle_is_detached_prefix_only: false,
-                    };
+        let contents = match render_active_bundle_contents(
+            &mut self.output_store,
+            &mut active,
+            &material.detached_prefix_items,
+            &material.detached_prefix_inline_items,
+            spill_worker_text_chars,
+        ) {
+            Ok(contents) => contents,
+            Err(err) => {
+                eprintln!("dropping timeout bundle content after output-bundle error: {err}");
+                let protected_bundle_id = active.was_disclosed().then_some(active.id);
+                if let Err(err) = self.finish_bundle(active) {
+                    eprintln!("dropping closed timeout bundle after output-bundle error: {err}");
                 }
+                return FollowUpDetachedPrefix {
+                    contents: compact_detached_prefix_without_output_bundle(material),
+                    protected_bundle_id,
+                    retained_active_timeout_bundle: None,
+                    retained_staged_timeout_output: None,
+                    retained_bundle_is_detached_prefix_only: false,
+                };
             }
         };
         let protected_bundle_id = active.was_disclosed().then_some(active.id);
@@ -2201,6 +2195,9 @@ fn render_active_bundle_contents(
             active,
             0,
         ))
+    } else if active.was_disclosed() && image_bundle_still_needed {
+        active.disclosed = true;
+        Ok(compact_output_bundle_items(inline_items, active))
     } else {
         Ok(materialize_items(inline_items.to_vec()))
     }

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -2195,9 +2195,6 @@ fn render_active_bundle_contents(
             active,
             0,
         ))
-    } else if active.was_disclosed() && image_bundle_still_needed {
-        active.disclosed = true;
-        Ok(compact_output_bundle_items(inline_items, active))
     } else {
         Ok(materialize_items(inline_items.to_vec()))
     }
@@ -3591,6 +3588,58 @@ mod tests {
         assert!(
             transcript.contains("TAIL\n"),
             "expected later small poll output to append to the existing timeout bundle, got: {transcript:?}"
+        );
+    }
+
+    #[test]
+    fn disclosed_timeout_image_bundle_follow_up_without_detached_prefix_does_not_replay() {
+        let mut state = ResponseState::new().expect("response state should initialize");
+        let mut bundle = state
+            .output_store
+            .new_bundle()
+            .expect("timeout bundle should initialize");
+        for index in 0..super::IMAGE_OUTPUT_BUNDLE_THRESHOLD {
+            let image = ReplyImage {
+                id: format!("image-{index}"),
+                data: base64::engine::general_purpose::STANDARD.encode([index as u8]),
+                mime_type: "image/png".to_string(),
+            };
+            let retained = bundle
+                .append_image(&mut state.output_store, &image)
+                .expect("timeout image should append");
+            assert!(matches!(retained, Some(ReplyItem::Image(_))));
+        }
+        bundle.disclosed = true;
+        state.active_timeout_bundle = Some(bundle);
+
+        let result = state.finalize_worker_result(
+            Ok(worker_reply(
+                vec![WorkerContent::worker_stdout("FOLLOW_UP_OK\n")],
+                None,
+            )),
+            false,
+            TimeoutBundleReuse::FollowUpInput,
+            0,
+        );
+
+        let text = result_text(&result);
+        let images = result_images(&result);
+
+        assert!(
+            text.contains("FOLLOW_UP_OK\n"),
+            "expected fresh follow-up reply inline, got: {text:?}"
+        );
+        assert!(
+            !text.contains("output bundle images"),
+            "did not expect stale timeout bundle notice in fresh follow-up reply: {text:?}"
+        );
+        assert!(
+            images.is_empty(),
+            "did not expect stale timeout bundle anchor images in fresh follow-up reply"
+        );
+        assert!(
+            !state.has_active_timeout_bundle(),
+            "expected completed follow-up to retire the old timeout bundle"
         );
     }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -164,7 +164,6 @@ fn init_ipc(state: Arc<WorkerState>) -> Result<(), Box<dyn std::error::Error>> {
             loop {
                 match conn.recv(None) {
                     Some(ServerToWorkerIpcMessage::StdinWrite { .. }) => {}
-                    Some(ServerToWorkerIpcMessage::PlotImageAck { .. }) => {}
                     Some(ServerToWorkerIpcMessage::Interrupt) => {
                         crate::r_session::clear_pending_input();
                     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -164,6 +164,7 @@ fn init_ipc(state: Arc<WorkerState>) -> Result<(), Box<dyn std::error::Error>> {
             loop {
                 match conn.recv(None) {
                     Some(ServerToWorkerIpcMessage::StdinWrite { .. }) => {}
+                    Some(ServerToWorkerIpcMessage::PlotImageAck { .. }) => {}
                     Some(ServerToWorkerIpcMessage::Interrupt) => {
                         crate::r_session::clear_pending_input();
                     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use crate::input_protocol::parse_input_frame_header;
 use crate::ipc::{
-    ServerToWorkerIpcMessage, connect_from_env, emit_backend_info, emit_request_end, set_global_ipc,
+    ServerToWorkerIpcMessage, connect_from_env, emit_backend_info, emit_session_end, set_global_ipc,
 };
 use crate::r_session::RSession;
 use crate::worker_protocol::WORKER_MODE_ARG;
@@ -118,7 +118,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("worker ipc init error: {err}");
         err
     })?;
-    emit_backend_info("r", true);
+    emit_backend_info(true);
     let request_state = state.clone();
     let _request_thread = thread::Builder::new()
         .name("worker-requests".to_string())
@@ -240,7 +240,7 @@ fn request_loop(rx: mpsc::Receiver<QueuedRequest>, state: Arc<WorkerState>) {
         let result = write_stdin_request(request.text);
         if let Err(err) = result {
             emit_stderr_message(&err.message);
-            emit_request_end();
+            emit_session_end();
         }
         state.mark_idle();
     }
@@ -268,7 +268,7 @@ fn handle_write_stdin(
             }
         };
         emit_stderr_message(&message);
-        emit_request_end();
+        emit_session_end();
     }
 }
 

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -143,6 +143,9 @@ impl LiveOutputCapture {
     }
 
     fn append_image(&self, image: IpcPlotImage) {
+        if image.updates_previous_image {
+            self.append_server_stdout_status_line(PREVIOUS_IMAGE_UPDATE_NOTICE.as_bytes());
+        }
         self.output_timeline.append_image(
             image.id.clone(),
             image.mime_type.clone(),
@@ -158,6 +161,14 @@ impl LiveOutputCapture {
                 image.is_new,
                 image.readline_results_seen,
             );
+        }
+    }
+
+    fn append_server_stdout_status_line(&self, bytes: &[u8]) {
+        self.output_timeline
+            .append_text(bytes, false, ContentOrigin::Server);
+        if let Some(tape) = &self.pending_output_tape {
+            tape.append_stdout_status_line(bytes);
         }
     }
 
@@ -177,6 +188,8 @@ const WORKER_MEM_GUARDRAIL_IDLE_INTERVAL: Duration = Duration::from_secs(60);
 #[cfg(target_os = "linux")]
 const LINUX_BWRAP_FALLBACK_NOTICE: &str =
     "[repl] Linux bubblewrap sandbox unavailable; continuing without bwrap\n";
+const PREVIOUS_IMAGE_UPDATE_NOTICE: &str =
+    "[repl] image update from previous request shown as a new image\n";
 const PRECHECKED_FOLLOW_UP_REQUIRES_META_MESSAGE: &str =
     "worker follow-up needs current sandbox metadata after precheck";
 
@@ -200,6 +213,11 @@ fn prechecked_follow_up_requires_meta_error() -> WorkerError {
 trait BackendDriver: Send {
     fn prepare_input_payload(&self, text: &str) -> Vec<u8>;
     fn on_input_start(&mut self, text: &str, ipc: &ServerIpcConnection);
+    fn should_settle_output_after_timeout(
+        &self,
+        oversized_output: OversizedOutputMode,
+        pending_input: Option<&str>,
+    ) -> bool;
     fn wait_for_completion(
         &mut self,
         timeout: Duration,
@@ -225,7 +243,7 @@ fn driver_on_input_start(_text: &str, ipc: &ServerIpcConnection) {
     ipc.begin_request();
 }
 
-const REQUEST_END_FALLBACK_WAIT: Duration = Duration::from_millis(20);
+const REQUEST_COMPLETION_STABLE_WAIT: Duration = Duration::from_millis(20);
 fn driver_wait_for_completion(
     timeout: Duration,
     ipc: ServerIpcConnection,
@@ -233,36 +251,13 @@ fn driver_wait_for_completion(
     if timeout.is_zero() {
         return Err(WorkerError::Timeout(timeout));
     }
-    let start = std::time::Instant::now();
-    let deadline = start + timeout;
-    loop {
-        let now = std::time::Instant::now();
-        if now >= deadline {
-            return Err(WorkerError::Timeout(timeout));
-        }
-        let remaining = deadline.saturating_duration_since(now);
-        let slice = remaining.min(Duration::from_millis(50));
-        match ipc.wait_for_request_end(slice) {
-            Ok(()) => {
-                return Ok(completion_info_from_ipc(&ipc, false));
-            }
-            Err(IpcWaitError::Timeout) => {
-                if ipc.waiting_for_next_input(REQUEST_END_FALLBACK_WAIT)
-                    && ipc.try_take_request_end()
-                {
-                    return Ok(completion_info_from_ipc(&ipc, false));
-                }
-                continue;
-            }
-            Err(IpcWaitError::SessionEnd) => {
-                return Ok(completion_info_from_ipc(&ipc, true));
-            }
-            Err(IpcWaitError::Disconnected) => {
-                return Err(WorkerError::Protocol(
-                    "ipc disconnected while waiting for request completion".to_string(),
-                ));
-            }
-        }
+    match ipc.wait_for_request_completion(timeout, REQUEST_COMPLETION_STABLE_WAIT) {
+        Ok(()) => Ok(completion_info_from_ipc(&ipc, false)),
+        Err(IpcWaitError::Timeout) => Err(WorkerError::Timeout(timeout)),
+        Err(IpcWaitError::SessionEnd) => Ok(completion_info_from_ipc(&ipc, true)),
+        Err(IpcWaitError::Disconnected) => Err(WorkerError::Protocol(
+            "ipc disconnected while waiting for request completion".to_string(),
+        )),
     }
 }
 
@@ -314,6 +309,19 @@ impl BackendDriver for RBackendDriver {
         driver_on_input_start(text, ipc);
     }
 
+    fn should_settle_output_after_timeout(
+        &self,
+        oversized_output: OversizedOutputMode,
+        pending_input: Option<&str>,
+    ) -> bool {
+        if !matches!(oversized_output, OversizedOutputMode::Files) {
+            return false;
+        }
+        pending_input
+            .map(|input| input.trim_end_matches(['\r', '\n']).contains('\n'))
+            .unwrap_or(false)
+    }
+
     fn wait_for_completion(
         &mut self,
         timeout: Duration,
@@ -362,6 +370,14 @@ impl BackendDriver for PythonBackendDriver {
             // payloads on the control channel so interrupt/session-end messages stay responsive.
             text: String::new(),
         });
+    }
+
+    fn should_settle_output_after_timeout(
+        &self,
+        _oversized_output: OversizedOutputMode,
+        _pending_input: Option<&str>,
+    ) -> bool {
+        false
     }
 
     fn wait_for_completion(
@@ -2073,7 +2089,7 @@ impl WorkerManager {
                     }
                 }
 
-                if self.should_settle_multiline_r_timeout() {
+                if self.should_settle_output_after_timeout() {
                     self.settle_output_after_timeout();
                 }
                 self.pending_request = true;
@@ -2333,7 +2349,11 @@ impl WorkerManager {
         // drain any bytes already written by the worker before we snapshot the ring.
         let elapsed = start.elapsed();
         let remaining = timeout.saturating_sub(elapsed);
-        self.settle_output_after_request_end(remaining);
+        if result.is_ok() {
+            self.pending_output_tape
+                .append_sideband(PendingSidebandKind::RequestBoundary);
+        }
+        self.settle_output_after_completion(remaining);
         if self.guardrail_event_pending() {
             let event = self
                 .guardrail
@@ -2347,7 +2367,7 @@ impl WorkerManager {
         result
     }
 
-    fn settle_output_after_request_end(&self, budget: Duration) {
+    fn settle_output_after_completion(&self, budget: Duration) {
         let total = budget.min(Duration::from_millis(120));
         if total.is_zero() {
             return;
@@ -2388,16 +2408,11 @@ impl WorkerManager {
         }
     }
 
-    fn should_settle_multiline_r_timeout(&self) -> bool {
-        if self.backend != Backend::R
-            || !matches!(self.oversized_output, OversizedOutputMode::Files)
-        {
-            return false;
-        }
-        self.pending_request_input
-            .as_deref()
-            .map(|input| input.trim_end_matches(['\r', '\n']).contains('\n'))
-            .unwrap_or(false)
+    fn should_settle_output_after_timeout(&self) -> bool {
+        self.driver.should_settle_output_after_timeout(
+            self.oversized_output,
+            self.pending_request_input.as_deref(),
+        )
     }
 
     fn settle_output_until_stable(&self, total: Duration, stable_needed: Duration) {
@@ -3694,18 +3709,16 @@ impl WorkerManager {
             return;
         };
         let status = if wait.is_zero() {
-            if ipc.try_take_request_end() {
-                Ok(())
-            } else {
-                Err(IpcWaitError::Timeout)
-            }
+            ipc.wait_for_request_completion(Duration::ZERO, REQUEST_COMPLETION_STABLE_WAIT)
         } else {
-            ipc.wait_for_request_end(wait)
+            ipc.wait_for_request_completion(wait, REQUEST_COMPLETION_STABLE_WAIT)
         };
         match status {
             Ok(()) => {
                 let mut settled_completion = completion_info_from_ipc(&ipc, false);
-                self.settle_output_after_request_end(Duration::from_millis(120));
+                self.pending_output_tape
+                    .append_sideband(PendingSidebandKind::RequestBoundary);
+                self.settle_output_after_completion(Duration::from_millis(120));
                 if matches!(self.oversized_output, OversizedOutputMode::Pager) {
                     update_last_reply_marker_offset_max(self.output.end_offset().unwrap_or(0));
                 }
@@ -3726,8 +3739,7 @@ impl WorkerManager {
                 self.settled_pending_completion = Some(settled_completion);
             }
             Err(IpcWaitError::SessionEnd) => {
-                self.note_session_end(true);
-                self.clear_pending_request_state();
+                self.settle_pending_session_end(&ipc);
             }
             Err(IpcWaitError::Timeout | IpcWaitError::Disconnected) => {
                 let worker_exited = self
@@ -3736,11 +3748,20 @@ impl WorkerManager {
                     .and_then(|process| process.is_running().ok())
                     .is_some_and(|running| !running);
                 if worker_exited {
-                    self.note_session_end(true);
-                    self.clear_pending_request_state();
+                    self.settle_pending_session_end(&ipc);
                 }
             }
         }
+    }
+
+    fn settle_pending_session_end(&mut self, ipc: &ServerIpcConnection) {
+        let settled_completion = completion_info_from_ipc(ipc, true);
+        self.pending_output_tape
+            .append_sideband(PendingSidebandKind::RequestBoundary);
+        self.settle_output_after_completion(Duration::from_millis(120));
+        self.note_session_end(true);
+        self.clear_pending_request_state();
+        self.settled_pending_completion = Some(settled_completion);
     }
 
     fn clear_pending_request_state(&mut self) {
@@ -4982,12 +5003,6 @@ impl WorkerProcess {
                             prompt: event.prompt,
                             line: event.line,
                         });
-                    }))
-                },
-                on_request_end: {
-                    let sideband_capture = live_output.clone();
-                    Some(Arc::new(move || {
-                        sideband_capture.append_sideband(PendingSidebandKind::RequestEnd);
                     }))
                 },
                 on_session_end: {
@@ -6325,7 +6340,7 @@ mod tests {
 
     #[test]
     fn trim_echo_then_append_protocol_warnings_drops_echo_only_multiline_input() {
-        let warning = "ReadlineResult after RequestEnd".to_string();
+        let warning = "late readline result".to_string();
         let echo = "> x <- 1\n> y <- 2\n";
         let mut contents = vec![WorkerContent::stdout(echo)];
 
@@ -6345,7 +6360,7 @@ mod tests {
 
     #[test]
     fn trim_echo_then_append_protocol_warnings_keeps_output_before_warning() {
-        let warning = "ReadlineResult after RequestEnd".to_string();
+        let warning = "late readline result".to_string();
         let mut contents = vec![WorkerContent::stdout("> x <- 1\n[1] 1\n")];
 
         trim_echo_then_append_protocol_warnings(
@@ -6541,7 +6556,7 @@ mod tests {
     }
 
     #[test]
-    fn completion_waits_for_request_end_when_primary_prompt_reappears() {
+    fn completion_infers_nested_waiting_prompt_that_reuses_primary_prompt_text() {
         let (server, worker) = crate::ipc::test_connection_pair().expect("ipc pair");
         driver_on_input_start("value <- readline(prompt = \"> \")", &server);
         let prompt = "> ".to_string();
@@ -6556,15 +6571,8 @@ mod tests {
             prompt: prompt.clone(),
         });
 
-        let result = driver_wait_for_completion(Duration::from_millis(75), server.clone());
-        assert!(
-            matches!(result, Err(WorkerError::Timeout(_))),
-            "expected timeout before request-end when a nested prompt reuses the primary prompt text"
-        );
-
-        let _ = worker.send(WorkerToServerIpcMessage::RequestEnd);
         let completion = driver_wait_for_completion(Duration::from_millis(200), server)
-            .expect("expected completion after request-end");
+            .expect("expected stable waiting prompt to complete request");
         assert_eq!(completion.prompt.as_deref(), Some("> "));
         assert_eq!(completion.echo_events.len(), 1);
         assert_eq!(completion.echo_events[0].prompt, "> ");
@@ -6575,7 +6583,31 @@ mod tests {
     }
 
     #[test]
-    fn completion_still_waits_when_only_continuation_prompt_arrives() {
+    fn completion_infers_stable_waiting_prompt_without_worker_completion_event() {
+        let (server, worker) = crate::ipc::test_connection_pair().expect("ipc pair");
+        driver_on_input_start("1+1", &server);
+        let prompt = "> ".to_string();
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
+            prompt: prompt.clone(),
+        });
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineResult {
+            prompt: prompt.clone(),
+            line: "1+1\n".to_string(),
+        });
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
+            prompt: prompt.clone(),
+        });
+
+        let completion = driver_wait_for_completion(Duration::from_millis(200), server)
+            .expect("expected stable waiting prompt to complete request");
+
+        assert_eq!(completion.prompt.as_deref(), Some("> "));
+        assert_eq!(completion.echo_events.len(), 1);
+        assert_eq!(completion.echo_events[0].line, "1+1\n");
+    }
+
+    #[test]
+    fn completion_infers_stable_continuation_prompt_when_input_is_consumed() {
         let (server, worker) = crate::ipc::test_connection_pair().expect("ipc pair");
         driver_on_input_start("1+\n1", &server);
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
@@ -6589,15 +6621,8 @@ mod tests {
             prompt: "+ ".to_string(),
         });
 
-        let result = driver_wait_for_completion(Duration::from_millis(75), server.clone());
-        assert!(
-            matches!(result, Err(WorkerError::Timeout(_))),
-            "expected timeout before request-end when only a continuation prompt is visible"
-        );
-
-        let _ = worker.send(WorkerToServerIpcMessage::RequestEnd);
         let completion = driver_wait_for_completion(Duration::from_millis(200), server)
-            .expect("expected completion after request-end");
+            .expect("expected stable continuation prompt to complete request");
         assert_eq!(completion.prompt.as_deref(), Some("+ "));
     }
 
@@ -6623,11 +6648,13 @@ mod tests {
                 prompt: "+ ".to_string(),
                 line: "1\n".to_string(),
             });
-            let _ = delayed_worker.send(WorkerToServerIpcMessage::RequestEnd);
+            let _ = delayed_worker.send(WorkerToServerIpcMessage::ReadlineStart {
+                prompt: "> ".to_string(),
+            });
         });
 
         let completion = driver_wait_for_completion(Duration::from_millis(200), server)
-            .expect("expected completion after request-end");
+            .expect("expected completion after stable waiting prompt");
         late_sender.join().expect("late sender should join");
 
         assert_eq!(completion.prompt.as_deref(), Some("> "));
@@ -6640,44 +6667,10 @@ mod tests {
     }
 
     #[test]
-    fn completion_warns_when_readline_result_arrives_after_request_end() {
-        let (server, worker) = crate::ipc::test_connection_pair().expect("ipc pair");
-        driver_on_input_start("1+1", &server);
-
-        let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
-            prompt: "> ".to_string(),
-        });
-        let _ = worker.send(WorkerToServerIpcMessage::RequestEnd);
-
-        let delayed_worker = worker.clone();
-        let late_sender = thread::spawn(move || {
-            thread::sleep(Duration::from_millis(1));
-            let _ = delayed_worker.send(WorkerToServerIpcMessage::ReadlineResult {
-                prompt: "> ".to_string(),
-                line: "1+1\n".to_string(),
-            });
-        });
-
-        let completion = driver_wait_for_completion(Duration::from_millis(200), server)
-            .expect("expected completion after request-end");
-        late_sender.join().expect("late sender should join");
-
-        assert!(
-            completion
-                .protocol_warnings
-                .iter()
-                .any(|warning| warning.contains("ReadlineResult after RequestEnd")),
-            "expected protocol warning, got: {:?}",
-            completion.protocol_warnings
-        );
-    }
-
-    #[test]
     fn next_request_result_is_retained_when_prompt_is_already_active() {
         let (server, worker) = crate::ipc::test_connection_pair().expect("ipc pair");
 
         driver_on_input_start("first()", &server);
-        let _ = worker.send(WorkerToServerIpcMessage::RequestEnd);
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: "> ".to_string(),
         });
@@ -6690,7 +6683,9 @@ mod tests {
             prompt: "> ".to_string(),
             line: "second()\n".to_string(),
         });
-        let _ = worker.send(WorkerToServerIpcMessage::RequestEnd);
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
+            prompt: "> ".to_string(),
+        });
 
         let second = driver_wait_for_completion(Duration::from_millis(200), server)
             .expect("expected second completion");
@@ -6713,13 +6708,12 @@ mod tests {
             prompt: "> ".to_string(),
             line: "first()\n".to_string(),
         });
-        let _ = worker.send(WorkerToServerIpcMessage::RequestEnd);
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: "> ".to_string(),
         });
 
         let completion = driver_wait_for_completion(Duration::from_millis(200), server)
-            .expect("expected completion after request-end");
+            .expect("expected completion after stable waiting prompt");
 
         assert_eq!(completion.prompt.as_deref(), Some("> "));
         assert!(completion.protocol_warnings.is_empty());
@@ -6729,7 +6723,7 @@ mod tests {
     }
 
     #[test]
-    fn completion_retains_echo_events_when_session_ends_before_request_end() {
+    fn completion_retains_echo_events_when_session_ends_before_prompt_completion() {
         let (server, worker) = crate::ipc::test_connection_pair().expect("ipc pair");
         driver_on_input_start("quit()", &server);
 
@@ -6741,6 +6735,34 @@ mod tests {
             line: "quit()\n".to_string(),
         });
         let _ = worker.send(WorkerToServerIpcMessage::SessionEnd);
+
+        let completion = driver_wait_for_completion(Duration::from_millis(200), server)
+            .expect("expected completion after session end");
+
+        assert!(completion.session_end_seen);
+        assert_eq!(completion.echo_events.len(), 1);
+        assert_eq!(completion.echo_events[0].prompt, "> ");
+        assert_eq!(completion.echo_events[0].line, "quit()\n");
+    }
+
+    #[test]
+    fn completion_reports_session_end_when_prompt_is_also_stable() {
+        let (server, worker) = crate::ipc::test_connection_pair().expect("ipc pair");
+        driver_on_input_start("quit()", &server);
+
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
+            prompt: "> ".to_string(),
+        });
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineResult {
+            prompt: "> ".to_string(),
+            line: "quit()\n".to_string(),
+        });
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
+            prompt: "> ".to_string(),
+        });
+        thread::sleep(Duration::from_millis(25));
+        let _ = worker.send(WorkerToServerIpcMessage::SessionEnd);
+        thread::sleep(Duration::from_millis(25));
 
         let completion = driver_wait_for_completion(Duration::from_millis(200), server)
             .expect("expected completion after session end");
@@ -6939,7 +6961,7 @@ mod tests {
 
     #[cfg(target_family = "unix")]
     #[test]
-    fn timed_out_request_end_with_exited_worker_reports_session_end_immediately() {
+    fn timed_out_prompt_completion_with_exited_worker_reports_session_end_immediately() {
         let _guard = env_test_mutex().lock().expect("env mutex");
         let (server, worker) = crate::ipc::test_connection_pair().expect("ipc pair");
         let mut manager = WorkerManager::new(
@@ -6964,7 +6986,9 @@ mod tests {
             prompt,
             line: "quit()\n".to_string(),
         });
-        let _ = worker.send(WorkerToServerIpcMessage::RequestEnd);
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
+            prompt: ">>> ".to_string(),
+        });
         drop(worker);
         manager.resolve_timeout_marker_with_wait(Duration::from_millis(200));
         let formatted = manager.drain_final_formatted_output();
@@ -7685,9 +7709,10 @@ mod tests {
             data: "AA==".to_string(),
             mime_type: "image/png".to_string(),
             is_new: true,
+            updates_previous_image: false,
             readline_results_seen: 0,
         });
-        capture.append_sideband(PendingSidebandKind::RequestEnd);
+        capture.append_sideband(PendingSidebandKind::RequestBoundary);
 
         assert!(
             tape.drain_final_snapshot().events.is_empty(),

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -144,7 +144,18 @@ impl LiveOutputCapture {
 
     fn append_image(&self, image: IpcPlotImage) {
         if image.updates_previous_image {
-            self.append_server_stdout_status_line(PREVIOUS_IMAGE_UPDATE_NOTICE.as_bytes());
+            self.output_timeline.append_text_event(
+                PREVIOUS_IMAGE_UPDATE_NOTICE.to_string(),
+                false,
+                ContentOrigin::Server,
+                Some(image.readline_results_seen),
+            );
+            if let Some(tape) = &self.pending_output_tape {
+                tape.append_stdout_status_event(
+                    PREVIOUS_IMAGE_UPDATE_NOTICE.to_string(),
+                    image.readline_results_seen,
+                );
+            }
         }
         self.output_timeline.append_image(
             image.id.clone(),
@@ -161,14 +172,6 @@ impl LiveOutputCapture {
                 image.is_new,
                 image.readline_results_seen,
             );
-        }
-    }
-
-    fn append_server_stdout_status_line(&self, bytes: &[u8]) {
-        self.output_timeline
-            .append_text(bytes, false, ContentOrigin::Server);
-        if let Some(tape) = &self.pending_output_tape {
-            tape.append_stdout_status_line(bytes);
         }
     }
 
@@ -6562,6 +6565,7 @@ mod tests {
         let prompt = "> ".to_string();
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: prompt.clone(),
+            client_waiting: false,
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineResult {
             prompt: prompt.clone(),
@@ -6569,6 +6573,7 @@ mod tests {
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: prompt.clone(),
+            client_waiting: true,
         });
 
         let completion = driver_wait_for_completion(Duration::from_millis(200), server)
@@ -6589,6 +6594,7 @@ mod tests {
         let prompt = "> ".to_string();
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: prompt.clone(),
+            client_waiting: false,
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineResult {
             prompt: prompt.clone(),
@@ -6596,10 +6602,38 @@ mod tests {
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: prompt.clone(),
+            client_waiting: true,
         });
 
         let completion = driver_wait_for_completion(Duration::from_millis(200), server)
             .expect("expected stable waiting prompt to complete request");
+
+        assert_eq!(completion.prompt.as_deref(), Some("> "));
+        assert_eq!(completion.echo_events.len(), 1);
+        assert_eq!(completion.echo_events[0].line, "1+1\n");
+    }
+
+    #[test]
+    fn completion_settle_after_prompt_does_not_count_as_execution_timeout() {
+        let (server, worker) = crate::ipc::test_connection_pair().expect("ipc pair");
+        driver_on_input_start("1+1", &server);
+        let prompt = "> ".to_string();
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
+            prompt: prompt.clone(),
+            client_waiting: true,
+        });
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineResult {
+            prompt: prompt.clone(),
+            line: "1+1\n".to_string(),
+        });
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
+            prompt: prompt.clone(),
+            client_waiting: true,
+        });
+        thread::sleep(Duration::from_millis(1));
+
+        let completion = driver_wait_for_completion(Duration::from_millis(5), server)
+            .expect("expected prompt seen before timeout to complete after stable settle");
 
         assert_eq!(completion.prompt.as_deref(), Some("> "));
         assert_eq!(completion.echo_events.len(), 1);
@@ -6612,6 +6646,7 @@ mod tests {
         driver_on_input_start("1+\n1", &server);
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: "> ".to_string(),
+            client_waiting: true,
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineResult {
             prompt: "> ".to_string(),
@@ -6619,6 +6654,7 @@ mod tests {
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: "+ ".to_string(),
+            client_waiting: true,
         });
 
         let completion = driver_wait_for_completion(Duration::from_millis(200), server)
@@ -6635,6 +6671,7 @@ mod tests {
 
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: prompt.clone(),
+            client_waiting: false,
         });
 
         let late_sender = thread::spawn(move || {
@@ -6650,6 +6687,7 @@ mod tests {
             });
             let _ = delayed_worker.send(WorkerToServerIpcMessage::ReadlineStart {
                 prompt: "> ".to_string(),
+                client_waiting: true,
             });
         });
 
@@ -6667,12 +6705,64 @@ mod tests {
     }
 
     #[test]
+    fn completion_waits_for_client_waiting_prompt_after_buffered_readline_start() {
+        let (server, worker) = crate::ipc::test_connection_pair().expect("ipc pair");
+        driver_on_input_start("1+\n1", &server);
+
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
+            prompt: "> ".to_string(),
+            client_waiting: false,
+        });
+        thread::sleep(REQUEST_COMPLETION_STABLE_WAIT + Duration::from_millis(5));
+        let early = server
+            .wait_for_request_completion(Duration::from_millis(1), REQUEST_COMPLETION_STABLE_WAIT);
+        assert!(
+            matches!(early, Err(IpcWaitError::Timeout)),
+            "did not expect buffered readline start to complete request, got {early:?}"
+        );
+
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineResult {
+            prompt: "> ".to_string(),
+            line: "1+\n".to_string(),
+        });
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
+            prompt: "+ ".to_string(),
+            client_waiting: false,
+        });
+        thread::sleep(REQUEST_COMPLETION_STABLE_WAIT + Duration::from_millis(5));
+        let continuation = server
+            .wait_for_request_completion(Duration::from_millis(1), REQUEST_COMPLETION_STABLE_WAIT);
+        assert!(
+            matches!(continuation, Err(IpcWaitError::Timeout)),
+            "did not expect buffered continuation start to complete request, got {continuation:?}"
+        );
+
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineResult {
+            prompt: "+ ".to_string(),
+            line: "1\n".to_string(),
+        });
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
+            prompt: "> ".to_string(),
+            client_waiting: true,
+        });
+
+        let completion = driver_wait_for_completion(Duration::from_millis(200), server)
+            .expect("expected completion after final client-waiting prompt");
+
+        assert_eq!(completion.prompt.as_deref(), Some("> "));
+        assert_eq!(completion.echo_events.len(), 2);
+        assert_eq!(completion.echo_events[0].line, "1+\n");
+        assert_eq!(completion.echo_events[1].line, "1\n");
+    }
+
+    #[test]
     fn next_request_result_is_retained_when_prompt_is_already_active() {
         let (server, worker) = crate::ipc::test_connection_pair().expect("ipc pair");
 
         driver_on_input_start("first()", &server);
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: "> ".to_string(),
+            client_waiting: true,
         });
         let first = driver_wait_for_completion(Duration::from_millis(200), server.clone())
             .expect("expected first completion");
@@ -6685,6 +6775,7 @@ mod tests {
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: "> ".to_string(),
+            client_waiting: true,
         });
 
         let second = driver_wait_for_completion(Duration::from_millis(200), server)
@@ -6703,6 +6794,7 @@ mod tests {
         driver_on_input_start("first()", &server);
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: "> ".to_string(),
+            client_waiting: true,
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineResult {
             prompt: "> ".to_string(),
@@ -6710,6 +6802,7 @@ mod tests {
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: "> ".to_string(),
+            client_waiting: true,
         });
 
         let completion = driver_wait_for_completion(Duration::from_millis(200), server)
@@ -6729,6 +6822,7 @@ mod tests {
 
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: "> ".to_string(),
+            client_waiting: true,
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineResult {
             prompt: "> ".to_string(),
@@ -6752,6 +6846,7 @@ mod tests {
 
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: "> ".to_string(),
+            client_waiting: true,
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineResult {
             prompt: "> ".to_string(),
@@ -6759,6 +6854,7 @@ mod tests {
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: "> ".to_string(),
+            client_waiting: true,
         });
         thread::sleep(Duration::from_millis(25));
         let _ = worker.send(WorkerToServerIpcMessage::SessionEnd);
@@ -6981,6 +7077,7 @@ mod tests {
         let prompt = ">>> ".to_string();
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: prompt.clone(),
+            client_waiting: true,
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineResult {
             prompt,
@@ -6988,6 +7085,7 @@ mod tests {
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineStart {
             prompt: ">>> ".to_string(),
+            client_waiting: true,
         });
         drop(worker);
         manager.resolve_timeout_marker_with_wait(Duration::from_millis(200));
@@ -7737,6 +7835,97 @@ mod tests {
                 )
             }),
             "pager mode should keep image events in the output timeline"
+        );
+    }
+
+    #[test]
+    fn files_output_capture_anchors_update_notice_before_late_echo() {
+        let output_ring = Arc::new(OutputRing::with_capacity(OUTPUT_RING_CAPACITY_BYTES));
+        let tape = PendingOutputTape::new();
+        let capture = LiveOutputCapture::new(
+            OversizedOutputMode::Files,
+            tape.clone(),
+            OutputTimeline::new(output_ring),
+        );
+
+        capture.append_sideband(PendingSidebandKind::ReadlineResult {
+            prompt: "> ".to_string(),
+            line: "lines(4:8, 4:8)\n".to_string(),
+        });
+        capture.append_image(IpcPlotImage {
+            id: "img-1".to_string(),
+            data: "AA==".to_string(),
+            mime_type: "image/png".to_string(),
+            is_new: true,
+            updates_previous_image: true,
+            readline_results_seen: 1,
+        });
+        capture.append_text(b"> lines(4:8, 4:8)\n", TextStream::Stdout);
+
+        let contents = tape
+            .drain_final_snapshot()
+            .format_contents_for_reply()
+            .contents;
+
+        assert_eq!(
+            contents,
+            vec![
+                WorkerContent::server_stdout(PREVIOUS_IMAGE_UPDATE_NOTICE),
+                WorkerContent::ContentImage {
+                    data: "AA==".to_string(),
+                    mime_type: "image/png".to_string(),
+                    id: "img-1".to_string(),
+                    is_new: true,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn pager_output_capture_anchors_update_notice_before_late_echo() {
+        let output_ring = Arc::new(OutputRing::with_capacity(OUTPUT_RING_CAPACITY_BYTES));
+        let capture = LiveOutputCapture::new(
+            OversizedOutputMode::Pager,
+            PendingOutputTape::new(),
+            OutputTimeline::new(output_ring.clone()),
+        );
+
+        capture.append_image(IpcPlotImage {
+            id: "img-1".to_string(),
+            data: "AA==".to_string(),
+            mime_type: "image/png".to_string(),
+            is_new: true,
+            updates_previous_image: true,
+            readline_results_seen: 1,
+        });
+        capture.append_text(b"> lines(4:8, 4:8)\n", TextStream::Stdout);
+
+        let end = output_ring.end_offset();
+        let collapsed = collapse_echo_with_attribution(
+            output_ring.read_range(0, end),
+            &[echo_event("> ", "lines(4:8, 4:8)\n")],
+            0,
+            &["> ".to_string()],
+            EchoCollapseMode::CollapseForFinalReply,
+        );
+        let contents = pager::contents_from_collapsed_output(
+            collapsed.bytes,
+            collapsed.events,
+            collapsed.text_spans,
+            end,
+        );
+
+        assert_eq!(
+            contents,
+            vec![
+                WorkerContent::server_stdout(PREVIOUS_IMAGE_UPDATE_NOTICE),
+                WorkerContent::ContentImage {
+                    data: "AA==".to_string(),
+                    mime_type: "image/png".to_string(),
+                    id: "img-1".to_string(),
+                    is_new: true,
+                },
+            ]
         );
     }
 

--- a/tests/docs_contracts.rs
+++ b/tests/docs_contracts.rs
@@ -57,6 +57,29 @@ fn docs_index_lists_main_docs() {
 }
 
 #[test]
+fn worker_sideband_protocol_keeps_plot_images_one_way() {
+    let protocol = read(&repo_root().join("docs/worker_sideband_protocol.md"));
+
+    for required in [
+        r#"{ "type": "plot_image", "mime_type": <string>, "data": <base64>, "is_update": <bool>, "source": <string|null> }"#,
+        "There is no plot-image acknowledgement message.",
+        "Workers must not delay stdout/stderr output waiting for sideband responses.",
+    ] {
+        assert!(
+            protocol.contains(required),
+            "missing {required} in docs/worker_sideband_protocol.md"
+        );
+    }
+
+    for forbidden in ["`plot_image_ack`", r#""sequence": <integer|null>"#] {
+        assert!(
+            !protocol.contains(forbidden),
+            "did not expect {forbidden} in docs/worker_sideband_protocol.md"
+        );
+    }
+}
+
+#[test]
 fn plans_layout_exists() {
     let root = repo_root();
     for required in [
@@ -101,6 +124,7 @@ fn ci_workflow_defines_dev_release_contract() {
     let workflow = read(&repo_root().join(".github/workflows/ci.yml"));
 
     for required in [
+        "workflow_dispatch:",
         "publish-dev:",
         "publish-release:",
         "tags:",
@@ -138,7 +162,6 @@ fn ci_workflow_defines_dev_release_contract() {
     }
 
     for forbidden in [
-        "workflow_dispatch:",
         "stable_tag:",
         "backfill-stable:",
         "- 'v*.*.*'",

--- a/tests/plot_images.rs
+++ b/tests/plot_images.rs
@@ -454,7 +454,11 @@ fn render_plot_transcript(snapshot: &PlotTranscriptSnapshot) -> String {
         }
 
         for line in plot_response_lines(&step.response) {
-            out.push_str(&format!("<<< {line}\n"));
+            if line.is_empty() {
+                out.push_str("<<<\n");
+            } else {
+                out.push_str(&format!("<<< {line}\n"));
+            }
         }
 
         if let Some(reference) = &step.reference {
@@ -617,6 +621,12 @@ async fn plots_emit_images_and_updates() -> TestResult<()> {
     assert_ne!(
         plot_images[0].bytes, update_images[0].bytes,
         "expected updated plot image to differ from initial plot"
+    );
+    assert!(
+        result_text(&update_result)
+            .contains("[repl] image update from previous request shown as a new image"),
+        "expected update response to include server notice, got: {}",
+        result_text(&update_result)
     );
     assert_reference_image("base_plot", &plot_images[0].bytes);
     assert_reference_image("base_plot_update", &update_images[0].bytes);

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -92,6 +92,10 @@ fn interrupt_recovery_deadline() -> Instant {
     Instant::now() + Duration::from_secs(if cfg!(target_os = "macos") { 20 } else { 5 })
 }
 
+fn python_startup_probe_budget() -> Duration {
+    Duration::from_secs(if cfg!(target_os = "macos") { 30 } else { 10 })
+}
+
 async fn start_python_session_with_env_vars(
     env_vars: Vec<(String, String)>,
 ) -> TestResult<Option<common::McpTestSession>> {
@@ -111,12 +115,14 @@ async fn start_python_session_with_env_vars(
         env_vars,
     )
     .await?;
-    let probe = session.write_stdin_raw_with("pass", Some(2.0)).await?;
+    let probe = session
+        .write_stdin_raw_with("print('mcp_repl_python_ready')", Some(2.0))
+        .await?;
     let probe = common::wait_until_not_busy(
         &mut session,
         probe,
         Duration::from_millis(100),
-        Duration::from_secs(10),
+        python_startup_probe_budget(),
     )
     .await?;
     let probe_text = result_text(&probe);

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -676,6 +676,32 @@ async fn python_multiline_block_does_not_echo_input_in_visible_reply() -> TestRe
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn python_buffered_multiline_prompt_does_not_complete_request_early() -> TestResult<()> {
+    let Some(session) = start_python_session().await? else {
+        return Ok(());
+    };
+
+    let result = session
+        .write_stdin_raw_with(
+            "if True:\n    pass\n\nimport time\ntime.sleep(0.5)\nprint('DONE')",
+            Some(5.0),
+        )
+        .await?;
+    let text = result_text(&result);
+    session.cancel().await?;
+
+    assert!(
+        !is_busy_response(&text),
+        "expected buffered multiline request to finish in the original call, got: {text:?}"
+    );
+    assert!(
+        text.contains("DONE"),
+        "expected buffered multiline request to include final output, got: {text:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn python_input_roundtrip() -> TestResult<()> {
     let Some(session) = start_python_session().await? else {
         return Ok(());

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -99,7 +99,7 @@ async fn start_python_session_with_env_vars(
         return Ok(None);
     }
 
-    let session = common::spawn_server_with_args_env(
+    let mut session = common::spawn_server_with_args_env(
         vec![
             "--interpreter".to_string(),
             "python".to_string(),
@@ -112,6 +112,13 @@ async fn start_python_session_with_env_vars(
     )
     .await?;
     let probe = session.write_stdin_raw_with("pass", Some(2.0)).await?;
+    let probe = common::wait_until_not_busy(
+        &mut session,
+        probe,
+        Duration::from_millis(100),
+        Duration::from_secs(10),
+    )
+    .await?;
     let probe_text = result_text(&probe);
     if probe_text.contains("worker io error: Permission denied")
         || probe_text.contains("python backend requires a unix-style pty")

--- a/tests/python_plot_images.rs
+++ b/tests/python_plot_images.rs
@@ -565,6 +565,80 @@ async fn python_noop_after_plot_does_not_emit_update_notice() -> TestResult<()> 
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn python_explicit_repeat_plot_and_show_emit_images_in_same_session() -> TestResult<()> {
+    if !python_plot_tests_enabled() {
+        return Ok(());
+    }
+    let session = common::spawn_python_server_with_files().await?;
+
+    let plot_input = format!(
+        "{}; plt.figure(21); plt.clf(); plt.plot(list(range(1, 11))); plt.show()",
+        python_plot_preamble()
+    );
+    let first_result = session
+        .write_stdin_raw_with(&plot_input, Some(30.0))
+        .await?;
+    let repeat_result = session
+        .write_stdin_raw_with(&plot_input, Some(30.0))
+        .await?;
+    let show_result = session
+        .write_stdin_raw_with("plt.show()", Some(30.0))
+        .await?;
+    let noop_result = session.write_stdin_raw_with("1+1", Some(30.0)).await?;
+    session.cancel().await?;
+
+    assert_ne!(
+        first_result.is_error,
+        Some(true),
+        "first plot reported an error: {}",
+        result_text(&first_result)
+    );
+    assert_ne!(
+        repeat_result.is_error,
+        Some(true),
+        "repeat plot reported an error: {}",
+        result_text(&repeat_result)
+    );
+    assert_ne!(
+        show_result.is_error,
+        Some(true),
+        "explicit show reported an error: {}",
+        result_text(&show_result)
+    );
+
+    let first_images = extract_images(&first_result);
+    let repeat_images = extract_images(&repeat_result);
+    let show_images = extract_images(&show_result);
+
+    assert_eq!(
+        first_images.len(),
+        1,
+        "expected first plot to emit one image"
+    );
+    assert_eq!(
+        repeat_images.len(),
+        1,
+        "expected explicit repeat plot to emit one image"
+    );
+    assert_eq!(
+        show_images.len(),
+        1,
+        "expected explicit show to emit one image"
+    );
+    assert_eq!(
+        first_images[0].bytes, repeat_images[0].bytes,
+        "expected explicit repeat plot to preserve image bytes"
+    );
+    assert_eq!(
+        first_images[0].bytes, show_images[0].bytes,
+        "expected explicit show to preserve image bytes"
+    );
+    assert_no_images(&noop_result, "python no-op after explicit repeat plot");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn python_plots_emit_stable_images_for_repeats() -> TestResult<()> {
     if !python_plot_tests_enabled() {
         return Ok(());

--- a/tests/python_plot_images.rs
+++ b/tests/python_plot_images.rs
@@ -479,6 +479,92 @@ async fn python_plots_emit_images_and_updates() -> TestResult<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn python_prompt_time_plot_flushes_before_completion_prompt() -> TestResult<()> {
+    if !python_plot_tests_enabled() {
+        return Ok(());
+    }
+    let session = common::spawn_python_server_with_files().await?;
+
+    let input = format!(
+        r#"{}
+import time
+fig = plt.figure(101)
+plt.clf()
+original_savefig = fig.savefig
+def slow_savefig(*args, **kwargs):
+    time.sleep(0.35)
+    return original_savefig(*args, **kwargs)
+fig.savefig = slow_savefig
+plt.scatter([1, 2, 3], [3, 2, 1])"#,
+        python_plot_preamble()
+    );
+    let result = session.write_stdin_raw_with(&input, Some(30.0)).await?;
+    session.cancel().await?;
+
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "scatter plot reported an error: {}",
+        result_text(&result)
+    );
+    let images = extract_images(&result);
+    assert_eq!(
+        images.len(),
+        1,
+        "expected prompt-time scatter plot to emit one image in the current response, got {images:?}; response text: {}",
+        result_text(&result)
+    );
+    assert_eq!(images[0].mime_type, "image/png");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn python_noop_after_plot_does_not_emit_update_notice() -> TestResult<()> {
+    if !python_plot_tests_enabled() {
+        return Ok(());
+    }
+    let session = common::spawn_python_server_with_files().await?;
+
+    let plot_input = format!(
+        "{}; plt.figure(17); plt.clf(); plt.plot([1, 2, 3]); plt.show()",
+        python_plot_preamble()
+    );
+    let plot_result = session
+        .write_stdin_raw_with(&plot_input, Some(30.0))
+        .await?;
+    assert_ne!(
+        plot_result.is_error,
+        Some(true),
+        "plot reported an error: {}",
+        result_text(&plot_result)
+    );
+    assert_eq!(
+        extract_images(&plot_result).len(),
+        1,
+        "expected initial plot request to emit one image"
+    );
+
+    let noop_result = session.write_stdin_raw_with("1+1", Some(30.0)).await?;
+    session.cancel().await?;
+
+    assert_ne!(
+        noop_result.is_error,
+        Some(true),
+        "1+1 reported an error: {}",
+        result_text(&noop_result)
+    );
+    assert_no_images(&noop_result, "python no-op after existing plot");
+    let noop_text = result_text(&noop_result);
+    assert!(
+        !noop_text.contains("[repl] image update from previous request"),
+        "did not expect unchanged figure update notice in no-op response: {noop_text:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn python_plots_emit_stable_images_for_repeats() -> TestResult<()> {
     if !python_plot_tests_enabled() {
         return Ok(());
@@ -830,6 +916,70 @@ async fn python_plot_updates_in_single_request_collapse() -> TestResult<()> {
         images.len(),
         1,
         "expected a single collapsed image update, got {images:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn python_multi_figure_updates_in_single_request_keep_distinct_images() -> TestResult<()> {
+    if !python_plot_tests_enabled() {
+        return Ok(());
+    }
+    let session = common::spawn_python_server_with_files().await?;
+
+    let initial_input = format!(
+        r#"{}
+plt.figure(1)
+plt.clf()
+plt.plot([1, 2, 3], [1, 2, 3])
+plt.figure(2)
+plt.clf()
+plt.plot([1, 2, 3], [3, 2, 1])"#,
+        python_plot_preamble()
+    );
+    let initial_result = session
+        .write_stdin_raw_with(&initial_input, Some(30.0))
+        .await?;
+    assert_ne!(
+        initial_result.is_error,
+        Some(true),
+        "initial multi-figure plot reported an error: {}",
+        result_text(&initial_result)
+    );
+    assert_eq!(
+        extract_images(&initial_result).len(),
+        2,
+        "expected initial request to emit two distinct figures"
+    );
+
+    let update_input = r#"plt.figure(1)
+plt.plot([1, 2, 3], [3, 3, 3])
+plt.figure(2)
+plt.plot([1, 2, 3], [1, 1, 1])"#;
+    let update_result = session
+        .write_stdin_raw_with(update_input, Some(30.0))
+        .await?;
+    session.cancel().await?;
+
+    assert_ne!(
+        update_result.is_error,
+        Some(true),
+        "multi-figure update reported an error: {}",
+        result_text(&update_result)
+    );
+    let update_text = result_text(&update_result);
+    assert_eq!(
+        update_text
+            .matches("[repl] image update from previous request shown as a new image")
+            .count(),
+        2,
+        "expected one update notice per updated figure, got: {update_text:?}"
+    );
+    assert_eq!(
+        extract_images(&update_result).len(),
+        2,
+        "expected updates to two existing figures to remain distinct in one response"
     );
 
     Ok(())

--- a/tests/repl_surface.rs
+++ b/tests/repl_surface.rs
@@ -139,6 +139,49 @@ async fn pager_keeps_plot_image_before_later_stdout() -> TestResult<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn files_poll_after_timeout_keeps_image_before_later_stdout() -> TestResult<()> {
+    let session = common::spawn_server_with_files().await?;
+
+    let input = concat!(
+        "Sys.sleep(0.25); ",
+        "invisible(.Call('mcp_repl_plot_emit', 'plot-1', charToRaw('img'), 'image/png', TRUE)); ",
+        "Sys.sleep(0.2); ",
+        "cat('done\\n')",
+    );
+    let first = session.write_stdin_raw_with(input, Some(0.05)).await?;
+    let first_text = result_text(&first);
+    if backend_unavailable(&first_text) {
+        eprintln!("repl_surface backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert!(
+        first_text.contains("<<repl status: busy"),
+        "expected first reply to time out, got: {first_text:?}"
+    );
+
+    let result = session.write_stdin_raw_with("", Some(30.0)).await?;
+    let text = result_text(&result);
+    if busy_response(&text) {
+        eprintln!("repl_surface timeout poll remained busy; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+
+    let image_idx = first_image_index(&result).ok_or("expected image in timeout poll")?;
+    let done_idx =
+        first_text_index_containing(&result, "done").ok_or("expected done text in timeout poll")?;
+    assert!(
+        image_idx < done_idx,
+        "expected image before later stdout after timeout poll, got content order: {:?}",
+        result.content
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn files_keeps_plot_image_before_later_stdout() -> TestResult<()> {
     let session = common::spawn_server_with_files().await?;
 

--- a/tests/repl_surface.rs
+++ b/tests/repl_surface.rs
@@ -182,13 +182,14 @@ async fn files_poll_after_timeout_keeps_image_before_later_stdout() -> TestResul
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn explicit_plot_emit_preserves_stdout_before_image() -> TestResult<()> {
+async fn explicit_plot_emit_returns_text_and_image_without_cross_channel_ordering() -> TestResult<()>
+{
     let session = common::spawn_server_with_files().await?;
 
     let input = concat!(
-        "cat('before\\n'); ",
+        "cat('before\\n'); flush.console(); ",
         "invisible(.Call('mcp_repl_plot_emit', 'plot-1', charToRaw('img'), 'image/png', TRUE)); ",
-        "cat('after\\n')",
+        "cat('after\\n'); flush.console()",
     );
     let result = session.write_stdin_raw_with(input, Some(30.0)).await?;
     let text = result_text(&result);
@@ -203,16 +204,10 @@ async fn explicit_plot_emit_preserves_stdout_before_image() -> TestResult<()> {
         return Ok(());
     }
 
-    let before_idx =
+    let _before_idx =
         first_text_index_containing(&result, "before").ok_or("expected before text in reply")?;
-    let image_idx = first_image_index(&result).ok_or("expected plot image in reply")?;
-    let after_idx =
-        first_text_index_containing(&result, "after").ok_or("expected after text in reply")?;
-    assert!(
-        before_idx < image_idx && image_idx < after_idx,
-        "expected before text, image, then after text, got content order: {:?}",
-        result.content
-    );
+    let _image_idx = first_image_index(&result).ok_or("expected plot image in reply")?;
+    let _after_idx = first_text_index_containing(&result, "after").ok_or("expected after text")?;
 
     session.cancel().await?;
     Ok(())

--- a/tests/repl_surface.rs
+++ b/tests/repl_surface.rs
@@ -182,6 +182,43 @@ async fn files_poll_after_timeout_keeps_image_before_later_stdout() -> TestResul
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn explicit_plot_emit_preserves_stdout_before_image() -> TestResult<()> {
+    let session = common::spawn_server_with_files().await?;
+
+    let input = concat!(
+        "cat('before\\n'); ",
+        "invisible(.Call('mcp_repl_plot_emit', 'plot-1', charToRaw('img'), 'image/png', TRUE)); ",
+        "cat('after\\n')",
+    );
+    let result = session.write_stdin_raw_with(input, Some(30.0)).await?;
+    let text = result_text(&result);
+    if backend_unavailable(&text) {
+        eprintln!("repl_surface backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    if busy_response(&text) {
+        eprintln!("repl_surface worker remained busy; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+
+    let before_idx =
+        first_text_index_containing(&result, "before").ok_or("expected before text in reply")?;
+    let image_idx = first_image_index(&result).ok_or("expected plot image in reply")?;
+    let after_idx =
+        first_text_index_containing(&result, "after").ok_or("expected after text in reply")?;
+    assert!(
+        before_idx < image_idx && image_idx < after_idx,
+        "expected before text, image, then after text, got content order: {:?}",
+        result.content
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn files_keeps_plot_image_before_later_stdout() -> TestResult<()> {
     let session = common::spawn_server_with_files().await?;
 

--- a/tests/sandbox_state_updates.rs
+++ b/tests/sandbox_state_updates.rs
@@ -314,6 +314,19 @@ flush.console()
 "#
 }
 
+fn timeout_then_tail_code_after(wait_secs: f64) -> String {
+    format!(
+        r#"
+Sys.sleep(0.2)
+cat("MID\n")
+flush.console()
+Sys.sleep({wait_secs:.3})
+cat("TAIL\n")
+flush.console()
+"#
+    )
+}
+
 fn timeout_then_paged_tail_code() -> &'static str {
     r#"
 line <- paste(rep("foo", 80), collapse = " ")
@@ -1187,7 +1200,7 @@ async fn sandbox_inherit_pending_interrupt_tail_with_bad_meta_fails_closed() -> 
     let session = spawn_inherit_files_server(temp.path(), Vec::new()).await?;
     let first = session
         .write_stdin_raw_with_meta(
-            timeout_then_tail_code(),
+            timeout_then_tail_code_after(3.0),
             Some(0.05),
             Some(workspace_write_meta(temp.path())),
         )

--- a/tests/sandbox_state_updates.rs
+++ b/tests/sandbox_state_updates.rs
@@ -344,7 +344,7 @@ fn timeout_then_paged_exit_code() -> &'static str {
 line <- paste(rep("foo", 80), collapse = " ")
 for (i in 1:300) cat(sprintf("line%04d %s\n", i, line))
 flush.console()
-Sys.sleep(0.2)
+Sys.sleep(1.0)
 q("no", status = 0, runLast = FALSE)
 "#
 }
@@ -422,7 +422,7 @@ fn timeout_then_large_completion_code() -> &'static str {
              cat(small); \
              cat('\\nFIRST_END\\n'); \
              flush.console(); \
-             Sys.sleep(0.5); \
+             Sys.sleep(1.0); \
              cat('SECOND_START\\n'); \
              cat(big); \
              cat('\\nSECOND_END\\n'); \
@@ -441,7 +441,7 @@ fn timeout_then_large_completion_and_quit_code() -> &'static str {
              cat(small); \
              cat('\\nFIRST_END\\n'); \
              flush.console(); \
-             Sys.sleep(0.5); \
+             Sys.sleep(1.0); \
              cat('SECOND_START\\n'); \
              cat(big); \
              cat('\\nSECOND_END\\n'); \
@@ -885,7 +885,7 @@ async fn sandbox_inherit_metadata_error_preserves_hidden_timeout_bundle() -> Tes
     let first = session
         .write_stdin_raw_with_meta(
             timeout_then_large_completion_code(),
-            Some(0.05),
+            Some(0.5),
             Some(workspace_write_meta(temp.path())),
         )
         .await?;
@@ -900,7 +900,7 @@ async fn sandbox_inherit_metadata_error_preserves_hidden_timeout_bundle() -> Tes
         "did not expect the first under-threshold timeout reply to disclose a bundle path, got: {first_text:?}"
     );
 
-    tokio::time::sleep(test_delay_ms(600, 900)).await;
+    tokio::time::sleep(test_delay_ms(1100, 1500)).await;
 
     let metadata_error = session
         .write_stdin_raw_with_meta(
@@ -1057,7 +1057,7 @@ async fn sandbox_inherit_session_ended_pager_command_ignores_state_meta_changes(
     let timed_out = session
         .write_stdin_raw_with_meta(
             timeout_then_paged_exit_code(),
-            Some(0.05),
+            Some(0.5),
             Some(workspace_write_meta(scratch.path())),
         )
         .await?;
@@ -1071,7 +1071,7 @@ async fn sandbox_inherit_session_ended_pager_command_ignores_state_meta_changes(
         timed_out_text.contains("--More--"),
         "expected timed-out request to leave pager active, got: {timed_out_text}"
     );
-    tokio::time::sleep(test_delay_ms(350, 700)).await;
+    tokio::time::sleep(test_delay_ms(1100, 1500)).await;
 
     let quit = session
         .write_stdin_raw_with_meta(":q", Some(5.0), Some(read_only_meta(scratch.path())))
@@ -1624,7 +1624,7 @@ async fn sandbox_inherit_empty_poll_respawn_retires_disclosed_timeout_bundle() -
     let first = session
         .write_stdin_raw_with_meta(
             timeout_then_large_completion_and_quit_code(),
-            Some(0.05),
+            Some(0.5),
             Some(full_access_meta(scratch.path())),
         )
         .await?;
@@ -1998,7 +1998,7 @@ async fn sandbox_inherit_metadata_change_keeps_timeout_bundle_output() -> TestRe
     let first = session
         .write_stdin_raw_with_meta(
             timeout_then_large_completion_code(),
-            Some(0.05),
+            Some(0.5),
             Some(read_only_meta(scratch.path())),
         )
         .await?;
@@ -2013,7 +2013,7 @@ async fn sandbox_inherit_metadata_change_keeps_timeout_bundle_output() -> TestRe
         "did not expect the initial timeout reply to disclose a transcript path, got: {first_text:?}"
     );
 
-    tokio::time::sleep(test_delay_ms(900, 1200)).await;
+    tokio::time::sleep(test_delay_ms(1100, 1500)).await;
 
     let second = session
         .write_stdin_raw_with_meta(
@@ -2056,7 +2056,7 @@ async fn sandbox_inherit_restart_tail_after_sandbox_respawn_keeps_timeout_bundle
     let first = session
         .write_stdin_raw_with_meta(
             timeout_then_large_completion_code(),
-            Some(0.05),
+            Some(0.5),
             Some(read_only_meta(scratch.path())),
         )
         .await?;
@@ -2071,7 +2071,7 @@ async fn sandbox_inherit_restart_tail_after_sandbox_respawn_keeps_timeout_bundle
         "did not expect the initial timeout reply to disclose a transcript path, got: {first_text:?}"
     );
 
-    tokio::time::sleep(test_delay_ms(900, 1200)).await;
+    tokio::time::sleep(test_delay_ms(1100, 1500)).await;
 
     let second = session
         .write_stdin_raw_with_meta(
@@ -2113,7 +2113,7 @@ async fn sandbox_inherit_disclosed_timeout_bundle_is_retired_on_state_change() -
     let first = session
         .write_stdin_raw_with_meta(
             timeout_then_large_completion_code(),
-            Some(0.05),
+            Some(0.5),
             Some(read_only_meta(scratch.path())),
         )
         .await?;

--- a/tests/snapshots/plot_images__grid_plots_emit_images_and_updates.snap
+++ b/tests/snapshots/plot_images__grid_plots_emit_images_and_updates.snap
@@ -39,6 +39,10 @@ expression: serialized
       "response": {
         "content": [
           {
+            "type": "text",
+            "text": "[repl] image update from previous request shown as a new image\n"
+          },
+          {
             "type": "image",
             "data": "blake3:<grid_plot_update>",
             "mimeType": "image/png"

--- a/tests/snapshots/plot_images__grid_plots_emit_images_and_updates@macos.snap
+++ b/tests/snapshots/plot_images__grid_plots_emit_images_and_updates@macos.snap
@@ -39,6 +39,10 @@ expression: serialized
       "response": {
         "content": [
           {
+            "type": "text",
+            "text": "[repl] image update from previous request shown as a new image\n"
+          },
+          {
             "type": "image",
             "data": "blake3:<grid_plot_update>",
             "mimeType": "image/png"

--- a/tests/snapshots/plot_images__grid_plots_emit_images_and_updates@transcript.snap
+++ b/tests/snapshots/plot_images__grid_plots_emit_images_and_updates@transcript.snap
@@ -16,6 +16,8 @@ expression: transcript
 
 2) r_repl
 >>> grid::grid.lines(x = c(0.1, 0.9), y = c(0.9, 0.1))
+<<< [repl] image update from previous request shown as a new image
+<<<
 <<< [image/png blake3:<grid_plot_update>]
 === reference grid_plot_update via Rscript --vanilla -
 === env MCP_REPL_TEST_PNG_DEST=<REFERENCE_PNG>

--- a/tests/snapshots/plot_images__grid_plots_emit_images_and_updates@transcript__macos.snap
+++ b/tests/snapshots/plot_images__grid_plots_emit_images_and_updates@transcript__macos.snap
@@ -16,6 +16,8 @@ expression: transcript
 
 2) r_repl
 >>> grid::grid.lines(x = c(0.1, 0.9), y = c(0.9, 0.1))
+<<< [repl] image update from previous request shown as a new image
+<<<
 <<< [image/png blake3:<grid_plot_update>]
 === reference grid_plot_update via Rscript --vanilla -
 === env MCP_REPL_TEST_PNG_DEST=<REFERENCE_PNG>

--- a/tests/snapshots/plot_images__plots_emit_images_and_updates.snap
+++ b/tests/snapshots/plot_images__plots_emit_images_and_updates.snap
@@ -38,6 +38,10 @@ expression: serialized
       "response": {
         "content": [
           {
+            "type": "text",
+            "text": "[repl] image update from previous request shown as a new image\n"
+          },
+          {
             "type": "image",
             "data": "blake3:<base_plot_update>",
             "mimeType": "image/png"

--- a/tests/snapshots/plot_images__plots_emit_images_and_updates@macos.snap
+++ b/tests/snapshots/plot_images__plots_emit_images_and_updates@macos.snap
@@ -38,6 +38,10 @@ expression: serialized
       "response": {
         "content": [
           {
+            "type": "text",
+            "text": "[repl] image update from previous request shown as a new image\n"
+          },
+          {
             "type": "image",
             "data": "blake3:<base_plot_update>",
             "mimeType": "image/png"

--- a/tests/snapshots/plot_images__plots_emit_images_and_updates@transcript.snap
+++ b/tests/snapshots/plot_images__plots_emit_images_and_updates@transcript.snap
@@ -15,6 +15,8 @@ expression: transcript
 
 2) r_repl
 >>> lines(4:8, 4:8)
+<<< [repl] image update from previous request shown as a new image
+<<<
 <<< [image/png blake3:<base_plot_update>]
 === reference base_plot_update via Rscript --vanilla -
 === env MCP_REPL_TEST_PNG_DEST=<REFERENCE_PNG>

--- a/tests/snapshots/plot_images__plots_emit_images_and_updates@transcript__macos.snap
+++ b/tests/snapshots/plot_images__plots_emit_images_and_updates@transcript__macos.snap
@@ -15,6 +15,8 @@ expression: transcript
 
 2) r_repl
 >>> lines(4:8, 4:8)
+<<< [repl] image update from previous request shown as a new image
+<<<
 <<< [image/png blake3:<base_plot_update>]
 === reference base_plot_update via Rscript --vanilla -
 === env MCP_REPL_TEST_PNG_DEST=<REFERENCE_PNG>

--- a/tests/write_stdin_behavior.rs
+++ b/tests/write_stdin_behavior.rs
@@ -1525,7 +1525,7 @@ async fn files_empty_poll_after_resolved_timeout_restores_prompt() -> TestResult
 #[tokio::test(flavor = "multi_thread")]
 async fn pager_follow_up_after_resolved_timeout_trims_detached_echo_prefix() -> TestResult<()> {
     let _guard = lock_test_mutex();
-    let mut session = spawn_pager_behavior_session(20_000).await?;
+    let session = spawn_pager_behavior_session(20_000).await?;
 
     let first = session
         .write_stdin_raw_with("Sys.sleep(0.2); 1+1", Some(0.05))
@@ -1538,9 +1538,32 @@ async fn pager_follow_up_after_resolved_timeout_trims_detached_echo_prefix() -> 
     }
 
     sleep(test_delay_ms(260, 700)).await;
-    let follow_up = session.write_stdin_raw_with("3+3", Some(2.0)).await?;
-    let follow_up = wait_until_not_busy(&mut session, follow_up).await?;
-    let follow_up_text = result_text(&follow_up);
+    let mut follow_up = session.write_stdin_raw_with("3+3", Some(2.0)).await?;
+    let mut follow_up_text = String::new();
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        let text = result_text(&follow_up);
+        follow_up_text.push_str(&text);
+        if text.contains("[1] 6") {
+            break;
+        }
+        if Instant::now() >= deadline {
+            return Err(
+                format!("worker did not run fresh pager follow-up: {follow_up_text:?}").into(),
+            );
+        }
+        sleep(Duration::from_millis(100)).await;
+        follow_up = if text.contains("input discarded while worker busy")
+            || text.contains("worker is busy")
+            || text.contains("request already running")
+        {
+            session.write_stdin_raw_with("3+3", Some(2.0)).await?
+        } else {
+            session
+                .write_stdin_raw_unterminated_with("", Some(2.0))
+                .await?
+        };
+    }
 
     session.cancel().await?;
 


### PR DESCRIPTION
## Summary

Refactors the server/backend boundary for request completion and plot image ordering. The branch removes the worker-owned `request_end` sideband message, uses worker-declared client-waiting prompt events as the completion signal, and keeps response image identity/update grouping owned by the server.

Public-facing changes:
- No MCP tool schema changes.
- Tightens visible reply ordering for flushed text before plot image events.

Internal-only changes:
- Removes `request_end` from the worker-to-server sideband protocol.
- Keeps plot image sideband messages one-way; workers do not receive plot-image acknowledgements and must not gate stdout/stderr on sideband responses.
- Makes response image IDs server-owned while allowing workers to provide optional plot source identity.
- Prevents stale disclosed image-bundle anchors from replaying before fresh follow-up replies.
- Keeps explicit repeated Python `plot()` and `show()` calls image-producing while preserving quiet no-op requests.
- Surfaces strict IPC parse failures as disconnects instead of hidden backend-info or request-completion timeouts.
- Adds manual `workflow_dispatch` support to CI.
- Documents remaining server/backend boundary follow-up work.

## Diff composition

Measured against `main`, this PR is `1896` insertions and `460` deletions across `32` files.
- runtime `src/`: `+839/-315` (`49.0%` of churn)
- inline tests inside `src/`: `+424/-54` (`20.3%` of churn)
- tests in `tests/`: `+433/-22` (`19.3%` of churn)
- docs: `+105/-27` (`5.6%` of churn)
- snapshots: `+24/-0` (`1.0%` of churn)
- other: `+71/-42` (`4.8%` of churn)

Largest files:
- `src/ipc.rs`: `+514/-169`
- `src/worker_process.rs`: `+325/-111`
- `tests/python_plot_images.rs`: `+224/-0`
- `src/output_timeline.rs`: `+141/-39`
- `src/pending_output_tape.rs`: `+139/-14`

## Testing

- `cargo +nightly fmt`
- `cargo check`
- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `codex review --base main`
