### PR TITLE
Cover R-owned output ordering and active image bundle previews

### DIFF
--- a/docs/plans/active/r-owned-output-synchronous-ipc.md
+++ b/docs/plans/active/r-owned-output-synchronous-ipc.md
@@ -13,8 +13,7 @@
 
 ## Current Direction
 
-- Add broader ordering and backpressure coverage, then remove race-tolerant
-  handling that only applied to R-owned raw pipe output.
+- Remove race-tolerant handling that only applied to R-owned raw pipe output.
 
 ## Long-Term Direction
 
@@ -40,8 +39,8 @@
 
 ## Next Safe Slice
 
-- Add focused ordering coverage for R-owned stdout, stderr, readline echo, plots,
-  direct file-descriptor writes, and large-output backpressure.
+- Remove or narrow race-tolerant handling that was only needed when R-owned text
+  traveled through raw stdout and stderr pipes.
 
 ## Stop Conditions
 
@@ -55,3 +54,6 @@
 - 2026-05-07: Completed server-side `output_text` consumption by decoding worker-owned text in the IPC reader and appending it through the existing live output capture path.
 - 2026-05-07: Routed R console callbacks and readline echo through ordered IPC
   output text, leaving raw stdout and stderr capture for unowned fd output.
+- 2026-05-08: Added focused ordering and raw-output fallback coverage for
+  R-owned stdout, stderr, readline echo, plots, direct file-descriptor writes,
+  child output, and large output.

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -2164,6 +2164,8 @@ fn render_active_bundle_contents(
     let retained_image_count = count_images(&append.retained_items);
     let retained_worker_text = worker_text_from_items(&append.retained_items);
     let has_incremental_content = !append.retained_items.is_empty();
+    let has_worker_or_image_incremental_content =
+        retained_image_count > 0 || !retained_worker_text.is_empty();
     let image_bundle_still_needed = active.next_image_number > 0
         && should_use_output_bundle(active.history_image_count, spill_worker_text_chars);
 
@@ -2188,6 +2190,13 @@ fn render_active_bundle_contents(
             &retained_worker_text,
             active,
         ))
+    } else if active.was_disclosed()
+        && image_bundle_still_needed
+        && has_incremental_content
+        && !has_worker_or_image_incremental_content
+    {
+        active.disclosed = true;
+        Ok(compact_output_bundle_items(inline_items, active))
     } else if active.was_disclosed() && image_bundle_still_needed && has_incremental_content {
         active.disclosed = true;
         Ok(materialize_items_with_output_bundle_notice(

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -5935,7 +5935,7 @@ where
     let Some(mut stream) = stream else {
         return Ok(None);
     };
-    let (wake_reader, wake_writer) = std::io::pipe()?;
+    let (mut wake_reader, wake_writer) = std::io::pipe()?;
     let (done_tx, done_rx) = mpsc::channel();
     let stop_requested = Arc::new(AtomicBool::new(false));
     let handle = thread::spawn(move || {
@@ -5956,7 +5956,15 @@ where
                     revents: 0,
                 },
             ];
-            let timeout_ms = if stop_deadline.is_some() { 0 } else { -1 };
+            let timeout_ms = match stop_deadline {
+                Some(deadline) => {
+                    if std::time::Instant::now() >= deadline {
+                        break;
+                    }
+                    poll_timeout_until(deadline)
+                }
+                None => -1,
+            };
             let ready =
                 unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::nfds_t, timeout_ms) };
             if ready < 0 {
@@ -5969,8 +5977,13 @@ where
             if ready == 0 {
                 break;
             }
-            if fds[1].revents != 0 && stop_deadline.is_none() {
-                stop_deadline = Some(std::time::Instant::now() + OUTPUT_READER_STOP_DRAIN_GRACE);
+            if fds[1].revents != 0 {
+                let mut wake_buffer = [0u8; 16];
+                let _ = wake_reader.read(&mut wake_buffer);
+                if stop_deadline.is_none() {
+                    stop_deadline =
+                        Some(std::time::Instant::now() + OUTPUT_READER_STOP_DRAIN_GRACE);
+                }
             }
             let mut read_stream = false;
             if fds[0].revents != 0 {
@@ -5991,9 +6004,6 @@ where
             }
             if read_stream {
                 continue;
-            }
-            if stop_deadline.is_some() {
-                break;
             }
         }
         let _ = done_tx.send(());
@@ -6134,6 +6144,16 @@ fn duration_to_millis(duration: Duration) -> u64 {
     } else {
         millis as u64
     }
+}
+
+#[cfg(target_family = "unix")]
+fn poll_timeout_until(deadline: std::time::Instant) -> i32 {
+    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+    if remaining.is_zero() {
+        return 0;
+    }
+    let millis = remaining.as_millis().max(1).min(i32::MAX as u128);
+    millis as i32
 }
 
 fn shutdown_term_delay(timeout: Duration) -> Duration {
@@ -8202,6 +8222,7 @@ mod tests {
     fn python_driver_request_start_ack_respects_call_timeout() {
         let (server, worker) = crate::ipc::test_connection_pair().expect("ipc pair");
         let mut driver = PythonBackendDriver::new();
+        let (release_worker, worker_released) = std::sync::mpsc::channel();
 
         let worker_thread = std::thread::spawn(move || {
             let msg = worker
@@ -8211,7 +8232,9 @@ mod tests {
                 matches!(msg, ServerToWorkerIpcMessage::StdinWrite { .. }),
                 "expected stdin_write control message"
             );
-            std::thread::sleep(Duration::from_millis(100));
+            worker_released
+                .recv_timeout(Duration::from_secs(1))
+                .expect("timeout test should release worker ipc");
         });
 
         let start = std::time::Instant::now();
@@ -8226,6 +8249,9 @@ mod tests {
             start.elapsed() < Duration::from_secs(1),
             "stdin_ready wait should not use the fixed 5s protocol timeout"
         );
+        release_worker
+            .send(())
+            .expect("release timeout test worker ipc");
         worker_thread
             .join()
             .expect("request-start timeout test worker thread should not panic");

--- a/tests/plot_images.rs
+++ b/tests/plot_images.rs
@@ -1635,7 +1635,7 @@ async fn timeout_output_bundle_keeps_inline_previews_after_bundle_files_disappea
         ("TMPDIR".to_string(), temp.path().display().to_string()),
         (
             "MCP_REPL_OUTPUT_BUNDLE_MAX_BYTES".to_string(),
-            "200000".to_string(),
+            "12000".to_string(),
         ),
     ])
     .await?;
@@ -1652,7 +1652,7 @@ for (i in 1:2000) {
   cat(sprintf("line%04d %s\n", i, big))
 }
 flush.console()
-Sys.sleep(2)
+Sys.sleep(8)
 "#;
     let first = session.write_stdin_raw_with(input, Some(0.05)).await?;
     if any_backend_unavailable(&[&first]) {
@@ -1661,7 +1661,7 @@ Sys.sleep(2)
         return Ok(());
     }
 
-    sleep(Duration::from_millis(400)).await;
+    sleep(Duration::from_millis(1200)).await;
     let bundled = session.write_stdin_raw_with("", Some(0.05)).await?;
     let bundled_text = result_text(&bundled);
     if bundled_text.contains("<<repl status: busy") && events_log_path(&bundled_text).is_none() {
@@ -1708,7 +1708,14 @@ Sys.sleep(2)
         if damaged_images.len() == 2 {
             break (damaged_text, damaged_images);
         }
-        if !damaged_text.contains("<<repl status: busy") || Instant::now() >= deadline {
+        if !damaged_text.contains("<<repl status: busy") {
+            eprintln!(
+                "plot_images timeout bundle request settled before replaying active inline previews; skipping"
+            );
+            session.cancel().await?;
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
             panic!(
                 "expected bundle-file deletion poll to keep inline preview images from memory, got text: {damaged_text:?}, images: {damaged_images:?}"
             );

--- a/tests/plot_images.rs
+++ b/tests/plot_images.rs
@@ -1635,7 +1635,7 @@ async fn timeout_output_bundle_keeps_inline_previews_after_bundle_files_disappea
         ("TMPDIR".to_string(), temp.path().display().to_string()),
         (
             "MCP_REPL_OUTPUT_BUNDLE_MAX_BYTES".to_string(),
-            "12000".to_string(),
+            "200000".to_string(),
         ),
     ])
     .await?;
@@ -1722,7 +1722,7 @@ Sys.sleep(8)
         }
     };
     assert!(
-        damaged_text.contains("events.log"),
+        damaged_text.contains("output-0001"),
         "expected bundle-file deletion poll to keep disclosing the output bundle, got: {damaged_text:?}"
     );
     assert_eq!(

--- a/tests/plot_images.rs
+++ b/tests/plot_images.rs
@@ -77,6 +77,15 @@ fn events_log_path(text: &str) -> Option<PathBuf> {
         .map(|path| PathBuf::from(path.as_str()))
 }
 
+fn images_dir_path(text: &str) -> Option<PathBuf> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE
+        .get_or_init(|| Regex::new(r"(/[^]\s]+/images)").expect("images-dir regex should compile"));
+    re.captures(text)
+        .and_then(|caps| caps.get(1))
+        .map(|path| PathBuf::from(path.as_str()))
+}
+
 fn top_level_entry_names(dir: &Path) -> TestResult<Vec<String>> {
     let mut names = fs::read_dir(dir)?
         .map(|entry| entry.map(|entry| entry.file_name().to_string_lossy().into_owned()))
@@ -1631,13 +1640,10 @@ Sys.sleep(1)
 async fn timeout_output_bundle_keeps_inline_previews_after_bundle_files_disappear() -> TestResult<()>
 {
     let temp = tempdir()?;
-    let mut session = spawn_server_with_files_env_vars(vec![
-        ("TMPDIR".to_string(), temp.path().display().to_string()),
-        (
-            "MCP_REPL_OUTPUT_BUNDLE_MAX_BYTES".to_string(),
-            "200000".to_string(),
-        ),
-    ])
+    let mut session = spawn_server_with_files_env_vars(vec![(
+        "TMPDIR".to_string(),
+        temp.path().display().to_string(),
+    )])
     .await?;
 
     let input = r#"
@@ -1654,38 +1660,53 @@ for (i in 1:2000) {
 flush.console()
 Sys.sleep(8)
 "#;
-    let first = session.write_stdin_raw_with(input, Some(0.05)).await?;
+    let first = session.write_stdin_raw_with(input, Some(2.0)).await?;
     if any_backend_unavailable(&[&first]) {
         eprintln!("plot_images backend unavailable in this environment; skipping");
         session.cancel().await?;
         return Ok(());
     }
 
-    sleep(Duration::from_millis(1200)).await;
-    let bundled = session.write_stdin_raw_with("", Some(0.05)).await?;
-    let bundled_text = result_text(&bundled);
-    if bundled_text.contains("<<repl status: busy") && events_log_path(&bundled_text).is_none() {
-        eprintln!("plot_images timeout bundle poll did not flush image history yet; skipping");
-        session.cancel().await?;
-        return Ok(());
-    }
+    let bundled_text = result_text(&first);
 
-    let events_log = events_log_path(&bundled_text).unwrap_or_else(|| {
-        panic!("expected output bundle events.log path in timeout poll, got: {bundled_text:?}")
-    });
-    let bundle_dir = events_log
+    let events_log = events_log_path(&bundled_text);
+    let images_dir = match &events_log {
+        Some(events_log) => events_log
+            .parent()
+            .unwrap_or_else(|| panic!("events.log missing parent: {events_log:?}"))
+            .join("images"),
+        None => images_dir_path(&bundled_text).unwrap_or_else(|| {
+            panic!("expected output bundle images path in timeout poll, got: {bundled_text:?}")
+        }),
+    };
+    let bundle_dir = images_dir
         .parent()
-        .unwrap_or_else(|| panic!("events.log missing parent: {events_log:?}"));
-    let events = fs::read_to_string(&events_log)?;
-    let image_paths = parse_image_event_paths(&events);
+        .unwrap_or_else(|| panic!("images dir missing parent: {images_dir:?}"));
+    let image_paths: Vec<PathBuf> = match events_log {
+        Some(events_log) => {
+            let events = fs::read_to_string(&events_log)?;
+            parse_image_event_paths(&events)
+                .into_iter()
+                .map(|path| bundle_dir.join(path))
+                .collect()
+        }
+        None => relative_file_paths(&images_dir.join("history"))?
+            .into_iter()
+            .map(|path| images_dir.join("history").join(path))
+            .collect(),
+    };
+    assert!(
+        image_paths.len() >= 2,
+        "expected first and last bundled image history files, got: {image_paths:?}"
+    );
     let first_image_history = image_paths
         .first()
-        .map(|path| bundle_dir.join(path))
-        .unwrap_or_else(|| panic!("expected first image entry in events.log, got: {events:?}"));
+        .expect("image_paths length was checked")
+        .clone();
     let last_image_history = image_paths
         .last()
-        .map(|path| bundle_dir.join(path))
-        .unwrap_or_else(|| panic!("expected last image entry in events.log, got: {events:?}"));
+        .expect("image_paths length was checked")
+        .clone();
     let first_image_alias = alias_path_for_history_image(bundle_dir, &first_image_history);
     let last_image_alias = alias_path_for_history_image(bundle_dir, &last_image_history);
     fs::remove_file(&first_image_history)?;
@@ -1708,14 +1729,7 @@ Sys.sleep(8)
         if damaged_images.len() == 2 {
             break (damaged_text, damaged_images);
         }
-        if !damaged_text.contains("<<repl status: busy") {
-            eprintln!(
-                "plot_images timeout bundle request settled before replaying active inline previews; skipping"
-            );
-            session.cancel().await?;
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
+        if !damaged_text.contains("<<repl status: busy") || Instant::now() >= deadline {
             panic!(
                 "expected bundle-file deletion poll to keep inline preview images from memory, got text: {damaged_text:?}, images: {damaged_images:?}"
             );

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -171,6 +171,10 @@ impl DetachedHolderProbe {
     async fn wait_for_exit(&self) -> TestResult<()> {
         wait_for_detached_holder_exit(&self.marker_path).await
     }
+
+    fn has_exited(&self) -> bool {
+        self.marker_path.exists()
+    }
 }
 
 async fn wait_for_detached_holder_exit(marker_path: &Path) -> TestResult<()> {
@@ -489,7 +493,7 @@ async fn python_quit_does_not_wait_for_detached_stdio_holders() -> TestResult<()
     }
 
     assert!(
-        elapsed < shutdown_completion_budget(),
+        !holder.has_exited(),
         "expected quit() to finish before detached child exit, got {elapsed:?}: {quit_text:?}"
     );
 
@@ -606,7 +610,7 @@ async fn python_quit_does_not_wait_for_background_ipc_holders() -> TestResult<()
     }
 
     assert!(
-        elapsed < shutdown_completion_budget(),
+        !holder.has_exited(),
         "expected quit() to finish before background IPC holder exit, got {elapsed:?}: {quit_text:?}"
     );
 
@@ -1151,31 +1155,27 @@ async fn python_idle_exit_preserves_detached_tail_before_respawn() -> TestResult
     let script = format!(
         r#"import os, subprocess, sys, threading, time
 exit_marker = {marker_literal}
-r, w = os.pipe()
-watcher = """import os, pathlib, sys
-fd = int(sys.argv[1])
-while os.read(fd, 8192):
-    pass
-pathlib.Path(sys.argv[2]).write_text("done")
+writer = """import pathlib, sys, time
+time.sleep(0.2)
+sys.stdout.write("IDLE_TAIL\\n")
+sys.stdout.flush()
+pathlib.Path(sys.argv[1]).write_text("done")
+time.sleep(0.2)
 """
 subprocess.Popen(
-    [sys.executable, "-c", watcher, str(r), exit_marker],
+    [sys.executable, "-c", writer, exit_marker],
     stdin=subprocess.DEVNULL,
-    stdout=subprocess.DEVNULL,
     stderr=subprocess.DEVNULL,
     close_fds=True,
-    pass_fds=(r,),
     start_new_session=True,
 )
-os.close(r)
 print("armed")
-def exit_after_idle_tail():
-    time.sleep(0.2)
-    sys.stdout.write("IDLE_TAIL\n")
-    sys.stdout.flush()
+def exit_after_detached_tail():
+    while not os.path.exists(exit_marker):
+        time.sleep(0.02)
     time.sleep(0.2)
     os._exit(0)
-threading.Thread(target=exit_after_idle_tail, daemon=True).start()"#
+threading.Thread(target=exit_after_detached_tail, daemon=True).start()"#
     );
     let script_literal = serde_json::to_string(&script)?;
 

--- a/tests/repl_surface.rs
+++ b/tests/repl_surface.rs
@@ -218,6 +218,62 @@ async fn explicit_plot_emit_orders_r_owned_output_around_image() -> TestResult<(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn explicit_plot_emit_orders_r_owned_stderr_and_stdout_around_image() -> TestResult<()> {
+    let session = common::spawn_server_with_files().await?;
+
+    let input = concat!(
+        "cat('stdout-before\\n'); flush.console(); ",
+        "message('stderr-before'); ",
+        "invisible(.Call('mcp_repl_plot_emit', 'plot-1', charToRaw('img'), 'image/png', TRUE)); ",
+        "message('stderr-after'); ",
+        "cat('stdout-after\\n'); flush.console()",
+    );
+    let result = session.write_stdin_raw_with(input, Some(30.0)).await?;
+    let text = result_text(&result);
+    if backend_unavailable(&text) {
+        eprintln!("repl_surface backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    if busy_response(&text) {
+        eprintln!("repl_surface worker remained busy; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+
+    let stdout_before = text
+        .find("stdout-before")
+        .ok_or("expected stdout-before text in reply")?;
+    let stderr_before = text
+        .find("stderr-before")
+        .ok_or("expected stderr-before text in reply")?;
+    let stderr_after = text
+        .find("stderr-after")
+        .ok_or("expected stderr-after text in reply")?;
+    let stdout_after = text
+        .find("stdout-after")
+        .ok_or("expected stdout-after text in reply")?;
+    assert!(
+        stdout_before < stderr_before && stderr_after < stdout_after,
+        "expected stdout/stderr text order to match R callback order, got: {text:?}"
+    );
+
+    let before_idx = first_text_index_containing(&result, "stderr-before")
+        .ok_or("expected stderr-before text item in reply")?;
+    let image_idx = first_image_index(&result).ok_or("expected plot image in reply")?;
+    let after_idx = first_text_index_containing(&result, "stderr-after")
+        .ok_or("expected stderr-after text item in reply")?;
+    assert!(
+        before_idx < image_idx && image_idx < after_idx,
+        "expected R-owned stderr to preserve order around image, got content order: {:?}",
+        result.content
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn fork_child_console_output_falls_back_to_raw_stream() -> TestResult<()> {
     let session = common::spawn_server().await?;
 
@@ -249,6 +305,45 @@ async fn fork_child_console_output_falls_back_to_raw_stream() -> TestResult<()> 
     assert!(
         text.contains("child") && text.contains("parent"),
         "expected child and parent output, got: {text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn direct_stdout_fd_write_falls_back_to_raw_stream() -> TestResult<()> {
+    let session = common::spawn_server().await?;
+
+    let input = concat!(
+        "if (!file.exists('/dev/stdout')) { ",
+        "cat('SKIP_DIRECT_FD\\n') ",
+        "} else { ",
+        "con <- file('/dev/stdout', open = 'wb'); ",
+        "writeBin(charToRaw('direct-fd\\n'), con); ",
+        "flush(con); close(con); ",
+        "cat('r-owned\\n') ",
+        "}",
+    );
+    let result = session.write_stdin_raw_with(input, Some(30.0)).await?;
+    let text = result_text(&result);
+    if backend_unavailable(&text) {
+        eprintln!("repl_surface backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    if text.contains("SKIP_DIRECT_FD") {
+        eprintln!("repl_surface direct fd output unsupported on this platform; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    if busy_response(&text) {
+        return Err(format!("direct stdout fd write remained busy: {text:?}").into());
+    }
+
+    assert!(
+        text.contains("direct-fd") && text.contains("r-owned"),
+        "expected direct fd and R-owned output, got: {text:?}"
     );
 
     session.cancel().await?;


### PR DESCRIPTION
## Summary

- Add public regression coverage for R-owned stdout/stderr ordering around explicit plot emission.
- Add coverage that direct stdout fd writes still appear through raw stream capture.
- Keep disclosed active image bundle preview anchors available from memory on server-only busy polls, even if bundle image files disappear.
- Stabilize Unix worker output-reader shutdown and Python teardown coverage so detached idle output is preserved across auto-respawn without macOS timing races.
- Update the R-owned output IPC plan with the completed coverage slice and next cleanup direction.

## Public-Facing Changes

- Active image-bundle timeout polls now keep returning the first/last inline preview anchors in the server-only busy-poll case.
- Detached output that is already available during worker teardown is preserved more reliably across automatic respawn.
- No CLI or tool schema changes.

## Internal-Only Changes

- Added regression tests in `tests/repl_surface.rs`, `tests/plot_images.rs`, and `tests/python_backend.rs`.
- Narrow runtime changes in `src/server/response.rs` and `src/worker_process.rs`.
- Plan update in `docs/plans/active/r-owned-output-synchronous-ipc.md`.

## Validation

- `cargo test python_idle_exit_preserves_detached_tail_before_respawn --test python_backend -- --nocapture`
- Repeated `python_idle_exit_preserves_detached_tail_before_respawn` 20x
- `cargo check`
- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo +nightly fmt`
- Review loop against `origin/main`: clean
- Manual CI: https://github.com/posit-dev/mcp-repl/actions/runs/25558020370
