### PR TITLE
Narrow files-mode echo carryover by source

### DIFF
--- a/docs/output_timeline.md
+++ b/docs/output_timeline.md
@@ -85,10 +85,11 @@ That matching is only opportunistic:
 - if exact sideband-to-stdout matching fails or becomes ambiguous, the server
   should degrade softly to raw captured stdout/stderr for that region, without
   eliding echo or inventing a cleaned-up transcript
-- sideband-first carryover is source-aware: Python-style raw prompt echo can
-  trim only raw text, and R-style prompt echo can trim only `output_text` frames
-  when an IPC reader drain boundary splits `readline_result` from the following
-  worker-owned echo
+- sideband-first carryover is source-aware: the backend records whether a
+  `readline_result` echo should arrive as raw stdout or as `output_text`, and
+  carryover only trims later text from that same source. Prompt spelling only
+  decides whether a prompt shape is eligible for carryover; it does not decide
+  the source.
 
 ## Ownership split
 

--- a/docs/output_timeline.md
+++ b/docs/output_timeline.md
@@ -1,19 +1,22 @@
 # Output Timeline
 
 This document explains how `mcp-repl` reconstructs visible REPL output from the
-worker's separate text pipes and sideband IPC stream.
+worker IPC stream plus any raw text that still arrives on stdout or stderr.
 
 ## Why this exists
 
 The worker emits different kinds of information on different channels:
 
-- stdout/stderr bytes travel on the normal process pipes.
+- Worker-owned text may travel as ordered `output_text` IPC frames.
+- Raw stdout/stderr bytes still capture unowned output from child processes,
+  direct file-descriptor writes, or backends that use a PTY.
 - Sideband IPC carries structural events such as `readline_start`,
   `readline_result`, `plot_image`, and `session_end`.
 
-Those channels do not arrive at the server in one globally ordered stream.
+Raw pipes and IPC do not arrive at the server in one globally ordered stream.
 The server therefore maintains its own output timeline and resolves it into the
-user-visible order when building a reply.
+user-visible order when building a reply. Worker-owned `output_text` frames do
+share IPC order with structural sideband facts.
 
 ## Current model
 
@@ -24,7 +27,8 @@ changes what must stay buffered between tool calls.
 
 - `src/pending_output_tape.rs` stores a mixed event tape for the current pending
   reply.
-- Worker stdout/stderr bytes are buffered as `TextFragment` events.
+- Worker-owned `output_text` frames and raw stdout/stderr bytes are buffered as
+  `TextFragment` events.
 - Sideband events are stored alongside text so later formatting can suppress
   echoed input and respect request boundaries.
 - When a reply is sealed, `PendingOutputSnapshot::format_contents()` converts the
@@ -74,22 +78,28 @@ Echo matching must be driven by the sideband facts themselves:
 
 That matching is only opportunistic:
 
-- the stdout/stderr pipes remain the authoritative visible text stream
+- raw stdout/stderr remains authoritative for text that did not arrive through
+  `output_text`
 - forked children, spawned subprocesses, or other writers may interleave with
   or corrupt what would otherwise have been a clean echoed line
 - if exact sideband-to-stdout matching fails or becomes ambiguous, the server
   should degrade softly to raw captured stdout/stderr for that region, without
   eliding echo or inventing a cleaned-up transcript
+- sideband-first carryover is reserved for raw prompt echo that can still arrive
+  after its `readline_result`, such as Python PTY echo; ordinary R-owned echo is
+  ordered IPC text and is resolved within the mixed timeline for the current
+  snapshot
 
 ## Ownership split
 
 - The worker is responsible for running the normal backend REPL and reporting the
   sideband facts it directly observes.
 - The server is responsible for timeline reconstruction.
-- The worker must not try to solve cross-channel ordering by pretending to know
-  exactly when stdout bytes became visible to the server.
-- The worker also must not delay stdout/stderr on sideband responses. Sideband
-  IPC reports facts; it is not backpressure for the visible text streams.
+- The worker must not try to solve raw pipe cross-channel ordering by pretending
+  to know exactly when stdout bytes became visible to the server.
+- The worker also must not delay raw stdout/stderr on sideband responses.
+  Sideband IPC reports facts; it is not backpressure for raw visible text
+  streams.
 
 In practice, that means image-vs-stdout ordering fixes belong in server timeline
 resolution, not in the wire protocol.

--- a/docs/output_timeline.md
+++ b/docs/output_timeline.md
@@ -85,10 +85,10 @@ That matching is only opportunistic:
 - if exact sideband-to-stdout matching fails or becomes ambiguous, the server
   should degrade softly to raw captured stdout/stderr for that region, without
   eliding echo or inventing a cleaned-up transcript
-- sideband-first carryover is reserved for raw prompt echo that can still arrive
-  after its `readline_result`, such as Python PTY echo; ordinary R-owned echo is
-  ordered IPC text and is resolved within the mixed timeline for the current
-  snapshot
+- sideband-first carryover is source-aware: Python-style raw prompt echo can
+  trim only raw text, and R-style prompt echo can trim only `output_text` frames
+  when an IPC reader drain boundary splits `readline_result` from the following
+  worker-owned echo
 
 ## Ownership split
 

--- a/docs/plans/active/r-owned-output-synchronous-ipc.md
+++ b/docs/plans/active/r-owned-output-synchronous-ipc.md
@@ -60,6 +60,7 @@
   R-owned stdout, stderr, readline echo, plots, direct file-descriptor writes,
   child output, and large output.
 - 2026-05-08: Narrowed files-mode sideband-first echo carryover so ordinary R
-  prompts no longer trim later raw stdout. R-owned `output_text` echo remains
-  eligible for source-aware carryover when a drain boundary splits it from its
-  `readline_result`.
+  prompts no longer trim later raw stdout. The backend now records the expected
+  echo source on `readline_result`, so Python raw prompt echo and R-owned
+  `output_text` echo can both carry across drain boundaries without deriving
+  the source from prompt spelling.

--- a/docs/plans/active/r-owned-output-synchronous-ipc.md
+++ b/docs/plans/active/r-owned-output-synchronous-ipc.md
@@ -25,8 +25,9 @@
 - Phase 0: completed - protocol frame and synchronous worker IPC writer.
 - Phase 1: completed - append `output_text` into server timelines.
 - Phase 2: completed - route R console callbacks and readline echo through `output_text`.
-- Phase 3: in progress - R prompt carryover removed from the files-mode
-  sideband-first fallback; remaining carryover is for non-R raw prompt echo.
+- Phase 3: in progress - R-shaped raw stdout is no longer trimmed by files-mode
+  sideband-first carryover; R-owned `output_text` echo still has source-aware
+  carryover for drain boundaries.
 
 ## Locked Decisions
 
@@ -40,8 +41,8 @@
 
 ## Next Safe Slice
 
-- Review remaining prompt-fallback cleanup in `src/worker_process.rs` and keep
-  any fallback documented as non-R raw pipe behavior.
+- Review remaining prompt-fallback cleanup in `src/worker_process.rs`; keep raw
+  pipe fallback separate from source-aware IPC echo carryover.
 
 ## Stop Conditions
 
@@ -59,5 +60,6 @@
   R-owned stdout, stderr, readline echo, plots, direct file-descriptor writes,
   child output, and large output.
 - 2026-05-08: Narrowed files-mode sideband-first echo carryover so ordinary R
-  prompts no longer trim later raw stdout. Python-style raw prompt echo remains
-  eligible for carryover.
+  prompts no longer trim later raw stdout. R-owned `output_text` echo remains
+  eligible for source-aware carryover when a drain boundary splits it from its
+  `readline_result`.

--- a/docs/plans/active/r-owned-output-synchronous-ipc.md
+++ b/docs/plans/active/r-owned-output-synchronous-ipc.md
@@ -8,8 +8,8 @@
 ## Status
 
 - State: active
-- Last updated: 2026-05-07
-- Current phase: phase 3 pending
+- Last updated: 2026-05-08
+- Current phase: phase 3 in progress
 
 ## Current Direction
 
@@ -25,7 +25,8 @@
 - Phase 0: completed - protocol frame and synchronous worker IPC writer.
 - Phase 1: completed - append `output_text` into server timelines.
 - Phase 2: completed - route R console callbacks and readline echo through `output_text`.
-- Phase 3: pending - remove race-tolerant handling that only existed for R-owned output.
+- Phase 3: in progress - R prompt carryover removed from the files-mode
+  sideband-first fallback; remaining carryover is for non-R raw prompt echo.
 
 ## Locked Decisions
 
@@ -39,8 +40,8 @@
 
 ## Next Safe Slice
 
-- Remove or narrow race-tolerant handling that was only needed when R-owned text
-  traveled through raw stdout and stderr pipes.
+- Review remaining prompt-fallback cleanup in `src/worker_process.rs` and keep
+  any fallback documented as non-R raw pipe behavior.
 
 ## Stop Conditions
 
@@ -57,3 +58,6 @@
 - 2026-05-08: Added focused ordering and raw-output fallback coverage for
   R-owned stdout, stderr, readline echo, plots, direct file-descriptor writes,
   child output, and large output.
+- 2026-05-08: Narrowed files-mode sideband-first echo carryover so ordinary R
+  prompts no longer trim later raw stdout. Python-style raw prompt echo remains
+  eligible for carryover.

--- a/src/pending_output_tape.rs
+++ b/src/pending_output_tape.rs
@@ -21,7 +21,7 @@ struct PendingOutputTapeInner {
     stdout_tail: PendingTextTail,
     stderr_tail: PendingTextTail,
     drained_readline_results: usize,
-    pending_echo_prefix: String,
+    pending_echo_prefix: Option<PendingEchoPrefix>,
     last_rendered_text: Option<RenderedTextState>,
 }
 
@@ -29,6 +29,7 @@ struct PendingOutputTapeInner {
 struct PendingTextTail {
     bytes: Vec<u8>,
     origin: Option<ContentOrigin>,
+    source: Option<PendingTextSource>,
     start_seq: Option<u64>,
 }
 
@@ -38,6 +39,7 @@ pub(crate) enum PendingOutputEvent {
         seq: u64,
         stream: TextStream,
         origin: ContentOrigin,
+        source: PendingTextSource,
         bytes: Vec<u8>,
         terminated: bool,
     },
@@ -85,7 +87,7 @@ pub(crate) enum PendingSidebandKind {
 pub(crate) struct PendingOutputSnapshot {
     pub events: Vec<PendingOutputEvent>,
     readline_result_base: usize,
-    leading_echo_prefix: Option<String>,
+    leading_echo_prefix: Option<PendingEchoPrefix>,
     prior_rendered_text: Option<RenderedTextState>,
 }
 
@@ -109,6 +111,18 @@ struct RenderedTextState {
     terminated: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PendingTextSource {
+    Raw,
+    Ipc,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PendingEchoPrefix {
+    text: String,
+    source: PendingTextSource,
+}
+
 struct RenderedPendingOutput {
     range: OutputRange,
     echo_events: Vec<IpcEchoEvent>,
@@ -122,15 +136,48 @@ impl PendingOutputTape {
     }
 
     pub(crate) fn append_stdout_bytes(&self, bytes: &[u8]) {
-        self.append_bytes(bytes, TextStream::Stdout, ContentOrigin::Worker);
+        self.append_bytes(
+            bytes,
+            TextStream::Stdout,
+            ContentOrigin::Worker,
+            PendingTextSource::Raw,
+        );
+    }
+
+    pub(crate) fn append_stdout_ipc_bytes(&self, bytes: &[u8]) {
+        self.append_bytes(
+            bytes,
+            TextStream::Stdout,
+            ContentOrigin::Worker,
+            PendingTextSource::Ipc,
+        );
     }
 
     pub(crate) fn append_stderr_bytes(&self, bytes: &[u8]) {
-        self.append_bytes(bytes, TextStream::Stderr, ContentOrigin::Worker);
+        self.append_bytes(
+            bytes,
+            TextStream::Stderr,
+            ContentOrigin::Worker,
+            PendingTextSource::Raw,
+        );
+    }
+
+    pub(crate) fn append_stderr_ipc_bytes(&self, bytes: &[u8]) {
+        self.append_bytes(
+            bytes,
+            TextStream::Stderr,
+            ContentOrigin::Worker,
+            PendingTextSource::Ipc,
+        );
     }
 
     pub(crate) fn append_server_stderr_bytes(&self, bytes: &[u8]) {
-        self.append_bytes(bytes, TextStream::Stderr, ContentOrigin::Server);
+        self.append_bytes(
+            bytes,
+            TextStream::Stderr,
+            ContentOrigin::Server,
+            PendingTextSource::Raw,
+        );
     }
 
     pub(crate) fn append_server_stderr_status_line(&self, bytes: &[u8]) {
@@ -156,6 +203,7 @@ impl PendingOutputTape {
             &mut guard,
             TextStream::Stderr,
             ContentOrigin::Server,
+            PendingTextSource::Raw,
             &status_line,
         );
     }
@@ -183,6 +231,7 @@ impl PendingOutputTape {
             &mut guard,
             TextStream::Stdout,
             ContentOrigin::Server,
+            PendingTextSource::Raw,
             &status_line,
         );
     }
@@ -350,24 +399,25 @@ impl PendingOutputTape {
         guard.drained_readline_results = guard
             .drained_readline_results
             .saturating_add(drained_readline_results);
-        // `pending_echo_prefix` only carries non-R raw REPL echo that was
-        // observed sideband-first in an earlier drain. R-owned echo now travels
-        // through ordered `output_text` frames and is resolved in the current
-        // mixed text/event timeline below.
-        let leading_echo_prefix =
-            (!guard.pending_echo_prefix.is_empty()).then(|| guard.pending_echo_prefix.clone());
+        // `pending_echo_prefix` only carries echo that was observed
+        // sideband-first in an earlier drain. Raw Python prompt echo and
+        // R-owned IPC echo use the same visible bytes, but they must only trim
+        // text delivered on their own channel.
+        let leading_echo_prefix = guard.pending_echo_prefix.clone();
         append_readline_results_to_echo_prefix(&mut guard.pending_echo_prefix, &events);
-        if !guard.pending_echo_prefix.is_empty() {
-            let echo_prefix = guard.pending_echo_prefix.clone();
+        if let Some(echo_prefix) = guard.pending_echo_prefix.clone() {
             let (matched_bytes, keep_remaining_suffix) =
-                leading_echo_match_progress(&events, &echo_prefix);
+                leading_echo_match_progress(&events, &echo_prefix.text, echo_prefix.source);
             if keep_remaining_suffix
                 && !(snapshot_has_no_visible_text(&events)
                     && snapshot_crossed_request_boundary(&events))
             {
-                guard.pending_echo_prefix = echo_prefix[matched_bytes..].to_string();
+                guard.pending_echo_prefix = Some(PendingEchoPrefix {
+                    text: echo_prefix.text[matched_bytes..].to_string(),
+                    source: echo_prefix.source,
+                });
             } else {
-                guard.pending_echo_prefix.clear();
+                guard.pending_echo_prefix = None;
             }
         }
         if snapshot_crossed_request_boundary(&events) {
@@ -382,7 +432,13 @@ impl PendingOutputTape {
         }
     }
 
-    fn append_bytes(&self, bytes: &[u8], stream: TextStream, origin: ContentOrigin) {
+    fn append_bytes(
+        &self,
+        bytes: &[u8],
+        stream: TextStream,
+        origin: ContentOrigin,
+        source: PendingTextSource,
+    ) {
         if bytes.is_empty() {
             return;
         }
@@ -395,6 +451,9 @@ impl PendingOutputTape {
         if tail_mut(&mut guard, stream)
             .origin
             .is_some_and(|tail_origin| tail_origin != origin)
+            || tail_mut(&mut guard, stream)
+                .source
+                .is_some_and(|tail_source| tail_source != source)
         {
             flush_tail(&mut guard, stream, true);
         }
@@ -406,6 +465,9 @@ impl PendingOutputTape {
         let tail = tail_mut(&mut guard, stream);
         if tail.origin.is_none() {
             tail.origin = Some(origin);
+        }
+        if tail.source.is_none() {
+            tail.source = Some(source);
         }
         tail.bytes.extend_from_slice(bytes);
         commit_complete_lines(&mut guard, stream);
@@ -442,7 +504,11 @@ impl PendingOutputSnapshot {
             collapsed.text_spans,
             source_end,
         );
-        maybe_trim_leading_echo_prefix(self.leading_echo_prefix.as_deref(), &mut contents);
+        maybe_trim_leading_echo_prefix(
+            self.leading_echo_prefix.as_ref(),
+            &self.events,
+            &mut contents,
+        );
         FormattedPendingOutput {
             contents,
             saw_stderr,
@@ -463,6 +529,7 @@ impl PendingOutputSnapshot {
                 PendingOutputEvent::TextFragment {
                     stream,
                     origin,
+                    source: _,
                     bytes: fragment,
                     terminated,
                     ..
@@ -564,32 +631,60 @@ impl PendingOutputSnapshot {
     }
 }
 
-fn maybe_trim_leading_echo_prefix(echo_prefix: Option<&str>, contents: &mut Vec<WorkerContent>) {
+fn maybe_trim_leading_echo_prefix(
+    echo_prefix: Option<&PendingEchoPrefix>,
+    events: &[PendingOutputEvent],
+    contents: &mut Vec<WorkerContent>,
+) {
     let Some(echo_prefix) = echo_prefix else {
         return;
     };
-    trim_matching_echo_prefix_from_contents(contents, echo_prefix);
+    let (matched_bytes, _) =
+        leading_echo_match_progress(events, &echo_prefix.text, echo_prefix.source);
+    if matched_bytes == 0 {
+        return;
+    }
+    trim_matching_echo_prefix_from_contents(contents, &echo_prefix.text[..matched_bytes]);
 }
 
-fn append_readline_results_to_echo_prefix(echo_prefix: &mut String, events: &[PendingOutputEvent]) {
+fn append_readline_results_to_echo_prefix(
+    echo_prefix: &mut Option<PendingEchoPrefix>,
+    events: &[PendingOutputEvent],
+) {
     for event in events {
         if let PendingOutputEvent::Sideband {
             kind: PendingSidebandKind::ReadlineResult { prompt, line },
             ..
         } = event
         {
-            if !is_trim_eligible_carryover_prompt(prompt) {
+            let Some(source) = trim_eligible_carryover_source(prompt) else {
                 continue;
-            }
-            echo_prefix.push_str(prompt);
-            echo_prefix.push_str(line);
+            };
+            let prefix = echo_prefix.get_or_insert_with(|| PendingEchoPrefix {
+                text: String::new(),
+                source,
+            });
+            assert_eq!(
+                prefix.source, source,
+                "mixed prompt carryover sources in one drain"
+            );
+            prefix.text.push_str(prompt);
+            prefix.text.push_str(line);
         }
     }
 }
 
-fn is_trim_eligible_carryover_prompt(prompt: &str) -> bool {
+fn trim_eligible_carryover_source(prompt: &str) -> Option<PendingTextSource> {
     let core = prompt.trim_end_matches(|ch: char| ch.is_whitespace());
-    matches!(core, ">>>" | "...")
+    if matches!(core, ">>>" | "...") {
+        return Some(PendingTextSource::Raw);
+    }
+    if matches!(core, ">" | "+")
+        || (core.starts_with("Browse[") && (core.ends_with('>') || core.ends_with('+')))
+    {
+        return Some(PendingTextSource::Ipc);
+    }
+    None
 }
 
 fn snapshot_has_no_visible_text(events: &[PendingOutputEvent]) -> bool {
@@ -614,7 +709,11 @@ fn snapshot_crossed_request_boundary(events: &[PendingOutputEvent]) -> bool {
     })
 }
 
-fn leading_echo_match_progress(events: &[PendingOutputEvent], echo_prefix: &str) -> (usize, bool) {
+fn leading_echo_match_progress(
+    events: &[PendingOutputEvent],
+    echo_prefix: &str,
+    expected_source: PendingTextSource,
+) -> (usize, bool) {
     if echo_prefix.is_empty() {
         return (0, false);
     }
@@ -627,6 +726,7 @@ fn leading_echo_match_progress(events: &[PendingOutputEvent], echo_prefix: &str)
         let PendingOutputEvent::TextFragment {
             stream,
             origin,
+            source,
             bytes,
             ..
         } = event
@@ -643,6 +743,9 @@ fn leading_echo_match_progress(events: &[PendingOutputEvent], echo_prefix: &str)
         };
 
         if !matches!(stream, TextStream::Stdout) || !matches!(origin, ContentOrigin::Worker) {
+            return (matched_bytes, false);
+        }
+        if *source != expected_source {
             return (matched_bytes, false);
         }
 
@@ -856,6 +959,7 @@ fn append_complete_bytes(
     inner: &mut PendingOutputTapeInner,
     stream: TextStream,
     origin: ContentOrigin,
+    source: PendingTextSource,
     bytes: &[u8],
 ) {
     if bytes.is_empty() {
@@ -868,6 +972,7 @@ fn append_complete_bytes(
             seq,
             stream,
             origin,
+            source,
             bytes: bytes.to_vec(),
             terminated: bytes.ends_with(b"\n"),
         },
@@ -876,7 +981,7 @@ fn append_complete_bytes(
 
 fn commit_complete_lines(inner: &mut PendingOutputTapeInner, stream: TextStream) {
     loop {
-        let (seq, origin, line, tail_empty) = {
+        let (seq, origin, source, line, tail_empty) = {
             let tail = tail_mut(inner, stream);
             let Some(newline_idx) = tail.bytes.iter().position(|byte| *byte == b'\n') else {
                 break;
@@ -887,13 +992,17 @@ fn commit_complete_lines(inner: &mut PendingOutputTapeInner, stream: TextStream)
             let origin = tail
                 .origin
                 .expect("text tail should record origin while bytes are buffered");
+            let source = tail
+                .source
+                .expect("text tail should record source while bytes are buffered");
             let line = tail.bytes.drain(..=newline_idx).collect::<Vec<u8>>();
             let tail_empty = tail.bytes.is_empty();
             if tail_empty {
                 tail.origin = None;
+                tail.source = None;
                 tail.start_seq = None;
             }
-            (seq, origin, line, tail_empty)
+            (seq, origin, source, line, tail_empty)
         };
         append_event(
             inner,
@@ -901,6 +1010,7 @@ fn commit_complete_lines(inner: &mut PendingOutputTapeInner, stream: TextStream)
                 seq,
                 stream,
                 origin,
+                source,
                 bytes: line,
                 terminated: true,
             },
@@ -914,7 +1024,7 @@ fn commit_complete_lines(inner: &mut PendingOutputTapeInner, stream: TextStream)
 }
 
 fn flush_tail(inner: &mut PendingOutputTapeInner, stream: TextStream, flush_incomplete: bool) {
-    let (seq, origin, bytes, tail_empty) = {
+    let (seq, origin, source, bytes, tail_empty) = {
         let tail = tail_mut(inner, stream);
         if tail.bytes.is_empty() {
             return;
@@ -932,13 +1042,17 @@ fn flush_tail(inner: &mut PendingOutputTapeInner, stream: TextStream, flush_inco
         let origin = tail
             .origin
             .expect("text tail should record origin while bytes are buffered");
+        let source = tail
+            .source
+            .expect("text tail should record source while bytes are buffered");
         let bytes = tail.bytes.drain(..flush_len).collect::<Vec<u8>>();
         let tail_empty = tail.bytes.is_empty();
         if tail_empty {
             tail.origin = None;
+            tail.source = None;
             tail.start_seq = None;
         }
-        (seq, origin, bytes, tail_empty)
+        (seq, origin, source, bytes, tail_empty)
     };
     append_event(
         inner,
@@ -946,6 +1060,7 @@ fn flush_tail(inner: &mut PendingOutputTapeInner, stream: TextStream, flush_inco
             seq,
             stream,
             origin,
+            source,
             bytes,
             terminated: false,
         },
@@ -1054,6 +1169,7 @@ mod tests {
                     seq: 0,
                     stream: TextStream::Stdout,
                     origin: ContentOrigin::Worker,
+                    source: PendingTextSource::Raw,
                     bytes: b"abc".to_vec(),
                     terminated: false,
                 },
@@ -1061,6 +1177,7 @@ mod tests {
                     seq: 1,
                     stream: TextStream::Stderr,
                     origin: ContentOrigin::Worker,
+                    source: PendingTextSource::Raw,
                     bytes: b"boom\n".to_vec(),
                     terminated: true,
                 },
@@ -1071,7 +1188,7 @@ mod tests {
     #[test]
     fn sideband_events_preserve_order_with_text() {
         let tape = PendingOutputTape::new();
-        tape.append_stdout_bytes(b"> 1+\n");
+        tape.append_stdout_ipc_bytes(b"> 1+\n");
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "> ".to_string(),
             line: "1+\n".to_string(),
@@ -1188,6 +1305,7 @@ mod tests {
                     seq: 0,
                     stream: TextStream::Stderr,
                     origin: ContentOrigin::Server,
+                    source: PendingTextSource::Raw,
                     bytes: b"[repl] guardrail".to_vec(),
                     terminated: false,
                 },
@@ -1195,6 +1313,7 @@ mod tests {
                     seq: 1,
                     stream: TextStream::Stdout,
                     origin: ContentOrigin::Worker,
+                    source: PendingTextSource::Raw,
                     bytes: b"ok\n".to_vec(),
                     terminated: true,
                 },
@@ -1329,7 +1448,7 @@ mod tests {
             .lock()
             .expect("pending output tape mutex poisoned");
         assert!(
-            guard.pending_echo_prefix.is_empty(),
+            guard.pending_echo_prefix.is_none(),
             "request boundary should clear unmatched carried echo"
         );
     }
@@ -1522,6 +1641,7 @@ mod tests {
                     seq: 0,
                     stream: TextStream::Stdout,
                     origin: ContentOrigin::Worker,
+                    source: PendingTextSource::Raw,
                     bytes: vec![0xC3],
                     terminated: false,
                 },
@@ -1529,6 +1649,7 @@ mod tests {
                     seq: 1,
                     stream: TextStream::Stdout,
                     origin: ContentOrigin::Server,
+                    source: PendingTextSource::Raw,
                     bytes: b"\n[repl] session ended\n".to_vec(),
                     terminated: true,
                 },
@@ -1550,6 +1671,7 @@ mod tests {
                     seq: 0,
                     stream: TextStream::Stderr,
                     origin: ContentOrigin::Server,
+                    source: PendingTextSource::Raw,
                     bytes: vec![0xC3],
                     terminated: false,
                 },
@@ -1557,6 +1679,7 @@ mod tests {
                     seq: 1,
                     stream: TextStream::Stderr,
                     origin: ContentOrigin::Worker,
+                    source: PendingTextSource::Raw,
                     bytes: b"boom\n".to_vec(),
                     terminated: true,
                 },
@@ -1568,12 +1691,12 @@ mod tests {
     fn reply_format_anchors_image_before_later_echoed_input_and_stdout() {
         let tape = PendingOutputTape::new();
 
-        tape.append_stdout_bytes(b"> plot(1:10)\n");
+        tape.append_stdout_ipc_bytes(b"> plot(1:10)\n");
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "> ".to_string(),
             line: "plot(1:10)\n".to_string(),
         });
-        tape.append_stdout_bytes(b"> cat('done\\n')\n");
+        tape.append_stdout_ipc_bytes(b"> cat('done\\n')\n");
         tape.append_stdout_bytes(b"done\n");
         tape.append_image(
             "img-1".to_string(),
@@ -1606,12 +1729,12 @@ mod tests {
     fn nonfinal_format_drops_leading_repl_echo_once_output_arrives() {
         let tape = PendingOutputTape::new();
 
-        tape.append_stdout_bytes(b"> plot(1:10)\n");
+        tape.append_stdout_ipc_bytes(b"> plot(1:10)\n");
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "> ".to_string(),
             line: "plot(1:10)\n".to_string(),
         });
-        tape.append_stdout_bytes(b"> cat('done\\n')\n");
+        tape.append_stdout_ipc_bytes(b"> cat('done\\n')\n");
         tape.append_stdout_bytes(b"done\n");
         tape.append_image(
             "img-1".to_string(),
@@ -1674,7 +1797,7 @@ mod tests {
             "sideband-only snapshot should not render visible content"
         );
 
-        tape.append_stdout_bytes(b"> cat('done\\n')\n");
+        tape.append_stdout_ipc_bytes(b"> cat('done\\n')\n");
         tape.append_stdout_bytes(b"done\n");
         tape.append_image(
             "img-1".to_string(),
@@ -1722,6 +1845,28 @@ mod tests {
         assert_eq!(
             second.format_contents().contents,
             vec![WorkerContent::stdout("> 1 + 1\n")]
+        );
+    }
+
+    #[test]
+    fn r_prompt_carryover_trims_late_ipc_output_text() {
+        let tape = PendingOutputTape::new();
+
+        tape.append_sideband(PendingSidebandKind::ReadlineResult {
+            prompt: "> ".to_string(),
+            line: "1 + 1\n".to_string(),
+        });
+        let first = tape.drain_snapshot();
+        assert!(
+            first.format_contents().contents.is_empty(),
+            "sideband-only snapshot should not render visible content"
+        );
+
+        tape.append_stdout_ipc_bytes(b"> 1 + 1\n");
+        let second = tape.drain_snapshot();
+        assert!(
+            second.format_contents().contents.is_empty(),
+            "expected late R-owned output_text echo to be trimmed"
         );
     }
 

--- a/src/pending_output_tape.rs
+++ b/src/pending_output_tape.rs
@@ -350,9 +350,10 @@ impl PendingOutputTape {
         guard.drained_readline_results = guard
             .drained_readline_results
             .saturating_add(drained_readline_results);
-        // `pending_echo_prefix` only carries trim-eligible REPL echo that was
-        // observed sideband-first in an earlier drain. Current-snapshot echo is
-        // resolved from the mixed text/event timeline below.
+        // `pending_echo_prefix` only carries non-R raw REPL echo that was
+        // observed sideband-first in an earlier drain. R-owned echo now travels
+        // through ordered `output_text` frames and is resolved in the current
+        // mixed text/event timeline below.
         let leading_echo_prefix =
             (!guard.pending_echo_prefix.is_empty()).then(|| guard.pending_echo_prefix.clone());
         append_readline_results_to_echo_prefix(&mut guard.pending_echo_prefix, &events);
@@ -588,8 +589,7 @@ fn append_readline_results_to_echo_prefix(echo_prefix: &mut String, events: &[Pe
 
 fn is_trim_eligible_carryover_prompt(prompt: &str) -> bool {
     let core = prompt.trim_end_matches(|ch: char| ch.is_whitespace());
-    matches!(core, ">" | "+" | ">>>" | "...")
-        || (core.starts_with("Browse[") && (core.ends_with('>') || core.ends_with('+')))
+    matches!(core, ">>>" | "...")
 }
 
 fn snapshot_has_no_visible_text(events: &[PendingOutputEvent]) -> bool {
@@ -1284,7 +1284,7 @@ mod tests {
         let tape = PendingOutputTape::new();
 
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
-            prompt: "> ".to_string(),
+            prompt: ">>> ".to_string(),
             line: "1+\n".to_string(),
         });
         let first = tape.drain_snapshot();
@@ -1293,7 +1293,7 @@ mod tests {
             "sideband-only snapshot should not render visible content"
         );
 
-        tape.append_stdout_bytes(b"> 1");
+        tape.append_stdout_bytes(b">>> 1");
         let second = tape.drain_snapshot();
         assert!(
             second.format_contents().contents.is_empty(),
@@ -1313,7 +1313,7 @@ mod tests {
         let tape = PendingOutputTape::new();
 
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
-            prompt: "> ".to_string(),
+            prompt: ">>> ".to_string(),
             line: "x <- 1\n".to_string(),
         });
         tape.append_sideband(PendingSidebandKind::RequestBoundary);
@@ -1340,7 +1340,7 @@ mod tests {
         let status = "[repl] previous plot updated\n".to_string();
 
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
-            prompt: "> ".to_string(),
+            prompt: ">>> ".to_string(),
             line: "plot(1:10)\n".to_string(),
         });
         tape.append_stdout_status_event(status.clone(), 1);
@@ -1352,7 +1352,7 @@ mod tests {
             vec![WorkerContent::server_stdout(status)]
         );
 
-        tape.append_stdout_bytes(b"> plot(1:10)\n");
+        tape.append_stdout_bytes(b">>> plot(1:10)\n");
         let second = tape.drain_snapshot();
         assert!(
             second.format_contents().contents.is_empty(),
@@ -1365,7 +1365,7 @@ mod tests {
         let tape = PendingOutputTape::new();
 
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
-            prompt: "> ".to_string(),
+            prompt: ">>> ".to_string(),
             line: "plot(1:10)\n".to_string(),
         });
         tape.append_image(
@@ -1388,7 +1388,7 @@ mod tests {
             }]
         );
 
-        tape.append_stdout_bytes(b"> plot(1:10)\n");
+        tape.append_stdout_bytes(b">>> plot(1:10)\n");
         let second = tape.drain_snapshot();
         assert!(
             second.format_contents().contents.is_empty(),
@@ -1401,11 +1401,11 @@ mod tests {
         let tape = PendingOutputTape::new();
 
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
-            prompt: "> ".to_string(),
+            prompt: ">>> ".to_string(),
             line: "x <- 1\n".to_string(),
         });
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
-            prompt: "> ".to_string(),
+            prompt: ">>> ".to_string(),
             line: "y <- 2\n".to_string(),
         });
         let first = tape.drain_snapshot();
@@ -1414,18 +1414,18 @@ mod tests {
             "sideband-only snapshot should not render visible content"
         );
 
-        tape.append_stdout_bytes(b"> x <- 1\nok\n");
+        tape.append_stdout_bytes(b">>> x <- 1\nok\n");
         let second = tape.drain_snapshot();
         assert_eq!(
             second.format_contents().contents,
             vec![WorkerContent::stdout("ok\n")]
         );
 
-        tape.append_stdout_bytes(b"> y <- 2\n");
+        tape.append_stdout_bytes(b">>> y <- 2\n");
         let third = tape.drain_snapshot();
         assert_eq!(
             third.format_contents().contents,
-            vec![WorkerContent::stdout("> y <- 2\n")]
+            vec![WorkerContent::stdout(">>> y <- 2\n")]
         );
     }
 
@@ -1704,6 +1704,28 @@ mod tests {
     }
 
     #[test]
+    fn r_prompt_carryover_does_not_trim_late_raw_stdout() {
+        let tape = PendingOutputTape::new();
+
+        tape.append_sideband(PendingSidebandKind::ReadlineResult {
+            prompt: "> ".to_string(),
+            line: "1 + 1\n".to_string(),
+        });
+        let first = tape.drain_snapshot();
+        assert!(
+            first.format_contents().contents.is_empty(),
+            "sideband-only snapshot should not render visible content"
+        );
+
+        tape.append_stdout_bytes(b"> 1 + 1\n");
+        let second = tape.drain_snapshot();
+        assert_eq!(
+            second.format_contents().contents,
+            vec![WorkerContent::stdout("> 1 + 1\n")]
+        );
+    }
+
+    #[test]
     fn custom_prompt_carryover_does_not_trim_real_output() {
         let tape = PendingOutputTape::new();
 
@@ -1730,7 +1752,7 @@ mod tests {
         let tape = PendingOutputTape::new();
 
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
-            prompt: "> ".to_string(),
+            prompt: ">>> ".to_string(),
             line: "plot(1:10)\n".to_string(),
         });
         let first = tape.drain_snapshot();
@@ -1757,7 +1779,7 @@ mod tests {
             }]
         );
 
-        tape.append_stdout_bytes(b"> plot(1:10)\ndone\n");
+        tape.append_stdout_bytes(b">>> plot(1:10)\ndone\n");
         let third = tape.drain_snapshot();
         assert_eq!(
             third.format_contents().contents,

--- a/src/pending_output_tape.rs
+++ b/src/pending_output_tape.rs
@@ -77,8 +77,14 @@ impl PendingOutputEvent {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum PendingSidebandKind {
-    ReadlineStart { prompt: String },
-    ReadlineResult { prompt: String, line: String },
+    ReadlineStart {
+        prompt: String,
+    },
+    ReadlineResult {
+        prompt: String,
+        line: String,
+        echo_source: PendingTextSource,
+    },
     RequestBoundary,
     SessionEnd,
 }
@@ -117,10 +123,64 @@ pub(crate) enum PendingTextSource {
     Ipc,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 struct PendingEchoPrefix {
+    segments: Vec<PendingEchoSegment>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PendingEchoSegment {
     text: String,
     source: PendingTextSource,
+}
+
+impl PendingEchoPrefix {
+    fn push(&mut self, source: PendingTextSource, text: String) {
+        if text.is_empty() {
+            return;
+        }
+        if let Some(last) = self.segments.last_mut()
+            && last.source == source
+        {
+            last.text.push_str(&text);
+            return;
+        }
+        self.segments.push(PendingEchoSegment { text, source });
+    }
+
+    fn is_empty(&self) -> bool {
+        self.segments.iter().all(|segment| segment.text.is_empty())
+    }
+
+    fn text_prefix(&self, mut byte_len: usize) -> String {
+        let mut text = String::new();
+        for segment in &self.segments {
+            if byte_len == 0 {
+                break;
+            }
+            let take = byte_len.min(segment.text.len());
+            text.push_str(&segment.text[..take]);
+            byte_len -= take;
+        }
+        text
+    }
+
+    fn suffix_after(&self, mut byte_len: usize) -> Option<Self> {
+        let mut segments = Vec::new();
+        for (idx, segment) in self.segments.iter().enumerate() {
+            if byte_len >= segment.text.len() {
+                byte_len -= segment.text.len();
+                continue;
+            }
+            segments.push(PendingEchoSegment {
+                text: segment.text[byte_len..].to_string(),
+                source: segment.source,
+            });
+            segments.extend(self.segments[idx.saturating_add(1)..].iter().cloned());
+            break;
+        }
+        (!segments.is_empty()).then_some(Self { segments })
+    }
 }
 
 struct RenderedPendingOutput {
@@ -407,15 +467,12 @@ impl PendingOutputTape {
         append_readline_results_to_echo_prefix(&mut guard.pending_echo_prefix, &events);
         if let Some(echo_prefix) = guard.pending_echo_prefix.clone() {
             let (matched_bytes, keep_remaining_suffix) =
-                leading_echo_match_progress(&events, &echo_prefix.text, echo_prefix.source);
+                leading_echo_match_progress(&events, &echo_prefix);
             if keep_remaining_suffix
                 && !(snapshot_has_no_visible_text(&events)
                     && snapshot_crossed_request_boundary(&events))
             {
-                guard.pending_echo_prefix = Some(PendingEchoPrefix {
-                    text: echo_prefix.text[matched_bytes..].to_string(),
-                    source: echo_prefix.source,
-                });
+                guard.pending_echo_prefix = echo_prefix.suffix_after(matched_bytes);
             } else {
                 guard.pending_echo_prefix = None;
             }
@@ -604,7 +661,7 @@ impl PendingOutputSnapshot {
                     PendingSidebandKind::ReadlineStart { prompt } => {
                         push_prompt_variant(&mut prompt_variants, prompt);
                     }
-                    PendingSidebandKind::ReadlineResult { prompt, line } => {
+                    PendingSidebandKind::ReadlineResult { prompt, line, .. } => {
                         push_prompt_variant(&mut prompt_variants, prompt);
                         echo_events.push(IpcEchoEvent {
                             prompt: prompt.clone(),
@@ -639,12 +696,11 @@ fn maybe_trim_leading_echo_prefix(
     let Some(echo_prefix) = echo_prefix else {
         return;
     };
-    let (matched_bytes, _) =
-        leading_echo_match_progress(events, &echo_prefix.text, echo_prefix.source);
+    let (matched_bytes, _) = leading_echo_match_progress(events, echo_prefix);
     if matched_bytes == 0 {
         return;
     }
-    trim_matching_echo_prefix_from_contents(contents, &echo_prefix.text[..matched_bytes]);
+    trim_matching_echo_prefix_from_contents(contents, &echo_prefix.text_prefix(matched_bytes));
 }
 
 fn append_readline_results_to_echo_prefix(
@@ -653,38 +709,44 @@ fn append_readline_results_to_echo_prefix(
 ) {
     for event in events {
         if let PendingOutputEvent::Sideband {
-            kind: PendingSidebandKind::ReadlineResult { prompt, line },
+            kind:
+                PendingSidebandKind::ReadlineResult {
+                    prompt,
+                    line,
+                    echo_source,
+                },
             ..
         } = event
         {
-            let Some(source) = trim_eligible_carryover_source(prompt) else {
+            if !is_trim_eligible_carryover_prompt(prompt) {
                 continue;
-            };
-            let prefix = echo_prefix.get_or_insert_with(|| PendingEchoPrefix {
-                text: String::new(),
-                source,
-            });
-            assert_eq!(
-                prefix.source, source,
-                "mixed prompt carryover sources in one drain"
-            );
-            prefix.text.push_str(prompt);
-            prefix.text.push_str(line);
+            }
+            let prefix = echo_prefix.get_or_insert_with(PendingEchoPrefix::default);
+            let mut text = String::with_capacity(prompt.len().saturating_add(line.len()));
+            text.push_str(prompt);
+            text.push_str(line);
+            prefix.push(*echo_source, text);
         }
+    }
+    if echo_prefix
+        .as_ref()
+        .is_some_and(PendingEchoPrefix::is_empty)
+    {
+        *echo_prefix = None;
     }
 }
 
-fn trim_eligible_carryover_source(prompt: &str) -> Option<PendingTextSource> {
+fn is_trim_eligible_carryover_prompt(prompt: &str) -> bool {
     let core = prompt.trim_end_matches(|ch: char| ch.is_whitespace());
     if matches!(core, ">>>" | "...") {
-        return Some(PendingTextSource::Raw);
+        return true;
     }
     if matches!(core, ">" | "+")
         || (core.starts_with("Browse[") && (core.ends_with('>') || core.ends_with('+')))
     {
-        return Some(PendingTextSource::Ipc);
+        return true;
     }
-    None
+    false
 }
 
 fn snapshot_has_no_visible_text(events: &[PendingOutputEvent]) -> bool {
@@ -711,14 +773,14 @@ fn snapshot_crossed_request_boundary(events: &[PendingOutputEvent]) -> bool {
 
 fn leading_echo_match_progress(
     events: &[PendingOutputEvent],
-    echo_prefix: &str,
-    expected_source: PendingTextSource,
+    echo_prefix: &PendingEchoPrefix,
 ) -> (usize, bool) {
     if echo_prefix.is_empty() {
         return (0, false);
     }
 
-    let mut remaining = echo_prefix;
+    let mut segment_idx = 0usize;
+    let mut segment_offset = 0usize;
     let mut matched_bytes = 0usize;
     let mut saw_visible_content = false;
 
@@ -745,9 +807,6 @@ fn leading_echo_match_progress(
         if !matches!(stream, TextStream::Stdout) || !matches!(origin, ContentOrigin::Worker) {
             return (matched_bytes, false);
         }
-        if *source != expected_source {
-            return (matched_bytes, false);
-        }
 
         let rendered = render_bytes(bytes);
         if rendered.is_empty() {
@@ -755,16 +814,40 @@ fn leading_echo_match_progress(
         }
 
         saw_visible_content = true;
-        if remaining.is_empty() {
-            return (matched_bytes, false);
-        }
 
-        let common = common_prefix_len(remaining, &rendered);
-        matched_bytes = matched_bytes.saturating_add(common);
-        remaining = &remaining[common..];
+        let mut remaining_rendered = rendered.as_str();
+        while !remaining_rendered.is_empty() {
+            let Some(segment) = echo_prefix.segments.get(segment_idx) else {
+                return (matched_bytes, false);
+            };
+            if *source != segment.source {
+                return (matched_bytes, false);
+            }
 
-        if common < rendered.len() {
-            return (matched_bytes, false);
+            let remaining_segment = &segment.text[segment_offset..];
+            if remaining_segment.is_empty() {
+                segment_idx = segment_idx.saturating_add(1);
+                segment_offset = 0;
+                continue;
+            }
+
+            let before_len = remaining_rendered.len();
+            let common = common_prefix_len(remaining_segment, remaining_rendered);
+            if common == 0 {
+                return (matched_bytes, false);
+            }
+            matched_bytes = matched_bytes.saturating_add(common);
+            segment_offset = segment_offset.saturating_add(common);
+            remaining_rendered = &remaining_rendered[common..];
+
+            let segment_complete = segment_offset == segment.text.len();
+            if segment_complete {
+                segment_idx = segment_idx.saturating_add(1);
+                segment_offset = 0;
+            }
+            if common < before_len && !segment_complete {
+                return (matched_bytes, false);
+            }
         }
     }
 
@@ -772,7 +855,7 @@ fn leading_echo_match_progress(
         return (matched_bytes, true);
     }
 
-    (matched_bytes, !remaining.is_empty())
+    (matched_bytes, segment_idx < echo_prefix.segments.len())
 }
 
 fn trim_matching_echo_prefix_from_contents(contents: &mut Vec<WorkerContent>, echo_prefix: &str) {
@@ -1192,6 +1275,7 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "> ".to_string(),
             line: "1+\n".to_string(),
+            echo_source: PendingTextSource::Ipc,
         });
         tape.append_stdout_bytes(b"[1] 2\n");
 
@@ -1405,6 +1489,7 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: ">>> ".to_string(),
             line: "1+\n".to_string(),
+            echo_source: PendingTextSource::Raw,
         });
         let first = tape.drain_snapshot();
         assert!(
@@ -1434,6 +1519,7 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: ">>> ".to_string(),
             line: "x <- 1\n".to_string(),
+            echo_source: PendingTextSource::Raw,
         });
         tape.append_sideband(PendingSidebandKind::RequestBoundary);
 
@@ -1461,6 +1547,7 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: ">>> ".to_string(),
             line: "plot(1:10)\n".to_string(),
+            echo_source: PendingTextSource::Raw,
         });
         tape.append_stdout_status_event(status.clone(), 1);
         tape.append_sideband(PendingSidebandKind::RequestBoundary);
@@ -1486,6 +1573,7 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: ">>> ".to_string(),
             line: "plot(1:10)\n".to_string(),
+            echo_source: PendingTextSource::Raw,
         });
         tape.append_image(
             "img-1".to_string(),
@@ -1522,10 +1610,12 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: ">>> ".to_string(),
             line: "x <- 1\n".to_string(),
+            echo_source: PendingTextSource::Raw,
         });
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: ">>> ".to_string(),
             line: "y <- 2\n".to_string(),
+            echo_source: PendingTextSource::Raw,
         });
         let first = tape.drain_snapshot();
         assert!(
@@ -1695,6 +1785,7 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "> ".to_string(),
             line: "plot(1:10)\n".to_string(),
+            echo_source: PendingTextSource::Ipc,
         });
         tape.append_stdout_ipc_bytes(b"> cat('done\\n')\n");
         tape.append_stdout_bytes(b"done\n");
@@ -1708,6 +1799,7 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "> ".to_string(),
             line: "cat('done\\n')\n".to_string(),
+            echo_source: PendingTextSource::Ipc,
         });
 
         let snapshot = tape.drain_snapshot();
@@ -1733,6 +1825,7 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "> ".to_string(),
             line: "plot(1:10)\n".to_string(),
+            echo_source: PendingTextSource::Ipc,
         });
         tape.append_stdout_ipc_bytes(b"> cat('done\\n')\n");
         tape.append_stdout_bytes(b"done\n");
@@ -1746,6 +1839,7 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "> ".to_string(),
             line: "cat('done\\n')\n".to_string(),
+            echo_source: PendingTextSource::Ipc,
         });
 
         let snapshot = tape.drain_snapshot();
@@ -1771,6 +1865,7 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "FIRST> ".to_string(),
             line: "alpha\n".to_string(),
+            echo_source: PendingTextSource::Raw,
         });
         tape.append_sideband(PendingSidebandKind::ReadlineStart {
             prompt: "SECOND> ".to_string(),
@@ -1790,6 +1885,7 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "> ".to_string(),
             line: "plot(1:10)\n".to_string(),
+            echo_source: PendingTextSource::Ipc,
         });
         let first = tape.drain_snapshot();
         assert!(
@@ -1809,6 +1905,7 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "> ".to_string(),
             line: "cat('done\\n')\n".to_string(),
+            echo_source: PendingTextSource::Ipc,
         });
 
         let second = tape.drain_snapshot();
@@ -1833,6 +1930,7 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "> ".to_string(),
             line: "1 + 1\n".to_string(),
+            echo_source: PendingTextSource::Ipc,
         });
         let first = tape.drain_snapshot();
         assert!(
@@ -1849,12 +1947,72 @@ mod tests {
     }
 
     #[test]
+    fn python_r_shaped_prompt_carryover_trims_late_raw_echo() {
+        let tape = PendingOutputTape::new();
+
+        tape.append_sideband(PendingSidebandKind::ReadlineResult {
+            prompt: "> ".to_string(),
+            line: "answer\n".to_string(),
+            echo_source: PendingTextSource::Raw,
+        });
+        let first = tape.drain_snapshot();
+        assert!(
+            first.format_contents().contents.is_empty(),
+            "sideband-only snapshot should not render visible content"
+        );
+
+        tape.append_stdout_bytes(b"> answer\n");
+        let second = tape.drain_snapshot();
+        assert!(
+            second.format_contents().contents.is_empty(),
+            "expected Python raw prompt echo to be trimmed"
+        );
+    }
+
+    #[test]
+    fn mixed_prompt_source_carryover_does_not_panic() {
+        let tape = PendingOutputTape::new();
+
+        tape.append_sideband(PendingSidebandKind::ReadlineResult {
+            prompt: ">>> ".to_string(),
+            line: "first\n".to_string(),
+            echo_source: PendingTextSource::Raw,
+        });
+        tape.append_sideband(PendingSidebandKind::ReadlineResult {
+            prompt: "> ".to_string(),
+            line: "second\n".to_string(),
+            echo_source: PendingTextSource::Ipc,
+        });
+
+        let first = tape.drain_snapshot();
+        assert!(
+            first.format_contents().contents.is_empty(),
+            "sideband-only snapshot should not render visible content"
+        );
+
+        tape.append_stdout_bytes(b">>> first\n");
+        let second = tape.drain_snapshot();
+        assert!(
+            second.format_contents().contents.is_empty(),
+            "expected raw segment to be trimmed"
+        );
+
+        tape.append_stdout_ipc_bytes(b"> second\n");
+        let third = tape.drain_snapshot();
+        assert!(
+            third.format_contents().contents.is_empty(),
+            "expected IPC segment to be trimmed"
+        );
+    }
+
+    #[test]
     fn r_prompt_carryover_trims_late_ipc_output_text() {
         let tape = PendingOutputTape::new();
 
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "> ".to_string(),
             line: "1 + 1\n".to_string(),
+            echo_source: PendingTextSource::Ipc,
         });
         let first = tape.drain_snapshot();
         assert!(
@@ -1877,6 +2035,7 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "FIRST> ".to_string(),
             line: "alpha\n".to_string(),
+            echo_source: PendingTextSource::Raw,
         });
         let first = tape.drain_snapshot();
         assert!(
@@ -1899,6 +2058,7 @@ mod tests {
         tape.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: ">>> ".to_string(),
             line: "plot(1:10)\n".to_string(),
+            echo_source: PendingTextSource::Raw,
         });
         let first = tape.drain_snapshot();
         assert!(

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -123,13 +123,31 @@ impl LiveOutputCapture {
         }
     }
 
-    fn append_text(&self, bytes: &[u8], stream: TextStream, is_continuation: bool) {
+    fn append_output_text(&self, bytes: &[u8], stream: TextStream, is_continuation: bool) {
+        self.append_text(bytes, stream, is_continuation, true);
+    }
+
+    fn append_raw_text(&self, bytes: &[u8], stream: TextStream) {
+        self.append_text(bytes, stream, false, false);
+    }
+
+    fn append_text(
+        &self,
+        bytes: &[u8],
+        stream: TextStream,
+        is_continuation: bool,
+        is_output_text: bool,
+    ) {
         match stream {
             TextStream::Stdout => {
                 self.output_timeline
                     .append_text(bytes, false, ContentOrigin::Worker);
                 if let Some(tape) = &self.pending_output_tape {
-                    tape.append_stdout_bytes(bytes);
+                    if is_output_text {
+                        tape.append_stdout_ipc_bytes(bytes);
+                    } else {
+                        tape.append_stdout_bytes(bytes);
+                    }
                 }
             }
             TextStream::Stderr => {
@@ -140,7 +158,11 @@ impl LiveOutputCapture {
                     is_continuation,
                 );
                 if let Some(tape) = &self.pending_output_tape {
-                    tape.append_stderr_bytes(bytes);
+                    if is_output_text {
+                        tape.append_stderr_ipc_bytes(bytes);
+                    } else {
+                        tape.append_stderr_bytes(bytes);
+                    }
                 }
             }
         }
@@ -5057,7 +5079,11 @@ impl WorkerProcess {
             let sideband_capture = live_output.clone();
             let handlers = IpcHandlers {
                 on_output_text: Some(Arc::new(move |text| {
-                    output_capture.append_text(&text.bytes, text.stream, text.is_continuation);
+                    output_capture.append_output_text(
+                        &text.bytes,
+                        text.stream,
+                        text.is_continuation,
+                    );
                 })),
                 on_plot_image: Some(Arc::new(move |image: IpcPlotImage| {
                     image_capture.append_image(image);
@@ -5992,7 +6018,7 @@ where
                         break;
                     }
                     Ok(n) => {
-                        live_output.append_text(&buffer[..n], output_stream, false);
+                        live_output.append_raw_text(&buffer[..n], output_stream);
                         read_stream = true;
                     }
                     Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
@@ -6066,7 +6092,7 @@ where
             }
             match stream.read(&mut buffer) {
                 Ok(0) => break,
-                Ok(n) => live_output.append_text(&buffer[..n], output_stream, false),
+                Ok(n) => live_output.append_raw_text(&buffer[..n], output_stream),
                 Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
                 Err(_) => break,
             }
@@ -6098,7 +6124,7 @@ where
         loop {
             match stream.read(&mut buffer) {
                 Ok(0) => break,
-                Ok(n) => live_output.append_text(&buffer[..n], output_stream, false),
+                Ok(n) => live_output.append_raw_text(&buffer[..n], output_stream),
                 Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
                 Err(_) => break,
             }
@@ -7447,7 +7473,7 @@ mod tests {
 
         manager
             .pending_output_tape
-            .append_stdout_bytes(b"> Sys.sleep(5)\n");
+            .append_stdout_ipc_bytes(b"> Sys.sleep(5)\n");
         manager
             .pending_output_tape
             .append_sideband(PendingSidebandKind::ReadlineResult {
@@ -7475,7 +7501,7 @@ mod tests {
 
         manager
             .pending_output_tape
-            .append_stdout_bytes(b"> Sys.sleep(5)\n");
+            .append_stdout_ipc_bytes(b"> Sys.sleep(5)\n");
         manager
             .pending_output_tape
             .append_sideband(PendingSidebandKind::ReadlineResult {
@@ -7504,7 +7530,7 @@ mod tests {
 
         manager
             .pending_output_tape
-            .append_stdout_bytes(b"> Sys.sleep(5)\n");
+            .append_stdout_ipc_bytes(b"> Sys.sleep(5)\n");
         manager
             .pending_output_tape
             .append_sideband(PendingSidebandKind::ReadlineResult {
@@ -7904,7 +7930,7 @@ mod tests {
             tape.clone(),
             OutputTimeline::new(output_ring.clone()),
         );
-        capture.append_text(b"pager output\n", TextStream::Stdout, false);
+        capture.append_output_text(b"pager output\n", TextStream::Stdout, false);
         capture.append_image(IpcPlotImage {
             id: "img-1".to_string(),
             data: "AA==".to_string(),
@@ -7963,7 +7989,7 @@ mod tests {
             updates_previous_image: true,
             readline_results_seen: 1,
         });
-        capture.append_text(b"> lines(4:8, 4:8)\n", TextStream::Stdout, false);
+        capture.append_output_text(b"> lines(4:8, 4:8)\n", TextStream::Stdout, false);
 
         let contents = tape
             .drain_final_snapshot()
@@ -8002,7 +8028,7 @@ mod tests {
         let session_capture = capture.clone();
         let (_server, worker) = crate::ipc::test_connection_pair_with_handlers(IpcHandlers {
             on_output_text: Some(Arc::new(move |text| {
-                output_capture.append_text(&text.bytes, text.stream, text.is_continuation);
+                output_capture.append_output_text(&text.bytes, text.stream, text.is_continuation);
             })),
             on_readline_start: Some(Arc::new(move |prompt| {
                 start_capture.append_sideband(PendingSidebandKind::ReadlineStart { prompt });
@@ -8155,7 +8181,7 @@ mod tests {
             updates_previous_image: true,
             readline_results_seen: 1,
         });
-        capture.append_text(b"> lines(4:8, 4:8)\n", TextStream::Stdout, false);
+        capture.append_output_text(b"> lines(4:8, 4:8)\n", TextStream::Stdout, false);
 
         let end = output_ring.end_offset();
         let collapsed = collapse_echo_with_attribution(

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -37,7 +37,9 @@ use crate::output_capture::{
 use crate::output_timeline::{EchoCollapseMode, collapse_echo_with_attribution};
 use crate::oversized_output::OversizedOutputMode;
 use crate::pager::{self, Pager};
-use crate::pending_output_tape::{FormattedPendingOutput, PendingOutputTape, PendingSidebandKind};
+use crate::pending_output_tape::{
+    FormattedPendingOutput, PendingOutputTape, PendingSidebandKind, PendingTextSource,
+};
 use crate::sandbox::{
     R_SESSION_TMPDIR_ENV, SandboxState, SandboxStateUpdate,
     prepare_worker_command_with_managed_network,
@@ -5043,6 +5045,10 @@ impl WorkerProcess {
             pending_output_tape.clone(),
             output_timeline.clone(),
         );
+        let readline_echo_source = match backend {
+            Backend::R => PendingTextSource::Ipc,
+            Backend::Python => PendingTextSource::Raw,
+        };
         let SpawnedWorker {
             child,
             stdin_tx,
@@ -5097,6 +5103,7 @@ impl WorkerProcess {
                         sideband_capture.append_sideband(PendingSidebandKind::ReadlineResult {
                             prompt: event.prompt,
                             line: event.line,
+                            echo_source: readline_echo_source,
                         });
                     }))
                 },
@@ -7479,6 +7486,7 @@ mod tests {
             .append_sideband(PendingSidebandKind::ReadlineResult {
                 prompt: "> ".to_string(),
                 line: "Sys.sleep(5)\n".to_string(),
+                echo_source: PendingTextSource::Ipc,
             });
 
         let formatted = manager.drain_formatted_output();
@@ -7507,6 +7515,7 @@ mod tests {
             .append_sideband(PendingSidebandKind::ReadlineResult {
                 prompt: "> ".to_string(),
                 line: "Sys.sleep(5)\n".to_string(),
+                echo_source: PendingTextSource::Ipc,
             });
         manager.pending_output_tape.append_stdout_bytes(b"start\n");
 
@@ -7536,6 +7545,7 @@ mod tests {
             .append_sideband(PendingSidebandKind::ReadlineResult {
                 prompt: "> ".to_string(),
                 line: "Sys.sleep(5)\n".to_string(),
+                echo_source: PendingTextSource::Ipc,
             });
 
         let context = manager.prepare_input_context_files();
@@ -7980,6 +7990,7 @@ mod tests {
         capture.append_sideband(PendingSidebandKind::ReadlineResult {
             prompt: "> ".to_string(),
             line: "lines(4:8, 4:8)\n".to_string(),
+            echo_source: PendingTextSource::Ipc,
         });
         capture.append_image(IpcPlotImage {
             id: "img-1".to_string(),
@@ -8037,6 +8048,7 @@ mod tests {
                 result_capture.append_sideband(PendingSidebandKind::ReadlineResult {
                     prompt: event.prompt,
                     line: event.line,
+                    echo_source: PendingTextSource::Ipc,
                 });
             })),
             on_plot_image: Some(Arc::new(move |image| {
@@ -8112,7 +8124,7 @@ mod tests {
         assert!(matches!(
             &snapshot.events[2],
             PendingOutputEvent::Sideband {
-                kind: PendingSidebandKind::ReadlineResult { prompt, line },
+                kind: PendingSidebandKind::ReadlineResult { prompt, line, .. },
                 ..
             } if prompt == "> " && line == "plot(1)\n"
         ));


### PR DESCRIPTION
## Summary

This is one small step in the larger refactor to move output onto synchronous IPC, so output text and output-related events travel through one ordered path instead of racing against stdout/stderr.

This PR updates files-mode prompt echo bookkeeping to remember which output path produced the carried echo text. That keeps existing echo de-duplication working as output moves to the synchronous path, without applying carryover from one output path to another.

Python prompt handling is unchanged.

## Testing

- Required Rust checks passed locally.
- `review-loop` is clean.
- Manual CI is green: https://github.com/posit-dev/mcp-repl/actions/runs/25562384189
