### PR TITLE
Cover files-mode prompt-shaped raw stdout

### DIFF
--- a/docs/plans/active/r-owned-output-synchronous-ipc.md
+++ b/docs/plans/active/r-owned-output-synchronous-ipc.md
@@ -9,7 +9,7 @@
 
 - State: active
 - Last updated: 2026-05-08
-- Current phase: phase 3 in progress
+- Current phase: phase 3 completed
 
 ## Current Direction
 
@@ -25,10 +25,12 @@
 - Phase 0: completed - protocol frame and synchronous worker IPC writer.
 - Phase 1: completed - append `output_text` into server timelines.
 - Phase 2: completed - route R console callbacks and readline echo through `output_text`.
-- Phase 3: in progress - R-shaped raw stdout is no longer trimmed by files-mode
+- Phase 3: completed - R-shaped raw stdout is no longer trimmed by files-mode
   sideband-first carryover; R-owned `output_text` echo still has source-aware
   carryover for drain boundaries. R completion prompts are now appended from
-  framed prompt facts instead of stripping prompt-shaped raw stdout.
+  framed prompt facts instead of stripping prompt-shaped raw stdout. A public
+  files-mode regression covers raw child stdout that exactly matches a later
+  R-owned prompt/input echo.
 
 ## Locked Decisions
 
@@ -43,8 +45,7 @@
 ## Next Safe Slice
 
 - Review remaining prompt-fallback cleanup in `src/worker_process.rs`; keep raw
-  pipe fallback separate from source-aware IPC echo carryover. Next, make
-  same-drain echo collapse source-aware instead of matching by prompt text only.
+  pipe fallback separate from source-aware IPC echo carryover.
 
 ## Stop Conditions
 
@@ -70,3 +71,8 @@
   the completion prompt. The server now appends the R completion prompt from
   framed IPC facts, including interrupt-drained completions, while leaving
   prompt-shaped child stdout visible.
+- 2026-05-08: Completed the files-mode prompt/readline cleanup slice with a
+  public regression proving raw child stdout that exactly matches a later
+  R-owned prompt/input echo remains visible. No runtime change was needed
+  because same-drain and carryover echo collapse already require matching
+  `readline_result` source facts.

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -1157,19 +1157,29 @@ async fn python_idle_exit_preserves_detached_tail_before_respawn() -> TestResult
         .to_str()
         .ok_or("idle exit marker path must be valid utf-8")?;
     let exit_marker_literal = serde_json::to_string(exit_marker)?;
+    let release_marker_path = marker_dir.path().join("idle-tail-release");
+    let release_marker = release_marker_path
+        .to_str()
+        .ok_or("idle tail release marker path must be valid utf-8")?;
+    let release_marker_literal = serde_json::to_string(release_marker)?;
     let script = format!(
         r#"import os, pathlib, subprocess, sys, threading, time
 tail_marker = {tail_marker_literal}
 exit_marker = {exit_marker_literal}
-writer = """import pathlib, sys, time
-time.sleep(0.2)
+release_marker = {release_marker_literal}
+writer = """import os, pathlib, sys, time
+deadline = time.monotonic() + 5
+while not os.path.exists(sys.argv[2]):
+    if time.monotonic() >= deadline:
+        sys.exit(2)
+    time.sleep(0.02)
 sys.stdout.write("IDLE_TAIL\\n")
 sys.stdout.flush()
 pathlib.Path(sys.argv[1]).write_text("done")
 time.sleep(0.2)
 """
 subprocess.Popen(
-    [sys.executable, "-c", writer, tail_marker],
+    [sys.executable, "-c", writer, tail_marker, release_marker],
     stdin=subprocess.DEVNULL,
     stderr=subprocess.DEVNULL,
     close_fds=True,
@@ -1202,6 +1212,7 @@ threading.Thread(target=exit_after_detached_tail, daemon=True).start()"#
         "expected arming output, got: {arm_text:?}"
     );
 
+    fs::write(&release_marker_path, "go")?;
     wait_for_detached_holder_exit(&exit_marker_path).await?;
     let reply = session
         .write_stdin_raw_with("print('AFTER_RESPAWN')", Some(5.0))

--- a/tests/repl_surface.rs
+++ b/tests/repl_surface.rs
@@ -399,6 +399,54 @@ async fn files_child_stdout_prompt_text_remains_ordinary_output() -> TestResult<
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn files_child_stdout_matching_later_r_echo_remains_visible() -> TestResult<()> {
+    let session = common::spawn_server_with_files().await?;
+
+    let input = concat!(
+        "if (.Platform$OS.type == 'windows') {\n",
+        "  cat('SKIP_CHILD_STDOUT\\n')\n",
+        "} else {\n",
+        "  invisible(system(\"printf '> 1 + 1\\\\n'\"))\n",
+        "}\n",
+        "1 + 1\n",
+    );
+    let result = session.write_stdin_raw_with(input, Some(30.0)).await?;
+    let text = result_text(&result);
+    if backend_unavailable(&text) {
+        eprintln!("repl_surface backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    if text.contains("SKIP_CHILD_STDOUT") {
+        eprintln!("repl_surface child stdout output unsupported on this platform; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    if busy_response(&text) {
+        return Err(format!("child stdout prompt text remained busy: {text:?}").into());
+    }
+
+    let matching_lines = text.matches("> 1 + 1\n").count();
+    assert_eq!(
+        matching_lines, 2,
+        "expected raw child text plus later matching R echo, got: {text:?}"
+    );
+    let raw_child_line = text
+        .find("> 1 + 1\n")
+        .expect("matching line count already checked");
+    let value_line = text
+        .find("[1] 2")
+        .ok_or_else(|| format!("expected later R result, got: {text:?}"))?;
+    assert!(
+        raw_child_line < value_line,
+        "expected raw child text to remain visible before later result, got: {text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn files_keeps_plot_image_before_later_stdout() -> TestResult<()> {
     let session = common::spawn_server_with_files().await?;
 


### PR DESCRIPTION
## Summary

Adds a files-mode regression showing that raw child stdout matching a later R input echo is kept visible, and only the matching echo produced by the R interpreter is elided.

No runtime code changed; the existing files-mode cleanup already uses framed `readline_result` facts for this case.

## Public Facing Changes

- No intentional user-visible output contract changes.

## Internal Changes

- Added a public `repl` surface regression in files mode.
- Stabilized a Python idle-respawn regression so the detached writer is released only after the setup reply returns.
- Updated the active R output IPC plan to mark this slice complete.

## Diff Composition

- Runtime code: none
- Tests: one `repl_surface` regression and one Python lifecycle test synchronization fix
- Docs/plans: active plan status update

## Validation

- `cargo test python_idle_exit_preserves_detached_tail_before_respawn --test python_backend -- --nocapture`
- `cargo test --test python_backend`
- `cargo check`
- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo +nightly fmt`
- `review-loop` against `origin/main`
