### PR TITLE
Move R stdin handling onto the worker protocol timeline

### DIFF
--- a/docs/worker_sideband_protocol.md
+++ b/docs/worker_sideband_protocol.md
@@ -126,16 +126,14 @@ invalid base64, and unknown message types are protocol errors.
 
 These frames remain for built-in workers that have not fully migrated on every
 platform. New protocol workers should not copy them for steady-state request
-handling. Built-in Unix Python still receives the legacy request-boundary
-frames, but stdin accounting comes from CPython readline events rather than a
-separate stdin bridge.
+handling. Built-in R no longer uses them. Built-in Unix Python still receives
+the legacy request-boundary frames, but stdin accounting comes from CPython
+readline events rather than a separate stdin bridge.
 
 `stdin_write`
 - `{ "type": "stdin_write", "byte_len": <usize>, "line_count": <usize>, "final_prompt": <string, optional> }`
 - Legacy server-to-worker request metadata emitted before the server writes raw
   input payload bytes to stdin.
-- Built-in R still uses `byte_len` to make its worker-owned stdin reader consume
-  exactly one raw payload before handing it to embedded R.
 - Built-in Unix Python uses these fields only to install active request state
   before CPython's next readline callback consumes stdin.
 - Non-Unix Python may still use them for the pipe-backed compatibility path

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1709,7 +1709,6 @@ pub fn emit_readline_start(prompt: &str) {
     }
 }
 
-#[cfg(target_family = "unix")]
 pub fn emit_readline_input(text: &str) {
     if let Some(ipc) = global_ipc() {
         let _ = ipc.send(WorkerToServerIpcMessage::ReadlineInput {
@@ -1718,7 +1717,6 @@ pub fn emit_readline_input(text: &str) {
     }
 }
 
-#[cfg(target_family = "unix")]
 pub fn emit_readline_discard(text: &str) {
     if let Some(ipc) = global_ipc() {
         let _ = ipc.send(WorkerToServerIpcMessage::ReadlineDiscard {
@@ -2079,7 +2077,8 @@ mod protocol_tests {
     use super::{
         IpcHandlers, IpcTransport, IpcWaitError, OUTPUT_TEXT_IPC_CHUNK_BYTES,
         OutputCriticalIpcWriter, ServerIpcConnection, ServerToWorkerIpcMessage,
-        WorkerToServerIpcMessage, test_connection_pair_with_handlers,
+        WorkerToServerIpcMessage, emit_readline_discard, emit_readline_input,
+        test_connection_pair_with_handlers,
     };
     use crate::worker_protocol::TextStream;
     use base64::Engine as _;
@@ -2140,6 +2139,12 @@ mod protocol_tests {
             parsed.is_err(),
             "plot_image should reject old worker-owned image fields"
         );
+    }
+
+    #[test]
+    fn readline_accounting_emitters_are_platform_neutral_noops_without_global_ipc() {
+        emit_readline_input("answer\n");
+        emit_readline_discard("queued\n");
     }
 
     #[test]

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -632,6 +632,7 @@ impl ServerIpcConnection {
         Ok(())
     }
 
+    #[cfg_attr(target_family = "unix", allow(dead_code))]
     pub fn begin_request(&self) {
         let mut guard = self.inbox.lock().unwrap();
         reset_after_completed_request(&mut guard);

--- a/src/r_session.rs
+++ b/src/r_session.rs
@@ -3,7 +3,7 @@ use std::ffi::{CStr, CString};
 use std::hash::{Hash, Hasher};
 use std::os::raw::{c_char, c_int, c_uchar};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::thread;
 
 use crate::ipc;
@@ -34,11 +34,7 @@ use windows_sys::Win32::Globalization::{GetACP, MultiByteToWideChar};
 
 const MCP_REPL_R_SCRIPT: &str = include_str!("../r/mcp_repl.R");
 
-#[derive(Debug)]
-pub struct RequestCompleted;
-
 pub struct RSession {
-    sender: mpsc::Sender<RRequest>,
     init: Arc<SessionInit>,
 }
 
@@ -50,40 +46,27 @@ impl RSession {
     }
 
     pub fn start_on_current_thread() -> Result<(), String> {
-        let (request_tx, request_rx) = mpsc::channel();
         let init = Arc::new(SessionInit::new());
-        let session = RSession {
-            sender: request_tx,
-            init: init.clone(),
-        };
+        let session = RSession { init: init.clone() };
         let session_set = SESSION.set(session);
         if session_set.is_err() {
             return Err("R session already initialized".to_string());
         }
-        run_session_on_current_thread(request_rx, init)
+        run_session_on_current_thread(init)
     }
 
     pub fn wait_until_ready(&self) -> Result<(), String> {
         self.init.wait_ready()
     }
 
-    pub fn send_request(&self, input: String) -> Result<mpsc::Receiver<RequestCompleted>, String> {
+    pub fn enqueue_input(&self, input: String) -> Result<(), String> {
         self.wait_until_ready()?;
-        let (reply_tx, reply_rx) = mpsc::channel();
-        let request = RRequest {
-            input,
-            reply: reply_tx,
-        };
-        self.sender
-            .send(request)
-            .map_err(|_| "R session is unavailable".to_string())?;
-        Ok(reply_rx)
+        let state = session_state();
+        let mut guard = state.inner.lock().unwrap();
+        queue_input(&mut guard.input_queue, &input);
+        state.cvar.notify_all();
+        Ok(())
     }
-}
-
-struct RRequest {
-    input: String,
-    reply: mpsc::Sender<RequestCompleted>,
 }
 
 #[derive(Debug)]
@@ -149,37 +132,15 @@ pub(crate) fn clear_pending_input() -> bool {
     };
     let mut guard = state.inner.lock().unwrap();
     let had_pending = !guard.input_queue.is_empty();
-    guard.input_queue.clear();
+    let discarded = drain_input_queue(&mut guard.input_queue);
+    drop(guard);
+    if !discarded.is_empty() {
+        ipc::emit_readline_discard(&discarded);
+    }
     had_pending
 }
 
-#[cfg(target_family = "windows")]
-pub(crate) fn complete_active_request_if_idle() -> bool {
-    let Some(state) = SESSION_STATE.get() else {
-        return false;
-    };
-    let mut guard = state.inner.lock().unwrap();
-    if !guard.input_queue.is_empty() {
-        return false;
-    }
-    let prompt = guard
-        .last_prompt
-        .clone()
-        .unwrap_or_else(|| "> ".to_string());
-    let active = guard.active_request.take();
-    let had_active = active.is_some();
-    drop(guard);
-    if had_active {
-        ipc::emit_readline_start(&prompt);
-        complete_active_request(state, active, false);
-    }
-    had_active
-}
-
-fn run_session_on_current_thread(
-    requests: mpsc::Receiver<RRequest>,
-    init: Arc<SessionInit>,
-) -> Result<(), String> {
+fn run_session_on_current_thread(init: Arc<SessionInit>) -> Result<(), String> {
     crate::diagnostics::startup_log("r-session: init begin");
     let state = Arc::new(SessionState::new());
     if SESSION_STATE.set(state.clone()).is_err() {
@@ -201,12 +162,6 @@ fn run_session_on_current_thread(
 
     init.mark_ready();
 
-    let request_state = state.clone();
-    thread::Builder::new()
-        .name("r-session-requests".to_string())
-        .spawn(move || handle_requests(requests, request_state))
-        .expect("failed to spawn request handler thread");
-
     unsafe {
         libr::run_Rmainloop();
     }
@@ -221,15 +176,10 @@ struct SessionState {
 
 struct SessionStateInner {
     input_queue: VecDeque<String>,
-    active_request: Option<ActiveRequest>,
+    plot_hashes: HashMap<String, u64>,
     last_prompt: Option<String>,
     shutdown: bool,
     session_end_emitted: bool,
-}
-
-struct ActiveRequest {
-    reply: mpsc::Sender<RequestCompleted>,
-    plot_hashes: HashMap<String, u64>,
 }
 
 impl SessionState {
@@ -237,7 +187,7 @@ impl SessionState {
         Self {
             inner: Mutex::new(SessionStateInner {
                 input_queue: VecDeque::new(),
-                active_request: None,
+                plot_hashes: HashMap::new(),
                 last_prompt: None,
                 shutdown: false,
                 session_end_emitted: false,
@@ -245,30 +195,6 @@ impl SessionState {
             cvar: Condvar::new(),
         }
     }
-}
-
-fn handle_requests(requests: mpsc::Receiver<RRequest>, state: Arc<SessionState>) {
-    for request in requests {
-        let mut guard = state.inner.lock().unwrap();
-        while guard.active_request.is_some() {
-            guard = state.cvar.wait(guard).unwrap();
-        }
-        let is_eof = is_eof_input(&request.input);
-        guard.active_request = Some(ActiveRequest {
-            reply: request.reply,
-            plot_hashes: HashMap::new(),
-        });
-        if is_eof {
-            guard.shutdown = true;
-        } else {
-            queue_input(&mut guard.input_queue, &request.input);
-        }
-        state.cvar.notify_all();
-    }
-
-    let mut guard = state.inner.lock().unwrap();
-    guard.shutdown = true;
-    state.cvar.notify_all();
 }
 
 fn initialize_r() -> Result<(), String> {
@@ -680,12 +606,8 @@ fn queue_input(queue: &mut VecDeque<String>, input: &str) {
     if input.is_empty() {
         return;
     }
-    let normalized = input.replace("\r\n", "\n");
-    let mut lines: Vec<String> = normalized
-        .split_inclusive('\n')
-        .map(str::to_string)
-        .collect();
-    if !normalized.ends_with('\n') {
+    let mut lines: Vec<String> = input.split_inclusive('\n').map(str::to_string).collect();
+    if !input.ends_with('\n') {
         if let Some(last) = lines.last_mut() {
             last.push('\n');
         } else {
@@ -695,16 +617,25 @@ fn queue_input(queue: &mut VecDeque<String>, input: &str) {
     queue.extend(lines);
 }
 
-fn is_eof_input(input: &str) -> bool {
-    let trimmed = input.trim_matches(|ch| ch == '\n' || ch == '\r');
-    let mut saw_eot = false;
-    for ch in trimmed.chars() {
-        match ch {
-            '\u{4}' => saw_eot = true,
-            _ => return false,
-        }
+fn drain_input_queue(queue: &mut VecDeque<String>) -> String {
+    let mut drained = String::new();
+    while let Some(line) = queue.pop_front() {
+        drained.push_str(&line);
     }
-    saw_eot
+    drained
+}
+
+fn split_console_line(mut line: String, max: usize) -> (String, Option<String>) {
+    if line.len() <= max {
+        return (line, None);
+    }
+    let mut split = max;
+    while split > 0 && !line.is_char_boundary(split) {
+        split -= 1;
+    }
+    assert!(split > 0, "R console buffer is too small for UTF-8 input");
+    let tail = line.split_off(split);
+    (line, Some(tail))
 }
 
 fn emit_output_text(stream: TextStream, bytes: &[u8]) {
@@ -918,15 +849,7 @@ fn decode_console_bytes_for_channel(_otype: c_int, bytes: &[u8]) -> Vec<u8> {
     bytes.to_vec()
 }
 
-fn complete_active_request(
-    state: &Arc<SessionState>,
-    active: Option<ActiveRequest>,
-    emit_session_end: bool,
-) {
-    if let Some(active) = active {
-        let _ = active.reply.send(RequestCompleted);
-        state.cvar.notify_all();
-    }
+fn complete_session_if_needed(emit_session_end: bool) {
     if emit_session_end {
         ipc::emit_session_end();
     }
@@ -961,17 +884,7 @@ pub extern "C-unwind" fn r_show_message(buf: *const c_char) {
 
 #[unsafe(no_mangle)]
 pub extern "C-unwind" fn r_busy(which: c_int) {
-    #[cfg(target_family = "windows")]
-    {
-        if which == 0 {
-            let _ = complete_active_request_if_idle();
-        }
-    }
-
-    #[cfg(not(target_family = "windows"))]
-    {
-        let _ = which;
-    }
+    let _ = which;
 }
 
 #[unsafe(no_mangle)]
@@ -987,9 +900,8 @@ pub extern "C-unwind" fn r_suicide(buf: *const c_char) {
     let mut guard = state.inner.lock().unwrap();
     let should_emit = !guard.session_end_emitted;
     guard.session_end_emitted = true;
-    let active = guard.active_request.take();
     drop(guard);
-    complete_active_request(state, active, should_emit);
+    complete_session_if_needed(should_emit);
     panic!("{message}");
 }
 
@@ -1018,27 +930,27 @@ pub extern "C-unwind" fn r_read_console(
         .map(|text| text.to_ascii_lowercase().contains("save workspace image"))
         .unwrap_or(false);
     let state = session_state();
+    ipc::emit_readline_start(prompt);
     let emit_idle_start;
     {
         let mut guard = state.inner.lock().unwrap();
         guard.last_prompt = Some(prompt.to_string());
-        emit_idle_start = guard.active_request.is_none() && guard.input_queue.is_empty();
-    }
-    if emit_idle_start {
-        ipc::emit_readline_start(prompt);
+        emit_idle_start = guard.input_queue.is_empty();
+        if emit_idle_start {
+            guard.plot_hashes.clear();
+        }
     }
 
     loop {
         let mut guard = state.inner.lock().unwrap();
 
         if is_save_prompt {
-            let active = guard.active_request.take();
             let should_emit = guard.shutdown && !guard.session_end_emitted;
             if guard.shutdown {
                 guard.session_end_emitted = true;
             }
             drop(guard);
-            complete_active_request(state, active, should_emit);
+            complete_session_if_needed(should_emit);
             if !buf.is_null() {
                 let response = b"n\n";
                 let max = (buflen as usize).saturating_sub(1);
@@ -1061,9 +973,8 @@ pub extern "C-unwind" fn r_read_console(
         if guard.shutdown {
             let should_emit = !guard.session_end_emitted;
             guard.session_end_emitted = true;
-            let active = guard.active_request.take();
             drop(guard);
-            complete_active_request(state, active, should_emit);
+            complete_session_if_needed(should_emit);
             if !buf.is_null() {
                 unsafe { *buf = 0 };
             }
@@ -1071,25 +982,21 @@ pub extern "C-unwind" fn r_read_console(
         }
 
         if let Some(line) = guard.input_queue.pop_front() {
-            let mut bytes = line.into_bytes();
-            if bytes.is_empty() || *bytes.last().unwrap() != b'\n' {
-                bytes.push(b'\n');
-            }
-
             let max = (buflen as usize).saturating_sub(1);
-            let (head, tail) = if bytes.len() > max {
-                bytes.split_at(max)
-            } else {
-                (bytes.as_slice(), &[][..])
-            };
-
-            if !tail.is_empty() {
-                let remainder = String::from_utf8_lossy(tail).to_string();
+            let (line_text, tail) = split_console_line(line, max);
+            if let Some(remainder) = tail {
                 guard.input_queue.push_front(remainder);
             }
             drop(guard);
 
-            let line_text = String::from_utf8_lossy(head).to_string();
+            let head = line_text.as_bytes();
+            if !buf.is_null() {
+                unsafe {
+                    std::ptr::copy_nonoverlapping(head.as_ptr(), buf, head.len());
+                    *buf.add(head.len()) = 0;
+                }
+            }
+            ipc::emit_readline_input(&line_text);
             let mut echoed = String::with_capacity(prompt.len() + line_text.len());
             echoed.push_str(prompt);
             echoed.push_str(&line_text);
@@ -1098,21 +1005,7 @@ pub extern "C-unwind" fn r_read_console(
                 emit_output_text(TextStream::Stdout, echoed.as_bytes());
             }
 
-            if !buf.is_null() {
-                unsafe {
-                    std::ptr::copy_nonoverlapping(head.as_ptr(), buf, head.len());
-                    *buf.add(head.len()) = 0;
-                }
-            }
-
             return 1;
-        }
-
-        if let Some(active) = guard.active_request.take() {
-            drop(guard);
-            ipc::emit_readline_start(prompt);
-            complete_active_request(state, Some(active), false);
-            continue;
         }
 
         guard = state.cvar.wait(guard).unwrap();
@@ -1130,19 +1023,16 @@ pub(crate) fn push_plot_image(
         .inner
         .lock()
         .map_err(|_| "session state lock poisoned".to_string())?;
-    let Some(active) = guard.active_request.as_mut() else {
-        return Ok(());
-    };
 
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     bytes.hash(&mut hasher);
     let hash = hasher.finish();
 
-    if active.plot_hashes.get(&plot_id) == Some(&hash) {
+    if guard.plot_hashes.get(&plot_id) == Some(&hash) {
         return Ok(());
     }
 
-    active.plot_hashes.insert(plot_id.clone(), hash);
+    guard.plot_hashes.insert(plot_id.clone(), hash);
     let mime_type = if mime_type.trim().is_empty() {
         "image/png".to_string()
     } else {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,112 +1,34 @@
-use std::io::Read;
+use std::io::BufRead;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, mpsc};
-#[cfg(windows)]
-use std::sync::{Condvar, Mutex};
 use std::thread;
 use std::time::Duration;
 
 use crate::backend::{Backend, backend_from_env};
-use crate::ipc::{
-    ServerToWorkerIpcMessage, connect_from_env, emit_session_end, emit_worker_ready, set_global_ipc,
-};
+use crate::ipc::{ServerToWorkerIpcMessage, connect_from_env, emit_worker_ready, set_global_ipc};
 use crate::r_session::RSession;
 use crate::worker_protocol::WORKER_MODE_ARG;
 
 struct WorkerState {
-    busy: AtomicBool,
     shutting_down: AtomicBool,
-    #[cfg(windows)]
-    stdin_read_in_progress: AtomicBool,
-    #[cfg(windows)]
-    stdin_wait: Mutex<()>,
-    #[cfg(windows)]
-    stdin_wait_cvar: Condvar,
 }
 
 impl WorkerState {
-    fn try_mark_busy(&self) -> bool {
-        #[cfg(windows)]
-        {
-            let mut guard = self.stdin_wait.lock().unwrap();
-            while self.stdin_read_in_progress.load(Ordering::SeqCst) && !self.is_shutting_down() {
-                guard = self.stdin_wait_cvar.wait(guard).unwrap();
-            }
-            if self.is_shutting_down() {
-                return false;
-            }
-        }
-        self.busy
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_ok()
-    }
-
-    fn mark_idle(&self) {
-        #[cfg(windows)]
-        let _guard = self.stdin_wait.lock().unwrap();
-        self.busy.store(false, Ordering::SeqCst);
-        #[cfg(windows)]
-        self.stdin_wait_cvar.notify_all();
-    }
-
     fn begin_shutdown(&self) {
-        #[cfg(windows)]
-        let _guard = self.stdin_wait.lock().unwrap();
         self.shutting_down.store(true, Ordering::SeqCst);
-        #[cfg(windows)]
-        self.stdin_wait_cvar.notify_all();
     }
 
     fn is_shutting_down(&self) -> bool {
         self.shutting_down.load(Ordering::SeqCst)
-    }
-
-    #[cfg(windows)]
-    fn wait_until_stdin_read_allowed(&self) -> bool {
-        let mut guard = self.stdin_wait.lock().unwrap();
-        while (self.busy.load(Ordering::SeqCst)
-            || self.stdin_read_in_progress.load(Ordering::SeqCst))
-            && !self.is_shutting_down()
-        {
-            guard = self.stdin_wait_cvar.wait(guard).unwrap();
-        }
-        if self.is_shutting_down() {
-            return false;
-        }
-        self.stdin_read_in_progress.store(true, Ordering::SeqCst);
-        true
-    }
-
-    #[cfg(windows)]
-    fn finish_stdin_read(&self) {
-        let _guard = self.stdin_wait.lock().unwrap();
-        self.stdin_read_in_progress.store(false, Ordering::SeqCst);
-        self.stdin_wait_cvar.notify_all();
     }
 }
 
 impl Default for WorkerState {
     fn default() -> Self {
         Self {
-            busy: AtomicBool::new(false),
             shutting_down: AtomicBool::new(false),
-            #[cfg(windows)]
-            stdin_read_in_progress: AtomicBool::new(false),
-            #[cfg(windows)]
-            stdin_wait: Mutex::new(()),
-            #[cfg(windows)]
-            stdin_wait_cvar: Condvar::new(),
         }
     }
-}
-
-struct QueuedRequest {
-    text: String,
-}
-
-enum StdinReadCommand {
-    Read { byte_len: usize },
-    Shutdown,
 }
 
 pub fn is_worker_mode() -> bool {
@@ -125,25 +47,17 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
 fn run_r_worker() -> Result<(), Box<dyn std::error::Error>> {
     crate::diagnostics::startup_log("worker: run begin");
     let state = Arc::new(WorkerState::default());
-    let (request_tx, request_rx) = mpsc::sync_channel(1);
-    let (stdin_tx, stdin_rx) = mpsc::channel();
-    init_ipc(state.clone(), stdin_tx.clone()).map_err(|err| {
+    init_ipc(state.clone()).map_err(|err| {
         eprintln!("worker ipc init error: {err}");
         err
     })?;
     emit_worker_ready("r", true, Some("quit(\"no\")\n"));
-    let request_state = state.clone();
-    let _request_thread = thread::Builder::new()
-        .name("worker-requests".to_string())
-        .spawn(move || request_loop(request_rx, request_state))
-        .map_err(|err| format!("failed to spawn worker request thread: {err}"))?;
 
     let stdin_state = state.clone();
-    let stdin_requests = request_tx.clone();
     let _stdin_thread = thread::Builder::new()
         .name("worker-stdin".to_string())
         .spawn(move || {
-            if let Err(err) = stdin_loop(stdin_state, stdin_rx, stdin_requests) {
+            if let Err(err) = stdin_loop(stdin_state) {
                 eprintln!("worker stdin error: {err}");
             }
         })
@@ -168,10 +82,7 @@ fn wait_for_r_session() -> Result<&'static RSession, String> {
     }
 }
 
-fn init_ipc(
-    state: Arc<WorkerState>,
-    stdin_tx: mpsc::Sender<StdinReadCommand>,
-) -> Result<(), Box<dyn std::error::Error>> {
+fn init_ipc(state: Arc<WorkerState>) -> Result<(), Box<dyn std::error::Error>> {
     let conn = connect_from_env(Duration::from_secs(2))?;
     set_global_ipc(conn.clone());
     if let Err(err) = thread::Builder::new()
@@ -181,15 +92,7 @@ fn init_ipc(
                 match conn.recv(None) {
                     Some(ServerToWorkerIpcMessage::RequestStart) => {}
                     Some(ServerToWorkerIpcMessage::PythonRequestStart { .. }) => {}
-                    Some(ServerToWorkerIpcMessage::StdinWrite {
-                        byte_len,
-                        line_count: _,
-                        final_prompt: _,
-                    }) => {
-                        if stdin_tx.send(StdinReadCommand::Read { byte_len }).is_err() {
-                            std::process::exit(0);
-                        }
-                    }
+                    Some(ServerToWorkerIpcMessage::StdinWrite { .. }) => {}
                     Some(ServerToWorkerIpcMessage::StdinWriteComplete) => {}
                     Some(ServerToWorkerIpcMessage::Interrupt) => {
                         crate::r_session::clear_pending_input();
@@ -201,7 +104,6 @@ fn init_ipc(
                         state.begin_shutdown();
                         crate::r_session::clear_pending_input();
                         let _ = crate::r_session::request_shutdown();
-                        let _ = stdin_tx.send(StdinReadCommand::Shutdown);
                     }
                     None => {
                         // Without IPC, the worker cannot participate in turn accounting (prompt,
@@ -217,38 +119,23 @@ fn init_ipc(
     Ok(())
 }
 
-fn stdin_loop(
-    state: Arc<WorkerState>,
-    stdin_rx: mpsc::Receiver<StdinReadCommand>,
-    request_tx: mpsc::SyncSender<QueuedRequest>,
-) -> Result<(), Box<dyn std::error::Error>> {
+fn stdin_loop(state: Arc<WorkerState>) -> Result<(), Box<dyn std::error::Error>> {
     let stdin = std::io::stdin();
     let mut reader = std::io::BufReader::new(stdin);
-    for command in stdin_rx {
-        let StdinReadCommand::Read { byte_len } = command else {
-            break;
-        };
+    loop {
         if state.is_shutting_down() {
             break;
         }
 
-        let mut buffer = vec![0u8; byte_len];
-        #[cfg(windows)]
-        {
-            if !state.wait_until_stdin_read_allowed() {
-                break;
-            }
-        }
-        let read_result = reader.read_exact(&mut buffer);
-        #[cfg(windows)]
-        state.finish_stdin_read();
-        if let Err(err) = read_result {
+        let mut buffer = Vec::new();
+        let read_len = reader.read_until(b'\n', &mut buffer)?;
+        if read_len == 0 {
             state.begin_shutdown();
             if !crate::r_session::request_shutdown() {
                 crate::ipc::emit_session_end();
                 std::process::exit(0);
             }
-            return Err(err.into());
+            break;
         }
 
         if state.is_shutting_down() {
@@ -256,71 +143,9 @@ fn stdin_loop(
         }
 
         let text = String::from_utf8_lossy(&buffer).to_string();
-        handle_write_stdin(text, state.clone(), &request_tx);
+        let session = wait_for_r_session().map_err(std::io::Error::other)?;
+        session.enqueue_input(text).map_err(std::io::Error::other)?;
     }
 
     Ok(())
-}
-
-fn request_loop(rx: mpsc::Receiver<QueuedRequest>, state: Arc<WorkerState>) {
-    for request in rx {
-        let result = write_stdin_request(request.text);
-        if let Err(err) = result {
-            emit_stderr_message(&err.message);
-            emit_session_end();
-        }
-        state.mark_idle();
-    }
-}
-fn handle_write_stdin(
-    text: String,
-    state: Arc<WorkerState>,
-    request_tx: &mpsc::SyncSender<QueuedRequest>,
-) {
-    if state.is_shutting_down() {
-        return;
-    }
-
-    if !state.try_mark_busy() {
-        emit_stderr_message("worker is busy; request already running");
-        return;
-    }
-
-    if let Err(err) = request_tx.try_send(QueuedRequest { text }) {
-        state.mark_idle();
-        let message = match err {
-            mpsc::TrySendError::Full(_) => "worker is busy; request already running".to_string(),
-            mpsc::TrySendError::Disconnected(_) => {
-                "worker execution thread exited unexpectedly".to_string()
-            }
-        };
-        emit_stderr_message(&message);
-        emit_session_end();
-    }
-}
-
-struct WorkerExecError {
-    message: String,
-}
-
-impl WorkerExecError {
-    fn new(message: impl Into<String>) -> Self {
-        Self {
-            message: message.into(),
-        }
-    }
-}
-
-fn write_stdin_request(text: String) -> Result<(), WorkerExecError> {
-    let session = wait_for_r_session()
-        .map_err(|err| WorkerExecError::new(format!("failed to start R session: {err}")))?;
-    let reply_rx = session.send_request(text).map_err(WorkerExecError::new)?;
-    reply_rx
-        .recv()
-        .map(|_| ())
-        .map_err(|err| WorkerExecError::new(format!("R session reply error: {err}")))
-}
-
-fn emit_stderr_message(message: &str) {
-    crate::output_stream::write_stderr_bytes(message.as_bytes());
 }

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -312,6 +312,7 @@ impl RBackendDriver {
     }
 }
 
+#[cfg_attr(target_family = "unix", allow(dead_code))]
 fn driver_on_input_start(_text: &str, ipc: &ServerIpcConnection) -> Result<(), WorkerError> {
     ipc.begin_request();
     if let Some(message) = ipc.take_protocol_error() {
@@ -320,6 +321,7 @@ fn driver_on_input_start(_text: &str, ipc: &ServerIpcConnection) -> Result<(), W
     Ok(())
 }
 
+#[cfg_attr(target_family = "unix", allow(dead_code))]
 fn driver_announce_stdin_write(
     byte_len: usize,
     line_count: usize,
@@ -401,6 +403,7 @@ fn driver_interrupt(process: &mut WorkerProcess) -> Result<(), WorkerError> {
     process.send_interrupt()
 }
 
+#[cfg_attr(target_family = "unix", allow(dead_code))]
 fn driver_refresh_backend_info(
     ipc: ServerIpcConnection,
     timeout: Duration,
@@ -471,18 +474,25 @@ fn driver_refresh_worker_ready(
 
 impl BackendDriver for RBackendDriver {
     fn prepare_input_payload(&self, text: &str) -> Vec<u8> {
-        text.as_bytes().to_vec()
+        let mut payload = text.as_bytes().to_vec();
+        if !payload.is_empty() && !payload.ends_with(b"\n") {
+            payload.push(b'\n');
+        }
+        payload
     }
 
     fn on_input_start(
         &mut self,
-        text: &str,
+        _text: &str,
         payload: &[u8],
         ipc: &ServerIpcConnection,
         _timeout: Duration,
     ) -> Result<(), WorkerError> {
-        driver_on_input_start(text, ipc)?;
-        driver_announce_stdin_write(payload.len(), 0, None, ipc)
+        ipc.begin_request_with_stdin(payload);
+        if let Some(message) = ipc.take_protocol_error() {
+            return Err(WorkerError::Protocol(message));
+        }
+        Ok(())
     }
 
     fn should_settle_output_after_timeout(
@@ -518,7 +528,7 @@ impl BackendDriver for RBackendDriver {
         ipc: ServerIpcConnection,
         timeout: Duration,
     ) -> Result<(), WorkerError> {
-        driver_refresh_backend_info(ipc, timeout, true)
+        driver_refresh_worker_ready(ipc, timeout)
     }
 }
 

--- a/tests/r_protocol.rs
+++ b/tests/r_protocol.rs
@@ -1,0 +1,176 @@
+#![allow(clippy::await_holding_lock)]
+
+mod common;
+
+use common::TestResult;
+use serde_json::{Map, Value, json};
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+fn test_mutex() -> &'static Mutex<()> {
+    static TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+    TEST_MUTEX.get_or_init(|| Mutex::new(()))
+}
+
+fn server_path() -> TestResult<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_mcp-repl") {
+        return Ok(PathBuf::from(path));
+    }
+
+    let mut path = std::env::current_exe()?;
+    path.pop();
+    path.pop();
+    let mut candidate = path.join("mcp-repl");
+    if cfg!(windows) {
+        candidate.set_extension("exe");
+    }
+    if candidate.exists() {
+        return Ok(candidate);
+    }
+    Err("unable to locate mcp-repl test binary".into())
+}
+
+async fn spawn_custom_r_worker_server() -> TestResult<common::McpTestSession> {
+    let tempdir = tempfile::tempdir()?;
+    let spec_path = tempdir.path().join("r-worker.json");
+    let env = Map::from_iter([(
+        "MCP_REPL_INTERPRETER".to_string(),
+        Value::String("r".to_string()),
+    )]);
+    let spec = json!({
+        "executable": server_path()?,
+        "args": ["worker"],
+        "working_dir": "inherit",
+        "env": env,
+        "stdin": "pipe",
+        "sandbox": "server"
+    });
+    std::fs::write(&spec_path, serde_json::to_vec_pretty(&spec)?)?;
+    common::spawn_server_with_args(vec![
+        "--worker-spec".to_string(),
+        spec_path.display().to_string(),
+        "--sandbox".to_string(),
+        "danger-full-access".to_string(),
+        "--oversized-output".to_string(),
+        "files".to_string(),
+    ])
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn custom_r_worker_spec_uses_generic_protocol() -> TestResult<()> {
+    let _guard = test_mutex()
+        .lock()
+        .map_err(|_| "r_protocol test mutex poisoned")?;
+    let session = spawn_custom_r_worker_server().await?;
+
+    let result = session
+        .write_stdin_raw_unterminated_with("1+1", Some(2.0))
+        .await?;
+    let text = common::result_text(&result);
+    if common::backend_unavailable(&text) {
+        eprintln!("r_protocol backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    session.cancel().await?;
+
+    assert!(
+        text.contains("2"),
+        "expected custom-launched R worker to evaluate through generic protocol, got: {text:?}"
+    );
+    assert!(
+        text.contains(">"),
+        "expected worker-supplied R prompt in response, got: {text:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn custom_r_worker_spec_handles_readline_follow_up() -> TestResult<()> {
+    let _guard = test_mutex()
+        .lock()
+        .map_err(|_| "r_protocol test mutex poisoned")?;
+    let session = spawn_custom_r_worker_server().await?;
+
+    let waiting = session
+        .write_stdin_raw_unterminated_with("value <- readline('FIRST> ')", Some(2.0))
+        .await?;
+    let waiting_text = common::result_text(&waiting);
+    if common::backend_unavailable(&waiting_text) {
+        eprintln!("r_protocol backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert!(
+        waiting_text.contains("FIRST> "),
+        "expected R readline prompt, got: {waiting_text:?}"
+    );
+
+    let answered = session
+        .write_stdin_raw_unterminated_with("alpha", Some(2.0))
+        .await?;
+    let answered_text = common::result_text(&answered);
+    assert!(
+        answered_text.contains(">"),
+        "expected R to return to top-level prompt after readline input, got: {answered_text:?}"
+    );
+
+    let printed = session
+        .write_stdin_raw_unterminated_with("cat(value, '\\n')", Some(2.0))
+        .await?;
+    let printed_text = common::result_text(&printed);
+    session.cancel().await?;
+
+    assert!(
+        printed_text.contains("alpha"),
+        "expected readline follow-up input to reach R, got: {printed_text:?}"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn custom_r_worker_spec_discards_buffered_input_on_interrupt() -> TestResult<()> {
+    let _guard = test_mutex()
+        .lock()
+        .map_err(|_| "r_protocol test mutex poisoned")?;
+    let mut session = spawn_custom_r_worker_server().await?;
+
+    let first = session
+        .write_stdin_raw_unterminated_with("Sys.sleep(5)\ncat('SHOULD_NOT_RUN\\n')", Some(0.1))
+        .await?;
+    let first_text = common::result_text(&first);
+    if common::backend_unavailable(&first_text) {
+        eprintln!("r_protocol backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert!(
+        common::is_busy_response(&first_text),
+        "expected long R request to time out, got: {first_text:?}"
+    );
+
+    let interrupted = session
+        .write_stdin_raw_unterminated_with("\u{3}cat('AFTER_INTERRUPT\\n')", Some(10.0))
+        .await?;
+    let interrupted = common::wait_until_not_busy(
+        &mut session,
+        interrupted,
+        std::time::Duration::from_millis(50),
+        std::time::Duration::from_secs(10),
+    )
+    .await?;
+    let interrupted_text = common::result_text(&interrupted);
+    session.cancel().await?;
+
+    assert!(
+        interrupted_text.contains("AFTER_INTERRUPT"),
+        "expected interrupt tail to run after R recovery, got: {interrupted_text:?}"
+    );
+    assert!(
+        !interrupted_text.contains("SHOULD_NOT_RUN"),
+        "expected buffered pre-interrupt input to be discarded, got: {interrupted_text:?}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

This is an architecture cleanup for the worker/server boundary.

Historically, worker structural facts traveled over sideband while much of the visible output traveled over stdout/stderr. That forced the server to reconstruct a single timeline from separate channels, which led to timing-sensitive behavior, prompt/output reconciliation, and backend-specific gating.

The target shape is simpler: worker-owned output and stdin facts arrive pre-ordered on the protocol timeline. Raw stdout/stderr remain as fallback for unowned output, mostly from forked child processes where deterministic ordering is not guaranteed anyway.

This PR moves R further into that model by making R request handling stdin-accounted and protocol-driven instead of relying on transitional request metadata.

## Summary

- Move the built-in R worker off transitional `stdin_write` request handling.
- Use `begin_request_with_stdin()` so the server accounts for R input generically.
- Have the R worker read stdin directly and enqueue input into the R session.
- Emit `readline_input` for R input delivered to the runtime-facing console layer.
- Emit `readline_discard` for queued R input discarded during interrupt cleanup.
- Add MCP-level coverage for a custom-launched R worker using the generic protocol path.
- Update protocol docs to state that built-in R no longer uses transitional stdin frames.

## Public-facing changes

Existing R MCP behavior should be preserved. This is primarily an internal boundary change.

## Internal changes

- Removes R-specific request channel and active-request completion bookkeeping.
- Reduces server knowledge of R request state.
- Keeps transitional stdin frames available for Python compatibility, but R no longer consumes them.
- Moves R closer to the language-agnostic worker contract where the worker owns runtime semantics and the server finalizes replies from ordered protocol facts.

## Diff composition

- Runtime code: `src/r_session.rs`, `src/worker.rs`, `src/worker_process.rs`, `src/ipc.rs`
- Tests: `tests/r_protocol.rs`
- Docs: `docs/worker_sideband_protocol.md`

## Testing

- `cargo +nightly fmt`
- `cargo check`
- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
