### PR TITLE
Consume output_text in server IPC reader

### DIFF
--- a/docs/plans/active/r-owned-output-synchronous-ipc.md
+++ b/docs/plans/active/r-owned-output-synchronous-ipc.md
@@ -9,12 +9,12 @@
 
 - State: active
 - Last updated: 2026-05-07
-- Current phase: phase 1 pending
+- Current phase: phase 2 pending
 
 ## Current Direction
 
-- Add the internal `output_text` frame and synchronous worker IPC writer first.
-- Then teach the server to consume `output_text` as worker-owned text before routing R console callbacks through it.
+- Route R console callbacks and readline echo through `output_text` now that the
+  protocol and server consumption path are in place.
 
 ## Long-Term Direction
 
@@ -24,7 +24,7 @@
 ## Phase Status
 
 - Phase 0: completed - protocol frame and synchronous worker IPC writer.
-- Phase 1: pending - append `output_text` into server timelines.
+- Phase 1: completed - append `output_text` into server timelines.
 - Phase 2: pending - route R console callbacks and readline echo through `output_text`.
 - Phase 3: pending - remove race-tolerant handling that only existed for R-owned output.
 
@@ -40,7 +40,7 @@
 
 ## Next Safe Slice
 
-- Append `output_text` frames directly to the server pending-output tape and output timeline while leaving raw stdout and stderr readers active.
+- Route R console callbacks and readline echo through `output_text`.
 
 ## Stop Conditions
 
@@ -51,3 +51,4 @@
 
 - 2026-05-07: Start with the protocol and synchronous worker writer so later routing can be reviewed separately from server timeline consumption.
 - 2026-05-07: Completed the protocol foundation without changing existing raw stdout/stderr capture or asynchronous non-output IPC sends.
+- 2026-05-07: Completed server-side `output_text` consumption by decoding worker-owned text in the IPC reader and appending it through the existing live output capture path.

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -22,6 +22,7 @@ use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 
 use crate::worker_protocol::TextStream;
@@ -146,6 +147,12 @@ pub struct IpcEchoEvent {
 }
 
 #[derive(Clone)]
+pub struct IpcOutputText {
+    pub stream: TextStream,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Clone)]
 pub struct IpcPlotImage {
     pub id: String,
     pub mime_type: String,
@@ -157,6 +164,7 @@ pub struct IpcPlotImage {
 
 #[derive(Default, Clone)]
 pub struct IpcHandlers {
+    pub on_output_text: Option<Arc<dyn Fn(IpcOutputText) + Send + Sync>>,
     pub on_plot_image: Option<Arc<dyn Fn(IpcPlotImage) + Send + Sync>>,
     pub on_readline_start: Option<Arc<dyn Fn(String) + Send + Sync>>,
     pub on_readline_result: Option<Arc<dyn Fn(IpcEchoEvent) + Send + Sync>>,
@@ -231,6 +239,7 @@ impl ServerIpcConnection {
 
         let reader_inbox = inbox.clone();
         let reader_cvar = cvar.clone();
+        let output_text_handler = handlers.on_output_text.clone();
         let plot_handler = handlers.on_plot_image.clone();
         let readline_start_handler = handlers.on_readline_start.clone();
         let readline_result_handler = handlers.on_readline_result.clone();
@@ -328,6 +337,28 @@ impl ServerIpcConnection {
                         drop(guard);
                         if let Some(handler) = session_end_handler.as_ref() {
                             handler();
+                        }
+                    }
+                    WorkerToServerIpcMessage::OutputText { stream, data_b64 } => {
+                        let bytes =
+                            match base64::engine::general_purpose::STANDARD.decode(&data_b64) {
+                                Ok(bytes) => bytes,
+                                Err(_) => {
+                                    let mut guard = reader_inbox.lock().unwrap();
+                                    guard.disconnected = true;
+                                    reader_cvar.notify_all();
+                                    break;
+                                }
+                            };
+                        if let Some(handler) = output_text_handler.as_ref() {
+                            handler(IpcOutputText { stream, bytes });
+                        } else {
+                            let mut guard = reader_inbox.lock().unwrap();
+                            guard.queue.push_back(WorkerToServerIpcMessage::OutputText {
+                                stream,
+                                data_b64,
+                            });
+                            reader_cvar.notify_all();
                         }
                     }
                     WorkerToServerIpcMessage::PlotImage {
@@ -1407,6 +1438,13 @@ pub fn emit_session_end() {
 
 #[cfg(test)]
 pub(crate) fn test_connection_pair() -> io::Result<(ServerIpcConnection, WorkerIpcConnection)> {
+    test_connection_pair_with_handlers(IpcHandlers::default())
+}
+
+#[cfg(test)]
+pub(crate) fn test_connection_pair_with_handlers(
+    handlers: IpcHandlers,
+) -> io::Result<(ServerIpcConnection, WorkerIpcConnection)> {
     let (server_read, worker_write) = std::io::pipe()?;
     let (worker_read, server_write) = std::io::pipe()?;
     let server = ServerIpcConnection::new(
@@ -1414,7 +1452,7 @@ pub(crate) fn test_connection_pair() -> io::Result<(ServerIpcConnection, WorkerI
             reader: Box::new(server_read),
             writer: Box::new(server_write),
         },
-        IpcHandlers::default(),
+        handlers,
     )?;
     let worker = WorkerIpcConnection::new(IpcTransport {
         reader: Box::new(worker_read),

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -439,6 +439,7 @@ const OUTPUT_READER_QUIESCE_GRACE: Duration = if cfg!(target_os = "macos") {
 } else {
     Duration::from_millis(120)
 };
+#[cfg(target_family = "unix")]
 const OUTPUT_READER_STOP_DRAIN_GRACE: Duration = Duration::from_millis(50);
 
 fn collect_completion_metadata(ipc: &ServerIpcConnection) -> (Option<String>, Vec<String>) {

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -439,6 +439,7 @@ const OUTPUT_READER_QUIESCE_GRACE: Duration = if cfg!(target_os = "macos") {
 } else {
     Duration::from_millis(120)
 };
+const OUTPUT_READER_STOP_DRAIN_GRACE: Duration = Duration::from_millis(50);
 
 fn collect_completion_metadata(ipc: &ServerIpcConnection) -> (Option<String>, Vec<String>) {
     let mut prompt = ipc.try_take_prompt().filter(|value| !value.is_empty());
@@ -5880,15 +5881,12 @@ where
     let (wake_reader, wake_writer) = std::io::pipe()?;
     let (done_tx, done_rx) = mpsc::channel();
     let stop_requested = Arc::new(AtomicBool::new(false));
-    let thread_stop = stop_requested.clone();
     let handle = thread::spawn(move || {
         let mut buffer = [0u8; 8192];
         let stream_fd = stream.as_raw_fd();
         let wake_fd = wake_reader.as_raw_fd();
+        let mut stop_deadline = None;
         loop {
-            if thread_stop.load(Ordering::Relaxed) {
-                break;
-            }
             let mut fds = [
                 libc::pollfd {
                     fd: stream_fd,
@@ -5901,7 +5899,9 @@ where
                     revents: 0,
                 },
             ];
-            let ready = unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::nfds_t, -1) };
+            let timeout_ms = if stop_deadline.is_some() { 0 } else { -1 };
+            let ready =
+                unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::nfds_t, timeout_ms) };
             if ready < 0 {
                 let err = std::io::Error::last_os_error();
                 if err.kind() == std::io::ErrorKind::Interrupted {
@@ -5909,19 +5909,34 @@ where
                 }
                 break;
             }
-            if fds[1].revents != 0 {
+            if ready == 0 {
                 break;
             }
-            if fds[0].revents == 0 {
+            if fds[1].revents != 0 && stop_deadline.is_none() {
+                stop_deadline = Some(std::time::Instant::now() + OUTPUT_READER_STOP_DRAIN_GRACE);
+            }
+            let mut read_stream = false;
+            if fds[0].revents != 0 {
+                match stream.read(&mut buffer) {
+                    Ok(0) => {
+                        break;
+                    }
+                    Ok(n) => {
+                        live_output.append_text(&buffer[..n], output_stream);
+                        read_stream = true;
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+                    Err(_) => break,
+                }
+            }
+            if stop_deadline.is_some_and(|deadline| std::time::Instant::now() >= deadline) {
+                break;
+            }
+            if read_stream {
                 continue;
             }
-            match stream.read(&mut buffer) {
-                Ok(0) => {
-                    break;
-                }
-                Ok(n) => live_output.append_text(&buffer[..n], output_stream),
-                Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
-                Err(_) => break,
+            if stop_deadline.is_some() {
+                break;
             }
         }
         let _ = done_tx.send(());

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -4990,9 +4990,13 @@ impl WorkerProcess {
         let ipc = IpcHandle::new();
         #[cfg(any(target_family = "unix", target_family = "windows"))]
         {
+            let output_capture = live_output.clone();
             let image_capture = live_output.clone();
             let sideband_capture = live_output.clone();
             let handlers = IpcHandlers {
+                on_output_text: Some(Arc::new(move |text| {
+                    output_capture.append_text(&text.bytes, text.stream);
+                })),
                 on_plot_image: Some(Arc::new(move |image: IpcPlotImage| {
                     image_capture.append_image(image);
                 })),
@@ -6143,9 +6147,11 @@ mod tests {
         OUTPUT_RING_CAPACITY_BYTES, OutputEventKind, OutputRing, OutputTextSpan,
         ensure_output_ring, reset_last_reply_marker_offset, reset_output_ring,
     };
+    use crate::pending_output_tape::PendingOutputEvent;
     use crate::sandbox::SandboxPolicy;
     #[cfg(target_os = "linux")]
     use crate::sandbox::sandbox_state_update_from_codex_meta;
+    use base64::Engine as _;
     #[cfg(target_os = "linux")]
     use serde_json::json;
     use std::sync::{Mutex, MutexGuard, OnceLock};
@@ -7879,6 +7885,158 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn files_ipc_output_text_appends_to_tape_and_timeline_in_ipc_order() {
+        let output_ring = Arc::new(OutputRing::with_capacity(OUTPUT_RING_CAPACITY_BYTES));
+        let tape = PendingOutputTape::new();
+        let capture = LiveOutputCapture::new(
+            OversizedOutputMode::Files,
+            tape.clone(),
+            OutputTimeline::new(output_ring.clone()),
+        );
+        let (done_tx, done_rx) = mpsc::channel();
+
+        let output_capture = capture.clone();
+        let start_capture = capture.clone();
+        let result_capture = capture.clone();
+        let image_capture = capture.clone();
+        let session_capture = capture.clone();
+        let (_server, worker) = crate::ipc::test_connection_pair_with_handlers(IpcHandlers {
+            on_output_text: Some(Arc::new(move |text| {
+                output_capture.append_text(&text.bytes, text.stream);
+            })),
+            on_readline_start: Some(Arc::new(move |prompt| {
+                start_capture.append_sideband(PendingSidebandKind::ReadlineStart { prompt });
+            })),
+            on_readline_result: Some(Arc::new(move |event| {
+                result_capture.append_sideband(PendingSidebandKind::ReadlineResult {
+                    prompt: event.prompt,
+                    line: event.line,
+                });
+            })),
+            on_plot_image: Some(Arc::new(move |image| {
+                image_capture.append_image(image);
+            })),
+            on_session_end: Some(Arc::new(move || {
+                session_capture.append_sideband(PendingSidebandKind::SessionEnd);
+                done_tx.send(()).expect("send session end marker");
+            })),
+        })
+        .expect("ipc pair");
+
+        worker
+            .send(WorkerToServerIpcMessage::ReadlineStart {
+                prompt: "> ".to_string(),
+                client_waiting: true,
+            })
+            .expect("send readline_start");
+        worker
+            .send(WorkerToServerIpcMessage::OutputText {
+                stream: TextStream::Stdout,
+                data_b64: base64::engine::general_purpose::STANDARD.encode(b"before\n"),
+            })
+            .expect("send stdout output_text");
+        worker
+            .send(WorkerToServerIpcMessage::ReadlineResult {
+                prompt: "> ".to_string(),
+                line: "plot(1)\n".to_string(),
+            })
+            .expect("send readline_result");
+        worker
+            .send(WorkerToServerIpcMessage::PlotImage {
+                mime_type: "image/png".to_string(),
+                data: "AA==".to_string(),
+                is_update: false,
+                source: None,
+            })
+            .expect("send plot_image");
+        worker
+            .send(WorkerToServerIpcMessage::OutputText {
+                stream: TextStream::Stderr,
+                data_b64: base64::engine::general_purpose::STANDARD.encode(b"err\n"),
+            })
+            .expect("send stderr output_text");
+        worker
+            .send(WorkerToServerIpcMessage::SessionEnd)
+            .expect("send session_end");
+
+        done_rx
+            .recv_timeout(Duration::from_millis(200))
+            .expect("server IPC consumed session_end");
+
+        let snapshot = tape.drain_final_snapshot();
+        assert_eq!(snapshot.events.len(), 6);
+        assert!(matches!(
+            &snapshot.events[0],
+            PendingOutputEvent::Sideband {
+                kind: PendingSidebandKind::ReadlineStart { prompt },
+                ..
+            } if prompt == "> "
+        ));
+        assert!(matches!(
+            &snapshot.events[1],
+            PendingOutputEvent::TextFragment {
+                stream: TextStream::Stdout,
+                origin: ContentOrigin::Worker,
+                bytes,
+                ..
+            } if bytes == b"before\n"
+        ));
+        assert!(matches!(
+            &snapshot.events[2],
+            PendingOutputEvent::Sideband {
+                kind: PendingSidebandKind::ReadlineResult { prompt, line },
+                ..
+            } if prompt == "> " && line == "plot(1)\n"
+        ));
+        assert!(matches!(
+            &snapshot.events[3],
+            PendingOutputEvent::Image {
+                id,
+                mime_type,
+                readline_results_seen: 1,
+                ..
+            } if id.starts_with("image-") && mime_type == "image/png"
+        ));
+        assert!(matches!(
+            &snapshot.events[4],
+            PendingOutputEvent::TextFragment {
+                stream: TextStream::Stderr,
+                origin: ContentOrigin::Worker,
+                bytes,
+                ..
+            } if bytes == b"err\n"
+        ));
+        assert!(matches!(
+            &snapshot.events[5],
+            PendingOutputEvent::Sideband {
+                kind: PendingSidebandKind::SessionEnd,
+                ..
+            }
+        ));
+
+        let end = output_ring.end_offset();
+        let range = output_ring.read_range(0, end);
+        assert_eq!(range.bytes, b"before\n\nstderr: err\n");
+        let image_event = range
+            .events
+            .iter()
+            .find_map(|event| match &event.kind {
+                OutputEventKind::Image {
+                    id,
+                    mime_type,
+                    readline_results_seen,
+                    ..
+                } => Some((event.offset, id, mime_type, readline_results_seen)),
+                _ => None,
+            })
+            .expect("timeline image event");
+        assert_eq!(image_event.0, b"before\n".len() as u64);
+        assert!(image_event.1.starts_with("image-"));
+        assert_eq!(image_event.2, "image/png");
+        assert_eq!(*image_event.3, 1);
     }
 
     #[test]

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -434,7 +434,11 @@ const WINDOWS_IPC_CONNECT_MAX_WAIT: Duration = Duration::from_secs(120);
 const COMPLETION_METADATA_SETTLE_MAX: Duration = Duration::from_millis(30);
 const COMPLETION_METADATA_SETTLE_POLL: Duration = Duration::from_millis(5);
 const COMPLETION_METADATA_STABLE: Duration = Duration::from_millis(10);
-const OUTPUT_READER_QUIESCE_GRACE: Duration = Duration::from_millis(120);
+const OUTPUT_READER_QUIESCE_GRACE: Duration = if cfg!(target_os = "macos") {
+    Duration::from_millis(500)
+} else {
+    Duration::from_millis(120)
+};
 
 fn collect_completion_metadata(ipc: &ServerIpcConnection) -> (Option<String>, Vec<String>) {
     let mut prompt = ipc.try_take_prompt().filter(|value| !value.is_empty());


### PR DESCRIPTION
## Summary

This internal slice teaches the server to consume worker-owned `output_text` IPC frames as authoritative ordered output.

- Decode `output_text { stream, data_b64 }` in the server IPC reader.
- Route decoded bytes through the existing live output capture path.
- Append files-mode text to `PendingOutputTape` and all-mode text to `OutputTimeline`.
- Preserve raw stdout/stderr readers for unowned child-process or direct fd output.
- Make Unix output-reader shutdown drain ready stream bytes before honoring the stop wake.
- Increase the macOS output-reader quiesce grace so exited-worker tail output has more time to drain before forced reader shutdown.
- Update the active plan to mark server-side `output_text` consumption complete.

## Public Facing Changes

None. This is internal protocol, output ordering, and worker-drain plumbing.

## Internal Changes

Adds an `on_output_text` IPC handler and regression coverage showing IPC ordering across `readline_start`, `output_text`, `readline_result`, `plot_image`, and `session_end`.

The output-reader shutdown changes address the PR CI failure where `python_idle_exit_preserves_detached_tail_before_respawn` missed final detached stdout before auto-respawn on `aarch64-apple-darwin`.

## Testing

- `cargo +nightly fmt`
- `cargo test --test python_backend python_idle_exit_preserves_detached_tail_before_respawn`
- `cargo check`
- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- CI: https://github.com/posit-dev/mcp-repl/actions/runs/25520991364
