### PR TITLE
Add output_text IPC protocol foundation

### DIFF
--- a/docs/plans/active/r-owned-output-synchronous-ipc.md
+++ b/docs/plans/active/r-owned-output-synchronous-ipc.md
@@ -1,0 +1,53 @@
+# R-Owned Output Synchronous IPC
+
+## Summary
+
+- Move R-owned observable text onto ordered worker-to-server IPC frames.
+- Keep raw stdout and stderr capture for unowned output from child processes and direct file-descriptor writes.
+
+## Status
+
+- State: active
+- Last updated: 2026-05-07
+- Current phase: phase 1 pending
+
+## Current Direction
+
+- Add the internal `output_text` frame and synchronous worker IPC writer first.
+- Then teach the server to consume `output_text` as worker-owned text before routing R console callbacks through it.
+
+## Long-Term Direction
+
+- R-owned text, readline facts, plots, and session termination should share one ordered IPC stream.
+- The server should not need timing reconstruction for output that the R backend owns.
+
+## Phase Status
+
+- Phase 0: completed - protocol frame and synchronous worker IPC writer.
+- Phase 1: pending - append `output_text` into server timelines.
+- Phase 2: pending - route R console callbacks and readline echo through `output_text`.
+- Phase 3: pending - remove race-tolerant handling that only existed for R-owned output.
+
+## Locked Decisions
+
+- Use `output_text { stream, data_b64 }` for worker-owned text.
+- Do not add per-output acknowledgements, byte matching, hashes, or alignment heuristics.
+- Keep raw stdout and stderr readers for output the worker protocol does not own.
+
+## Open Questions
+
+- None for the current protocol slice.
+
+## Next Safe Slice
+
+- Append `output_text` frames directly to the server pending-output tape and output timeline while leaving raw stdout and stderr readers active.
+
+## Stop Conditions
+
+- Stop and ask before changing the public reply shape.
+- Stop and ask before removing raw stdout or stderr capture.
+
+## Decision Log
+
+- 2026-05-07: Start with the protocol and synchronous worker writer so later routing can be reviewed separately from server timeline consumption.
+- 2026-05-07: Completed the protocol foundation without changing existing raw stdout/stderr capture or asynchronous non-output IPC sends.

--- a/docs/worker_sideband_protocol.md
+++ b/docs/worker_sideband_protocol.md
@@ -56,7 +56,16 @@ Worker-to-server messages are strict: unknown fields are protocol errors.
 - `{ "type": "readline_result", "prompt": <string>, "line": <string> }`
 - Emitted after a line is read. Includes the prompt and the line that was consumed.
 - The server can reconstruct echoed readline bytes as `prompt + line` for conservative
-  echo suppression. Output streams remain unframed.
+  echo suppression of raw pipe output.
+
+`output_text`
+- `{ "type": "output_text", "stream": <"stdout"|"stderr">, "data_b64": <base64> }`
+- Carries worker-owned text bytes on the ordered IPC stream. The payload is base64
+  so workers can preserve bytes without depending on JSON string encoding.
+- Workers send output-critical frames synchronously: each JSON line is written,
+  newline-terminated, and flushed before the send returns.
+- Workers treat synchronous write failure as IPC failure. They must not silently
+  fall back to stdout or stderr for output that is owned by the worker protocol.
 
 `plot_image`
 - `{ "type": "plot_image", "mime_type": <string>, "data": <base64>, "is_update": <bool>, "source": <string|null> }`
@@ -76,7 +85,8 @@ Worker-to-server messages are strict: unknown fields are protocol errors.
 
 ## Notes
 
-- Output streams (stdout/stderr) remain on the main pipes and are captured separately.
+- Raw stdout/stderr capture remains active for unowned output, such as child
+  processes or direct file-descriptor writes.
 - The server infers request completion when prompt/readline sideband facts show
   that the worker is waiting for the next input.
 - To reduce IPC-vs-output capture races, the server applies a short

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -23,6 +23,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
+
+use crate::worker_protocol::TextStream;
 #[cfg(target_family = "windows")]
 use windows_sys::Win32::Foundation::{
     CloseHandle, ERROR_FILE_NOT_FOUND, ERROR_PIPE_BUSY, ERROR_PIPE_CONNECTED, ERROR_SUCCESS,
@@ -90,6 +92,10 @@ pub enum WorkerToServerIpcMessage {
     BackendInfo {
         #[serde(default)]
         supports_images: bool,
+    },
+    OutputText {
+        stream: TextStream,
+        data_b64: String,
     },
     ReadlineStart {
         prompt: String,
@@ -170,6 +176,29 @@ pub struct WorkerIpcConnection {
     sender: mpsc::Sender<WorkerToServerIpcMessage>,
     inbox: Arc<Mutex<WorkerIpcInbox>>,
     cvar: Arc<Condvar>,
+}
+
+#[allow(dead_code)]
+#[derive(Clone)]
+pub struct OutputCriticalIpcWriter {
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+}
+
+#[allow(dead_code)]
+impl OutputCriticalIpcWriter {
+    pub fn new(writer: Box<dyn Write + Send>) -> Self {
+        Self {
+            writer: Arc::new(Mutex::new(writer)),
+        }
+    }
+
+    pub fn send(&self, message: WorkerToServerIpcMessage) -> io::Result<()> {
+        let mut writer = self
+            .writer
+            .lock()
+            .map_err(|_| io::Error::other("ipc writer mutex poisoned"))?;
+        write_ipc_message(&mut **writer, &message)
+    }
 }
 
 #[derive(Clone, Default)]
@@ -651,6 +680,13 @@ where
             }
         }
     });
+}
+
+fn write_ipc_message<T: Serialize>(writer: &mut dyn Write, message: &T) -> io::Result<()> {
+    let payload = serde_json::to_string(message).map_err(io::Error::other)?;
+    writer.write_all(payload.as_bytes())?;
+    writer.write_all(b"\n")?;
+    writer.flush()
 }
 
 #[derive(Debug)]
@@ -1522,12 +1558,15 @@ fn take_backend_info(guard: &mut ServerIpcInbox) -> Option<WorkerToServerIpcMess
 #[cfg(test)]
 mod protocol_tests {
     use super::{
-        IpcHandlers, IpcTransport, ServerIpcConnection, ServerToWorkerIpcMessage,
-        WorkerIpcConnection, WorkerToServerIpcMessage,
+        IpcHandlers, IpcTransport, OutputCriticalIpcWriter, ServerIpcConnection,
+        ServerToWorkerIpcMessage, WorkerIpcConnection, WorkerToServerIpcMessage,
     };
+    use crate::worker_protocol::TextStream;
+    use base64::Engine as _;
     use serde_json::json;
-    use std::io::Write;
-    use std::sync::{Arc, Mutex};
+    use std::io::{BufRead, Write};
+    use std::sync::{Arc, Mutex, mpsc};
+    use std::thread;
     use std::time::{Duration, Instant};
 
     #[test]
@@ -1581,6 +1620,32 @@ mod protocol_tests {
             parsed.is_err(),
             "plot_image should reject old worker-owned image fields"
         );
+    }
+
+    #[test]
+    fn output_text_protocol_uses_stream_and_base64_payload() {
+        let parsed = serde_json::from_value::<WorkerToServerIpcMessage>(json!({
+            "type": "output_text",
+            "stream": "stdout",
+            "data_b64": "YWxwaGE="
+        }));
+
+        let Ok(WorkerToServerIpcMessage::OutputText { stream, data_b64 }) = parsed else {
+            panic!("output_text should deserialize");
+        };
+        assert_eq!(stream, TextStream::Stdout);
+        assert_eq!(data_b64, "YWxwaGE=");
+    }
+
+    #[test]
+    fn output_text_protocol_rejects_plain_data_payload() {
+        let parsed = serde_json::from_value::<WorkerToServerIpcMessage>(json!({
+            "type": "output_text",
+            "stream": "stdout",
+            "data": "alpha"
+        }));
+
+        assert!(parsed.is_err(), "output_text should require data_b64");
     }
 
     #[test]
@@ -1646,6 +1711,84 @@ mod protocol_tests {
             matches!(result, Err(super::IpcWaitError::Disconnected)),
             "invalid worker message should disconnect server IPC, got: {result:?}"
         );
+    }
+
+    #[test]
+    fn output_critical_writer_flushes_before_returning() {
+        let (server_read, worker_write) = std::io::pipe().expect("server pipe");
+        let writer = OutputCriticalIpcWriter::new(Box::new(worker_write));
+        let (line_tx, line_rx) = mpsc::channel();
+        thread::spawn(move || {
+            let mut reader = std::io::BufReader::new(server_read);
+            let mut line = String::new();
+            reader.read_line(&mut line).expect("read IPC line");
+            line_tx.send(line).expect("send IPC line");
+        });
+
+        writer
+            .send(WorkerToServerIpcMessage::OutputText {
+                stream: TextStream::Stdout,
+                data_b64: base64::engine::general_purpose::STANDARD.encode(b"alpha"),
+            })
+            .expect("send output_text");
+
+        let line = line_rx
+            .recv_timeout(Duration::from_millis(200))
+            .expect("IPC line flushed before send returned");
+        assert!(line.contains(r#""type":"output_text""#), "{line}");
+        assert!(line.contains(r#""data_b64":"YWxwaGE=""#), "{line}");
+    }
+
+    #[test]
+    fn output_critical_writer_serializes_shared_writes() {
+        let (server_read, worker_write) = std::io::pipe().expect("server pipe");
+        let writer = OutputCriticalIpcWriter::new(Box::new(worker_write));
+        let second_writer = writer.clone();
+        let (line_tx, line_rx) = mpsc::channel();
+        thread::spawn(move || {
+            let mut reader = std::io::BufReader::new(server_read);
+            for _ in 0..2 {
+                let mut line = String::new();
+                reader.read_line(&mut line).expect("read IPC line");
+                line_tx.send(line).expect("send IPC line");
+            }
+        });
+
+        writer
+            .send(WorkerToServerIpcMessage::OutputText {
+                stream: TextStream::Stdout,
+                data_b64: base64::engine::general_purpose::STANDARD.encode(b"first"),
+            })
+            .expect("send first output_text");
+        second_writer
+            .send(WorkerToServerIpcMessage::OutputText {
+                stream: TextStream::Stderr,
+                data_b64: base64::engine::general_purpose::STANDARD.encode(b"second"),
+            })
+            .expect("send second output_text");
+
+        let first = line_rx
+            .recv_timeout(Duration::from_millis(200))
+            .expect("first IPC line");
+        let second = line_rx
+            .recv_timeout(Duration::from_millis(200))
+            .expect("second IPC line");
+        assert!(first.contains(r#""data_b64":"Zmlyc3Q=""#), "{first}");
+        assert!(second.contains(r#""data_b64":"c2Vjb25k""#), "{second}");
+    }
+
+    #[test]
+    fn synchronous_worker_output_text_reports_broken_pipe() {
+        let (server_read, worker_write) = std::io::pipe().expect("server pipe");
+        drop(server_read);
+        let writer = OutputCriticalIpcWriter::new(Box::new(worker_write));
+
+        let result = writer.send(WorkerToServerIpcMessage::OutputText {
+            stream: TextStream::Stdout,
+            data_b64: base64::engine::general_purpose::STANDARD.encode(b"lost"),
+        });
+
+        assert!(result.is_err(), "broken IPC pipe should be reported");
     }
 
     #[test]

--- a/tests/codex_approvals_tui.rs
+++ b/tests/codex_approvals_tui.rs
@@ -1658,10 +1658,21 @@ tryCatch({
                         if normalized_key == "turn_started_at_unix_ms" {
                             continue;
                         }
+                        if path_matches(path, &["x-codex-turn-metadata"])
+                            && matches!(
+                                normalized_key.as_str(),
+                                "thread_id" | "thread_source" | "model" | "reasoning_effort"
+                            )
+                        {
+                            continue;
+                        }
                         path.push(normalized_key.clone());
                         normalize_inner(&mut child, path, workspace, codex_home);
                         path.pop();
                         map.insert(normalized_key, child);
+                    }
+                    if path_matches(path, &["capabilities", "elicitation"]) && map.is_empty() {
+                        map.insert("form".to_string(), Value::Object(serde_json::Map::new()));
                     }
                 }
                 Value::Array(items) => {
@@ -1745,6 +1756,62 @@ tryCatch({
                 }
             }),
             "wire snapshots should not retain per-run turn timestamps"
+        );
+    }
+
+    #[test]
+    fn normalize_wire_snapshot_drops_volatile_turn_metadata_fields() {
+        let workspace = std::env::temp_dir().join("mcp-repl-wire-workspace");
+        let codex_home = std::env::temp_dir().join("mcp-repl-wire-codex-home");
+        let mut value = serde_json::json!({
+            "x-codex-turn-metadata": {
+                "session_id": "session-1",
+                "thread_id": "019e0388-ee09-70a3-8c94-c356d55b7b49",
+                "thread_source": "user",
+                "turn_id": "turn-1",
+                "sandbox": "seatbelt",
+                "model": "gpt-5.5",
+                "reasoning_effort": "medium"
+            }
+        });
+
+        normalize_wire_snapshot_value(&mut value, &workspace, &codex_home);
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "x-codex-turn-metadata": {
+                    "session_id": "<SESSION_ID>",
+                    "turn_id": "<TURN_ID>",
+                    "sandbox": "<SANDBOX_BACKEND>"
+                }
+            }),
+            "wire snapshots should not retain volatile Codex turn metadata fields"
+        );
+    }
+
+    #[test]
+    fn normalize_wire_snapshot_normalizes_empty_elicitation_capability() {
+        let workspace = std::env::temp_dir().join("mcp-repl-wire-workspace");
+        let codex_home = std::env::temp_dir().join("mcp-repl-wire-codex-home");
+        let mut value = serde_json::json!({
+            "capabilities": {
+                "elicitation": {}
+            }
+        });
+
+        normalize_wire_snapshot_value(&mut value, &workspace, &codex_home);
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "capabilities": {
+                    "elicitation": {
+                        "form": {}
+                    }
+                }
+            }),
+            "wire snapshots should normalize Codex elicitation capability shape"
         );
     }
 

--- a/tests/docs_contracts.rs
+++ b/tests/docs_contracts.rs
@@ -61,6 +61,7 @@ fn worker_sideband_protocol_keeps_plot_images_one_way() {
     let protocol = read(&repo_root().join("docs/worker_sideband_protocol.md"));
 
     for required in [
+        r#"{ "type": "output_text", "stream": <"stdout"|"stderr">, "data_b64": <base64> }"#,
         r#"{ "type": "plot_image", "mime_type": <string>, "data": <base64>, "is_update": <bool>, "source": <string|null> }"#,
         "There is no plot-image acknowledgement message.",
         "Workers must not delay stdout/stderr output waiting for sideband responses.",

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -5,7 +5,7 @@ mod common;
 use common::TestResult;
 use rmcp::model::RawContent;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use tempfile::tempdir;
 use tokio::time::{Duration, Instant, sleep};
@@ -145,6 +145,46 @@ async fn start_python_session() -> TestResult<Option<common::McpTestSession>> {
 const DETACHED_STDIO_HOLDER_SECS: f64 = 2.5;
 
 #[cfg(unix)]
+struct DetachedHolderProbe {
+    _dir: tempfile::TempDir,
+    marker_path: PathBuf,
+}
+
+#[cfg(unix)]
+impl DetachedHolderProbe {
+    fn new() -> TestResult<Self> {
+        let dir = tempdir()?;
+        Ok(Self {
+            marker_path: dir.path().join("holder-exited"),
+            _dir: dir,
+        })
+    }
+
+    fn marker_literal(&self) -> TestResult<String> {
+        let marker = self
+            .marker_path
+            .to_str()
+            .ok_or("detached holder marker path must be valid utf-8")?;
+        Ok(serde_json::to_string(marker)?)
+    }
+
+    async fn wait_for_exit(&self) -> TestResult<()> {
+        wait_for_detached_holder_exit(&self.marker_path).await
+    }
+}
+
+async fn wait_for_detached_holder_exit(marker_path: &Path) -> TestResult<()> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if marker_path.exists() {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    Err(format!("detached holder did not exit: {}", marker_path.display()).into())
+}
+
+#[cfg(unix)]
 fn shutdown_completion_budget() -> Duration {
     if cfg!(target_os = "macos") {
         Duration::from_millis(1_500)
@@ -154,12 +194,19 @@ fn shutdown_completion_budget() -> Duration {
 }
 
 #[cfg(unix)]
-async fn arm_detached_stdio_holder(session: &mut common::McpTestSession) -> TestResult<()> {
+async fn arm_detached_stdio_holder(
+    session: &mut common::McpTestSession,
+) -> TestResult<DetachedHolderProbe> {
+    let holder = DetachedHolderProbe::new()?;
+    let marker_literal = holder.marker_literal()?;
     let setup = session
         .write_stdin_raw_with(
             format!(
                 r#"import subprocess, sys
-script = "import time; time.sleep({DETACHED_STDIO_HOLDER_SECS})"
+script = """import pathlib, time
+time.sleep({DETACHED_STDIO_HOLDER_SECS})
+pathlib.Path({marker_literal}).write_text('done')
+"""
 subprocess.Popen(
     [sys.executable, "-c", script],
     stdin=subprocess.DEVNULL,
@@ -180,16 +227,23 @@ print("detached ready")
         setup_text.contains("detached ready"),
         "expected detached-stdio setup reply, got: {setup_text:?}"
     );
-    Ok(())
+    Ok(holder)
 }
 
 #[cfg(unix)]
-async fn arm_background_ipc_holder(session: &mut common::McpTestSession) -> TestResult<()> {
+async fn arm_background_ipc_holder(
+    session: &mut common::McpTestSession,
+) -> TestResult<DetachedHolderProbe> {
+    let holder = DetachedHolderProbe::new()?;
+    let marker_literal = holder.marker_literal()?;
     let setup = session
         .write_stdin_raw_with(
             format!(
                 r#"import subprocess, sys
-script = "import time; time.sleep({DETACHED_STDIO_HOLDER_SECS})"
+script = """import pathlib, time
+time.sleep({DETACHED_STDIO_HOLDER_SECS})
+pathlib.Path({marker_literal}).write_text('done')
+"""
 subprocess.Popen(
     [sys.executable, "-c", script],
     stdin=subprocess.DEVNULL,
@@ -212,7 +266,7 @@ print("ipc background ready")
         setup_text.contains("ipc background ready"),
         "expected background-ipc setup reply, got: {setup_text:?}"
     );
-    Ok(())
+    Ok(holder)
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -411,11 +465,12 @@ exec("pid = os.fork()\nif pid == 0:\n    os._exit(0)\n_, status = os.waitpid(pid
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread")]
 async fn python_quit_does_not_wait_for_detached_stdio_holders() -> TestResult<()> {
+    let _guard = lock_test_mutex();
     let Some(mut session) = start_python_session().await? else {
         return Ok(());
     };
 
-    arm_detached_stdio_holder(&mut session).await?;
+    let holder = arm_detached_stdio_holder(&mut session).await?;
 
     let start = Instant::now();
     let quit = session.write_stdin_raw_with("quit()", Some(5.0)).await?;
@@ -423,6 +478,7 @@ async fn python_quit_does_not_wait_for_detached_stdio_holders() -> TestResult<()
     let quit_text = result_text(&quit);
     if is_busy_response(&quit_text) {
         eprintln!("python_quit_does_not_wait_for_detached_stdio_holders remained busy on quit");
+        holder.wait_for_exit().await?;
         session.cancel().await?;
         return Ok(());
     }
@@ -440,10 +496,12 @@ async fn python_quit_does_not_wait_for_detached_stdio_holders() -> TestResult<()
         eprintln!(
             "python_quit_does_not_wait_for_detached_stdio_holders remained busy after respawn"
         );
+        holder.wait_for_exit().await?;
         session.cancel().await?;
         return Ok(());
     }
 
+    holder.wait_for_exit().await?;
     session.cancel().await?;
 
     assert!(
@@ -456,6 +514,7 @@ async fn python_quit_does_not_wait_for_detached_stdio_holders() -> TestResult<()
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread")]
 async fn python_respawn_does_not_wait_for_detached_stdio_holders() -> TestResult<()> {
+    let _guard = lock_test_mutex();
     let Some(session) = start_python_session().await? else {
         return Ok(());
     };
@@ -523,11 +582,12 @@ print("detached respawn armed")
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread")]
 async fn python_quit_does_not_wait_for_background_ipc_holders() -> TestResult<()> {
+    let _guard = lock_test_mutex();
     let Some(mut session) = start_python_session().await? else {
         return Ok(());
     };
 
-    arm_background_ipc_holder(&mut session).await?;
+    let holder = arm_background_ipc_holder(&mut session).await?;
 
     let start = Instant::now();
     let quit = session.write_stdin_raw_with("quit()", Some(5.0)).await?;
@@ -535,6 +595,7 @@ async fn python_quit_does_not_wait_for_background_ipc_holders() -> TestResult<()
     let quit_text = result_text(&quit);
     if is_busy_response(&quit_text) {
         eprintln!("python_quit_does_not_wait_for_background_ipc_holders remained busy on quit");
+        holder.wait_for_exit().await?;
         session.cancel().await?;
         return Ok(());
     }
@@ -552,10 +613,12 @@ async fn python_quit_does_not_wait_for_background_ipc_holders() -> TestResult<()
         eprintln!(
             "python_quit_does_not_wait_for_background_ipc_holders remained busy after respawn"
         );
+        holder.wait_for_exit().await?;
         session.cancel().await?;
         return Ok(());
     }
 
+    holder.wait_for_exit().await?;
     session.cancel().await?;
 
     assert!(
@@ -568,6 +631,7 @@ async fn python_quit_does_not_wait_for_background_ipc_holders() -> TestResult<()
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread")]
 async fn python_respawn_does_not_wait_for_background_ipc_holders() -> TestResult<()> {
+    let _guard = lock_test_mutex();
     let Some(session) = start_python_session().await? else {
         return Ok(());
     };
@@ -1051,13 +1115,22 @@ print("parent ready")
 
 #[tokio::test(flavor = "multi_thread")]
 async fn python_idle_exit_preserves_detached_tail_before_respawn() -> TestResult<()> {
+    let _guard = lock_test_mutex();
     let Some(session) = start_python_session().await? else {
         return Ok(());
     };
+    let marker_dir = tempdir()?;
+    let marker_path = marker_dir.path().join("idle-tail-written");
+    let marker = marker_path
+        .to_str()
+        .ok_or("idle marker path must be valid utf-8")?;
+    let marker_literal = serde_json::to_string(marker)?;
 
     let arm = session
         .write_stdin_raw_with(
-            "import os, sys, threading, time; print('armed'); threading.Thread(target=lambda: (time.sleep(0.2), sys.stdout.write('IDLE_TAIL\\n'), sys.stdout.flush(), os._exit(0)), daemon=True).start()",
+            format!(
+                "import os, pathlib, sys, threading, time; print('armed'); threading.Thread(target=lambda: (time.sleep(0.2), sys.stdout.write('IDLE_TAIL\\n'), sys.stdout.flush(), pathlib.Path({marker_literal}).write_text('done'), os._exit(0)), daemon=True).start()"
+            ),
             Some(5.0),
         )
         .await?;
@@ -1074,7 +1147,7 @@ async fn python_idle_exit_preserves_detached_tail_before_respawn() -> TestResult
         "expected arming output, got: {arm_text:?}"
     );
 
-    sleep(Duration::from_millis(500)).await;
+    wait_for_detached_holder_exit(&marker_path).await?;
     let reply = session
         .write_stdin_raw_with("print('AFTER_RESPAWN')", Some(5.0))
         .await?;
@@ -1103,6 +1176,7 @@ async fn python_idle_exit_preserves_detached_tail_before_respawn() -> TestResult
 
 #[tokio::test(flavor = "multi_thread")]
 async fn python_restart_does_not_leak_old_generation_output() -> TestResult<()> {
+    let _guard = lock_test_mutex();
     let Some(session) = start_python_session().await? else {
         return Ok(());
     };

--- a/tests/sandbox_state_updates.rs
+++ b/tests/sandbox_state_updates.rs
@@ -1250,13 +1250,14 @@ async fn sandbox_inherit_pending_interrupt_tail_with_bad_meta_fails_closed() -> 
         "expected rejected interrupt follow-up to leave the old request running, got: {busy_follow_up_text}"
     );
 
-    let mut final_poll_text = String::new();
+    let mut final_poll_text = busy_follow_up_text.clone();
     for _ in 0..20 {
         let final_poll = session
             .write_stdin_raw_with_meta("", Some(0.2), Some(workspace_write_meta(temp.path())))
             .await?;
-        final_poll_text = common::result_text(&final_poll);
-        if !final_poll_text.contains("<<repl status: busy") {
+        let poll_text = common::result_text(&final_poll);
+        final_poll_text.push_str(&poll_text);
+        if !poll_text.contains("<<repl status: busy") && final_poll_text.contains("TAIL") {
             break;
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;

--- a/tests/snapshots/codex_approvals_tui__linux__codex_exec_wire_sandbox_state_meta.snap
+++ b/tests/snapshots/codex_approvals_tui__linux__codex_exec_wire_sandbox_state_meta.snap
@@ -30,7 +30,6 @@ expression: snapshot
           "progressToken": 1,
           "x-codex-turn-metadata": {
             "session_id": "<SESSION_ID>",
-            "thread_source": "user",
             "turn_id": "<TURN_ID>",
             "workspaces": {
               "<WORKSPACE>": {

--- a/tests/snapshots/codex_approvals_tui__macos__codex_exec_wire_sandbox_state_meta.snap
+++ b/tests/snapshots/codex_approvals_tui__macos__codex_exec_wire_sandbox_state_meta.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/codex_approvals_tui.rs
-assertion_line: 2490
 expression: snapshot
 ---
 {
@@ -30,7 +29,6 @@ expression: snapshot
           "progressToken": 1,
           "x-codex-turn-metadata": {
             "session_id": "<SESSION_ID>",
-            "thread_source": "user",
             "turn_id": "<TURN_ID>",
             "workspaces": {
               "<WORKSPACE>": {

--- a/tests/write_stdin_batch.rs
+++ b/tests/write_stdin_batch.rs
@@ -205,12 +205,27 @@ async fn write_stdin_files_multidrain_plot_then_later_stdout_snapshot() -> TestR
 #[cfg(not(windows))]
 #[tokio::test(flavor = "multi_thread")]
 async fn write_stdin_timeout_polling_returns_pending_output() -> TestResult<()> {
-    let session = common::spawn_server().await?;
+    let mut session = common::spawn_server().await?;
+
+    let warmup = session.write_stdin_raw_with("1+1", Some(5.0)).await?;
+    let warmup = common::wait_until_not_busy(
+        &mut session,
+        warmup,
+        Duration::from_millis(100),
+        Duration::from_secs(10),
+    )
+    .await?;
+    let warmup_text = collect_text(&warmup);
+    if backend_unavailable(&warmup_text) {
+        eprintln!("write_stdin_batch backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
 
     let first = session
         .write_stdin_raw_with(
-            "cat(\"start\\n\"); flush.console(); Sys.sleep(1); cat(\"end\\n\")",
-            Some(0.5),
+            "cat(\"start\\n\"); flush.console(); Sys.sleep(2); cat(\"end\\n\")",
+            Some(1.0),
         )
         .await?;
     let first_text = collect_text(&first);
@@ -228,7 +243,7 @@ async fn write_stdin_timeout_polling_returns_pending_output() -> TestResult<()> 
         "expected timeout status marker, got: {first_text:?}"
     );
 
-    let second = session.write_stdin_raw_with("", Some(2.0)).await?;
+    let second = session.write_stdin_raw_with("", Some(3.0)).await?;
     let second_text = collect_text(&second);
     session.cancel().await?;
 


### PR DESCRIPTION
## Summary

This PR adds the protocol foundation for moving worker-owned text output onto ordered IPC.

It introduces:
- `output_text { stream, data_b64 }` worker-to-server IPC messages
- an isolated synchronous output-critical IPC writer that writes, flushes, and reports failures
- protocol docs and focused unit coverage
- an active plan for the remaining R-owned output migration

## Public Facing Changes

No user-facing REPL behavior changes in this slice. Raw stdout/stderr capture and existing non-output IPC behavior remain unchanged.

## Internal Changes

- Adds the `output_text` IPC frame shape.
- Adds a synchronous writer primitive for output-critical IPC messages.
- Documents that raw stdout/stderr capture remains active for unowned output, such as child processes and direct fd writes.
- Records the next slice: append `output_text` directly into the server timelines.

## Testing

- `cargo check`
- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo +nightly fmt`
