### PR TITLE
Use framed R completion metadata

### DIFF
--- a/docs/plans/active/r-owned-output-synchronous-ipc.md
+++ b/docs/plans/active/r-owned-output-synchronous-ipc.md
@@ -68,4 +68,5 @@
   the source from prompt spelling.
 - 2026-05-08: Stopped treating R raw stdout that equals the primary prompt as
   the completion prompt. The server now appends the R completion prompt from
-  framed IPC facts while leaving prompt-shaped child stdout visible.
+  framed IPC facts, including interrupt-drained completions, while leaving
+  prompt-shaped child stdout visible.

--- a/docs/plans/active/r-owned-output-synchronous-ipc.md
+++ b/docs/plans/active/r-owned-output-synchronous-ipc.md
@@ -27,7 +27,8 @@
 - Phase 2: completed - route R console callbacks and readline echo through `output_text`.
 - Phase 3: in progress - R-shaped raw stdout is no longer trimmed by files-mode
   sideband-first carryover; R-owned `output_text` echo still has source-aware
-  carryover for drain boundaries.
+  carryover for drain boundaries. R completion prompts are now appended from
+  framed prompt facts instead of stripping prompt-shaped raw stdout.
 
 ## Locked Decisions
 
@@ -42,7 +43,8 @@
 ## Next Safe Slice
 
 - Review remaining prompt-fallback cleanup in `src/worker_process.rs`; keep raw
-  pipe fallback separate from source-aware IPC echo carryover.
+  pipe fallback separate from source-aware IPC echo carryover. Next, make
+  same-drain echo collapse source-aware instead of matching by prompt text only.
 
 ## Stop Conditions
 
@@ -64,3 +66,6 @@
   echo source on `readline_result`, so Python raw prompt echo and R-owned
   `output_text` echo can both carry across drain boundaries without deriving
   the source from prompt spelling.
+- 2026-05-08: Stopped treating R raw stdout that equals the primary prompt as
+  the completion prompt. The server now appends the R completion prompt from
+  framed IPC facts while leaving prompt-shaped child stdout visible.

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -1662,10 +1662,7 @@ impl WorkerManager {
             contents.push(idle_status_content());
         }
         if !timed_out && !session_end {
-            if let Some(prompt_text) = resolved_prompt.as_deref() {
-                strip_prompt_from_contents(&mut contents, prompt_text);
-            }
-            append_prompt_if_missing(&mut contents, resolved_prompt.clone());
+            reconcile_completion_prompt(&mut contents, resolved_prompt.clone(), self.backend);
         }
 
         Ok(ReplyWithOffset {
@@ -1804,11 +1801,12 @@ impl WorkerManager {
             self.pager_prompt = resolved_prompt.clone();
         }
         if !timed_out && !session_end {
-            if let Some(prompt_text) = resolved_prompt.as_deref() {
-                strip_prompt_from_contents(&mut contents, prompt_text);
-            }
             if !self.pager.is_active() {
-                append_prompt_if_missing(&mut contents, resolved_prompt.clone());
+                reconcile_completion_prompt(&mut contents, resolved_prompt.clone(), self.backend);
+            } else if matches!(self.backend, Backend::Python)
+                && let Some(prompt_text) = resolved_prompt.as_deref()
+            {
+                strip_prompt_from_contents(&mut contents, prompt_text);
             }
         }
 
@@ -2146,10 +2144,11 @@ impl WorkerManager {
                     );
                 }
                 if !session_end {
-                    if let Some(prompt_text) = resolved_prompt.as_deref() {
-                        strip_prompt_from_contents(&mut contents, prompt_text);
-                    }
-                    append_prompt_if_missing(&mut contents, resolved_prompt.clone());
+                    reconcile_completion_prompt(
+                        &mut contents,
+                        resolved_prompt.clone(),
+                        self.backend,
+                    );
                 }
                 self.guardrail.busy.store(false, Ordering::Relaxed);
                 Ok(ReplyWithOffset {
@@ -2298,11 +2297,16 @@ impl WorkerManager {
                     );
                 }
                 if !session_end {
-                    if let Some(prompt_text) = resolved_prompt.as_deref() {
-                        strip_prompt_from_contents(&mut contents, prompt_text);
-                    }
                     if !self.pager.is_active() {
-                        append_prompt_if_missing(&mut contents, resolved_prompt.clone());
+                        reconcile_completion_prompt(
+                            &mut contents,
+                            resolved_prompt.clone(),
+                            self.backend,
+                        );
+                    } else if matches!(self.backend, Backend::Python)
+                        && let Some(prompt_text) = resolved_prompt.as_deref()
+                    {
+                        strip_prompt_from_contents(&mut contents, prompt_text);
                     }
                 }
                 self.guardrail.busy.store(false, Ordering::Relaxed);
@@ -4692,6 +4696,34 @@ fn append_prompt_if_missing(contents: &mut Vec<WorkerContent>, prompt: Option<St
         return;
     }
     contents.push(WorkerContent::worker_stdout(prompt));
+}
+
+fn append_prompt(contents: &mut Vec<WorkerContent>, prompt: Option<String>) {
+    let Some(prompt) = prompt else {
+        return;
+    };
+    if prompt.is_empty() {
+        return;
+    }
+    contents.push(WorkerContent::worker_stdout(prompt));
+}
+
+fn reconcile_completion_prompt(
+    contents: &mut Vec<WorkerContent>,
+    prompt: Option<String>,
+    backend: Backend,
+) {
+    match backend {
+        // R reports completion prompts as framed IPC facts. Prompt-shaped raw
+        // stdout can come from child processes and must stay visible.
+        Backend::R => append_prompt(contents, prompt),
+        Backend::Python => {
+            if let Some(prompt_text) = prompt.as_deref() {
+                strip_prompt_from_contents(contents, prompt_text);
+            }
+            append_prompt_if_missing(contents, prompt);
+        }
+    }
 }
 
 fn strip_trailing_prompt(contents: &mut Vec<WorkerContent>, prompt: &str) {

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -2736,12 +2736,7 @@ impl WorkerManager {
                 WorkerReply::Output { prompt, .. } => prompt.clone(),
             };
             let WorkerReply::Output { contents, .. } = &mut reply.reply;
-            if let Some(prompt) = prompt.as_deref() {
-                strip_trailing_prompt(contents, prompt);
-            }
-            if let Some(prompt) = prompt {
-                append_prompt_if_missing(contents, Some(prompt));
-            }
+            reconcile_polled_completion_prompt(contents, prompt, self.backend);
             let reply = self.finalize_reply(reply);
             self.maybe_reset_after_session_end_with_options(
                 deferred_sandbox_state_update,
@@ -2792,11 +2787,16 @@ impl WorkerManager {
         };
         self.remember_prompt(resolved_prompt.clone());
         if !session_end {
-            if let Some(prompt_text) = resolved_prompt.as_deref() {
-                strip_trailing_prompt(&mut contents, prompt_text);
-            }
             if !timed_out {
-                append_prompt_if_missing(&mut contents, resolved_prompt.clone());
+                reconcile_trailing_completion_prompt(
+                    &mut contents,
+                    resolved_prompt.clone(),
+                    self.backend,
+                );
+            } else if matches!(self.backend, Backend::Python)
+                && let Some(prompt_text) = resolved_prompt.as_deref()
+            {
+                strip_trailing_prompt(&mut contents, prompt_text);
             }
         }
 
@@ -2902,12 +2902,11 @@ impl WorkerManager {
             };
             let WorkerReply::Output { contents, .. } = &mut reply.reply;
             if !pager_active {
-                if let Some(prompt) = prompt.as_deref() {
-                    strip_trailing_prompt(contents, prompt);
-                }
-                if let Some(prompt) = prompt {
-                    append_prompt_if_missing(contents, Some(prompt));
-                }
+                reconcile_polled_completion_prompt(contents, prompt, self.backend);
+            } else if matches!(self.backend, Backend::Python)
+                && let Some(prompt) = prompt.as_deref()
+            {
+                strip_trailing_prompt(contents, prompt);
             }
             let reply = self.finalize_reply(reply);
             self.maybe_reset_after_session_end_with_options(
@@ -2979,11 +2978,16 @@ impl WorkerManager {
             self.pager_prompt = resolved_prompt.clone();
         }
         if !session_end {
-            if let Some(prompt_text) = resolved_prompt.as_deref() {
-                strip_trailing_prompt(&mut contents, prompt_text);
-            }
             if !timed_out && !self.pager.is_active() {
-                append_prompt_if_missing(&mut contents, resolved_prompt.clone());
+                reconcile_trailing_completion_prompt(
+                    &mut contents,
+                    resolved_prompt.clone(),
+                    self.backend,
+                );
+            } else if matches!(self.backend, Backend::Python)
+                && let Some(prompt_text) = resolved_prompt.as_deref()
+            {
+                strip_trailing_prompt(&mut contents, prompt_text);
             }
         }
 
@@ -4720,6 +4724,40 @@ fn reconcile_completion_prompt(
         Backend::Python => {
             if let Some(prompt_text) = prompt.as_deref() {
                 strip_prompt_from_contents(contents, prompt_text);
+            }
+            append_prompt_if_missing(contents, prompt);
+        }
+    }
+}
+
+fn reconcile_trailing_completion_prompt(
+    contents: &mut Vec<WorkerContent>,
+    prompt: Option<String>,
+    backend: Backend,
+) {
+    match backend {
+        // R reports completion prompts as framed IPC facts. Prompt-shaped raw
+        // stdout can come from child processes and must stay visible.
+        Backend::R => append_prompt(contents, prompt),
+        Backend::Python => {
+            if let Some(prompt_text) = prompt.as_deref() {
+                strip_trailing_prompt(contents, prompt_text);
+            }
+            append_prompt_if_missing(contents, prompt);
+        }
+    }
+}
+
+fn reconcile_polled_completion_prompt(
+    contents: &mut Vec<WorkerContent>,
+    prompt: Option<String>,
+    backend: Backend,
+) {
+    match backend {
+        Backend::R => {}
+        Backend::Python => {
+            if let Some(prompt_text) = prompt.as_deref() {
+                strip_trailing_prompt(contents, prompt_text);
             }
             append_prompt_if_missing(contents, prompt);
         }

--- a/tests/interrupt.rs
+++ b/tests/interrupt.rs
@@ -57,6 +57,16 @@ async fn spawn_interrupt_session() -> TestResult<common::McpTestSession> {
     .await
 }
 
+async fn spawn_interrupt_files_session() -> TestResult<common::McpTestSession> {
+    common::spawn_server_with_args(vec![
+        "--sandbox".to_string(),
+        "danger-full-access".to_string(),
+        "--oversized-output".to_string(),
+        "files".to_string(),
+    ])
+    .await
+}
+
 #[cfg(windows)]
 fn backend_unavailable(text: &str) -> bool {
     text.contains("Fatal error: cannot create 'R_TempDir'")
@@ -145,6 +155,64 @@ async fn interrupt_unblocks_long_running_request() -> TestResult<()> {
 
     session.cancel().await?;
     Ok(())
+}
+
+#[cfg(unix)]
+async fn assert_interrupt_drain_preserves_prompt_shaped_child_stdout(
+    session: common::McpTestSession,
+) -> TestResult<()> {
+    let input = "Sys.sleep(0.3); invisible(system(\"printf '> '\"))";
+    let timeout_result = session.write_stdin_raw_with(input, Some(0.05)).await?;
+    let timeout_text = result_text(&timeout_result);
+    if backend_unavailable(&timeout_text) {
+        eprintln!("interrupt test backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert!(
+        timeout_text.contains("<<repl status: busy"),
+        "expected child stdout request to time out, got: {timeout_text:?}"
+    );
+
+    sleep(Duration::from_millis(700)).await;
+
+    let interrupt_result = session.write_stdin_raw_with("\u{3}", Some(5.0)).await?;
+    let interrupt_text = result_text(&interrupt_result);
+    if backend_unavailable(&interrupt_text) {
+        eprintln!("interrupt test backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    if is_busy_response(&interrupt_text) {
+        eprintln!("interrupt drain did not complete in time; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert_eq!(
+        interrupt_text, "> > ",
+        "expected raw prompt-shaped output plus completion prompt, got: {interrupt_text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn interrupt_drain_preserves_prompt_shaped_child_stdout() -> TestResult<()> {
+    let _guard = lock_test_mutex();
+    assert_interrupt_drain_preserves_prompt_shaped_child_stdout(spawn_interrupt_session().await?)
+        .await
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn files_interrupt_drain_preserves_prompt_shaped_child_stdout() -> TestResult<()> {
+    let _guard = lock_test_mutex();
+    assert_interrupt_drain_preserves_prompt_shaped_child_stdout(
+        spawn_interrupt_files_session().await?,
+    )
+    .await
 }
 
 #[cfg(unix)]

--- a/tests/interrupt.rs
+++ b/tests/interrupt.rs
@@ -57,6 +57,7 @@ async fn spawn_interrupt_session() -> TestResult<common::McpTestSession> {
     .await
 }
 
+#[cfg(unix)]
 async fn spawn_interrupt_files_session() -> TestResult<common::McpTestSession> {
     common::spawn_server_with_args(vec![
         "--sandbox".to_string(),

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -1147,14 +1147,20 @@ async fn python_idle_exit_preserves_detached_tail_before_respawn() -> TestResult
         return Ok(());
     };
     let marker_dir = tempdir()?;
-    let marker_path = marker_dir.path().join("idle-worker-exited");
-    let marker = marker_path
+    let tail_marker_path = marker_dir.path().join("idle-tail-written");
+    let tail_marker = tail_marker_path
         .to_str()
-        .ok_or("idle marker path must be valid utf-8")?;
-    let marker_literal = serde_json::to_string(marker)?;
+        .ok_or("idle tail marker path must be valid utf-8")?;
+    let tail_marker_literal = serde_json::to_string(tail_marker)?;
+    let exit_marker_path = marker_dir.path().join("idle-worker-exiting");
+    let exit_marker = exit_marker_path
+        .to_str()
+        .ok_or("idle exit marker path must be valid utf-8")?;
+    let exit_marker_literal = serde_json::to_string(exit_marker)?;
     let script = format!(
-        r#"import os, subprocess, sys, threading, time
-exit_marker = {marker_literal}
+        r#"import os, pathlib, subprocess, sys, threading, time
+tail_marker = {tail_marker_literal}
+exit_marker = {exit_marker_literal}
 writer = """import pathlib, sys, time
 time.sleep(0.2)
 sys.stdout.write("IDLE_TAIL\\n")
@@ -1163,7 +1169,7 @@ pathlib.Path(sys.argv[1]).write_text("done")
 time.sleep(0.2)
 """
 subprocess.Popen(
-    [sys.executable, "-c", writer, exit_marker],
+    [sys.executable, "-c", writer, tail_marker],
     stdin=subprocess.DEVNULL,
     stderr=subprocess.DEVNULL,
     close_fds=True,
@@ -1171,9 +1177,9 @@ subprocess.Popen(
 )
 print("armed")
 def exit_after_detached_tail():
-    while not os.path.exists(exit_marker):
+    while not os.path.exists(tail_marker):
         time.sleep(0.02)
-    time.sleep(0.2)
+    pathlib.Path(exit_marker).write_text("done")
     os._exit(0)
 threading.Thread(target=exit_after_detached_tail, daemon=True).start()"#
     );
@@ -1195,7 +1201,7 @@ threading.Thread(target=exit_after_detached_tail, daemon=True).start()"#
         "expected arming output, got: {arm_text:?}"
     );
 
-    wait_for_detached_holder_exit(&marker_path).await?;
+    wait_for_detached_holder_exit(&exit_marker_path).await?;
     let reply = session
         .write_stdin_raw_with("print('AFTER_RESPAWN')", Some(5.0))
         .await?;

--- a/tests/repl_surface.rs
+++ b/tests/repl_surface.rs
@@ -319,7 +319,7 @@ async fn direct_stdout_fd_write_falls_back_to_raw_stream() -> TestResult<()> {
         "if (!file.exists('/dev/stdout')) { ",
         "cat('SKIP_DIRECT_FD\\n') ",
         "} else { ",
-        "con <- file('/dev/stdout', open = 'wb'); ",
+        "con <- suppressWarnings(file('/dev/stdout', open = 'wb')); ",
         "writeBin(charToRaw('direct-fd\\n'), con); ",
         "flush(con); close(con); ",
         "cat('r-owned\\n') ",
@@ -348,6 +348,54 @@ async fn direct_stdout_fd_write_falls_back_to_raw_stream() -> TestResult<()> {
 
     session.cancel().await?;
     Ok(())
+}
+
+async fn assert_child_stdout_prompt_text_remains_ordinary_output(
+    session: common::McpTestSession,
+) -> TestResult<()> {
+    let input = concat!(
+        "if (.Platform$OS.type == 'windows') { ",
+        "cat('SKIP_CHILD_STDOUT\\n') ",
+        "} else { ",
+        "invisible(system(\"printf '> '\")) ",
+        "}",
+    );
+    let result = session.write_stdin_raw_with(input, Some(30.0)).await?;
+    let text = result_text(&result);
+    if backend_unavailable(&text) {
+        eprintln!("repl_surface backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    if text.contains("SKIP_CHILD_STDOUT") {
+        eprintln!("repl_surface child stdout output unsupported on this platform; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    if busy_response(&text) {
+        return Err(format!("child stdout prompt text remained busy: {text:?}").into());
+    }
+
+    assert_eq!(
+        text, "> > ",
+        "expected raw prompt-shaped output plus completion prompt, got: {text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn child_stdout_prompt_text_remains_ordinary_output() -> TestResult<()> {
+    assert_child_stdout_prompt_text_remains_ordinary_output(common::spawn_server().await?).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn files_child_stdout_prompt_text_remains_ordinary_output() -> TestResult<()> {
+    assert_child_stdout_prompt_text_remains_ordinary_output(
+        common::spawn_server_with_files().await?,
+    )
+    .await
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary
- Use framed IPC completion metadata as the source of the R completion prompt.
- Leave R worker stdout/stderr as ordinary visible output, including output from child processes.
- Add regressions for normal replies, files mode, and interrupt-drained completions.
- Stabilize the Python idle-respawn regression harness that failed on macOS CI.

## Public-facing changes
R replies now preserve output emitted by user code and child processes while still showing the completion prompt supplied by worker protocol metadata.

## Internal-only changes
Prompt finalization is backend-specific: R appends the completion prompt from IPC metadata, while Python keeps its existing completion behavior. The active design plan was updated with the landed slice. The Python idle-respawn test now waits for a worker exit marker before issuing the follow-up request.

## Testing
- `cargo check`
- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo +nightly fmt`
- 30 consecutive runs of `cargo test --test python_backend python_idle_exit_preserves_detached_tail_before_respawn -- --exact --nocapture`
- Review loop clean against `origin/main` for `888bc8f79abc922f7e122cc6ed7b9eabb91990fe`
- Manual CI run: https://github.com/posit-dev/mcp-repl/actions/runs/25568837247
