### PR TITLE
Migrate integration tests to exact MCP responses

### DIFF
--- a/src/sandbox/seatbelt_base_policy.sbpl
+++ b/src/sandbox/seatbelt_base_policy.sbpl
@@ -22,6 +22,12 @@
   (require-all
     (path "/dev/null")
     (vnode-type CHARACTER-DEVICE)))
+; Allow runtimes and child processes to write directly to inherited stdout/stderr
+; through the standard device aliases.
+(allow file-read* file-write*
+  (literal "/dev/stdout")
+  (literal "/dev/stderr")
+  (regex #"^/dev/fd/[12]$"))
 ; Allow uv's SystemConfiguration probe to touch /dev/dtracehelper on macOS.
 (allow file-write-data
   (require-all

--- a/src/sandbox/seatbelt_base_policy.sbpl
+++ b/src/sandbox/seatbelt_base_policy.sbpl
@@ -22,12 +22,8 @@
   (require-all
     (path "/dev/null")
     (vnode-type CHARACTER-DEVICE)))
-; Allow runtimes and child processes to write directly to inherited stdout/stderr
-; through the standard device aliases.
-(allow file-read* file-write*
-  (literal "/dev/stdout")
-  (literal "/dev/stderr")
-  (regex #"^/dev/fd/[12]$"))
+; Do not allow /dev/stdout, /dev/stderr, or /dev/fd aliases without a real
+; package or user workflow that requires reopening inherited stdio by path.
 ; Allow uv's SystemConfiguration probe to touch /dev/dtracehelper on macOS.
 (allow file-write-data
   (require-all

--- a/tests/codex_integration.rs
+++ b/tests/codex_integration.rs
@@ -40,9 +40,6 @@ mod unix_impl {
     const MOCK_TOOL_INPUT: &str = "cat(\"CODEX_MOCK_MCP_OK\\n\")\n";
     const LIVE_FINAL_MARKER: &str = "CODEX_LIVE_DONE";
     const INSTALL_SCRIPTED_TOOL_CALL_MARKER: &str = "INSTALL_SCRIPTED_TOOL_CALL";
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
-    const FULL_ACCESS_TEST_ENV: &str = "MCP_REPL_ENABLE_FULL_ACCESS_TUI_TEST";
-
     fn codex_exec_test_mutex() -> &'static tokio::sync::Mutex<()> {
         static TEST_MUTEX: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
         TEST_MUTEX.get_or_init(|| tokio::sync::Mutex::new(()))
@@ -426,17 +423,10 @@ mod unix_impl {
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     pub(super) async fn run_codex_tui_full_access_sandbox_update() -> TestResult<()> {
         const TEST_NAME: &str = "codex_tui_full_access_sandbox_update";
-        if !full_access_test_enabled() {
-            print_skip_banner(TEST_NAME, &format!("{FULL_ACCESS_TEST_ENV} is not set"));
-            return Ok(());
-        }
         if !codex_client_ready(TEST_NAME) {
             return Ok(());
         }
-        if !common::sandbox_exec_available() {
-            print_skip_banner(TEST_NAME, "sandbox-exec unavailable");
-            return Ok(());
-        }
+        assert!(common::sandbox_exec_available(), "sandbox-exec unavailable");
         if !loopback_bind_available().await {
             print_skip_banner(TEST_NAME, "loopback TCP bind unavailable");
             return Ok(());
@@ -459,15 +449,15 @@ mod unix_impl {
         driver.drain(Duration::from_millis(800));
         driver.ensure_running("after startup")?;
         driver.wait_for_warmup(Duration::from_secs(10))?;
-        wait_for_log_contains(&env.debug_dir, "workspace-write", Duration::from_secs(10))?;
 
         driver.send_line(&format!(
             "{FULL_ACCESS_MARKER}: probe write before full access"
         ))?;
         driver.wait_for_contains("WRITE_ERROR:", Duration::from_secs(20))?;
         driver.wait_for_contains("Tool call 1 completed", Duration::from_secs(20))?;
+        wait_for_log_contains(&env.debug_dir, "workspace-write", Duration::from_secs(10))?;
 
-        driver.send_line("/approvals")?;
+        driver.send_line("/permissions")?;
         driver.wait_for_contains("Update Model Permissions", Duration::from_secs(15))?;
         driver.send("3")?;
         driver.wait_for_contains(
@@ -475,18 +465,17 @@ mod unix_impl {
             Duration::from_secs(15),
         )?;
 
+        driver.send_line(&format!(
+            "{FULL_ACCESS_MARKER}: probe write after full access"
+        ))?;
+        driver.wait_for_contains("WRITE_OK", Duration::from_secs(20))?;
+        driver.wait_for_contains("Tool call 2 completed", Duration::from_secs(20))?;
         wait_for_log_contains(
             &env.debug_dir,
             "danger-full-access",
             Duration::from_secs(20),
         )?;
         wait_for_log_contains(&env.debug_dir, "tool-call-meta", Duration::from_secs(20))?;
-
-        driver.send_line(&format!(
-            "{FULL_ACCESS_MARKER}: probe write after full access"
-        ))?;
-        driver.wait_for_contains("WRITE_OK", Duration::from_secs(20))?;
-        driver.wait_for_contains("Tool call 2 completed", Duration::from_secs(20))?;
         driver.kill()?;
 
         let outputs = mock_server.function_call_outputs().await;
@@ -536,11 +525,6 @@ mod unix_impl {
             "expected parse_error marker in mock request log, got: {last_request:?}"
         );
         Ok(())
-    }
-
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
-    fn full_access_test_enabled() -> bool {
-        std::env::var_os(FULL_ACCESS_TEST_ENV).is_some()
     }
 
     async fn loopback_bind_available() -> bool {
@@ -1513,7 +1497,11 @@ trust_level = "trusted"
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
             .as_nanos();
-        let target = std::env::temp_dir().join(format!("mcp-repl-codex-probe-{nanos}.txt"));
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(PathBuf::from)
+            .ok_or_else(|| "missing HOME/USERPROFILE for outside-workspace probe".to_string())?;
+        let target = home.join(format!(".mcp-repl-codex-probe-{nanos}.txt"));
         let target_literal = serde_json::to_string(&target.to_string_lossy().to_string())
             .map_err(|err| format!("failed to encode target path: {err}"))?;
         Ok(r#"target <- __TARGET__

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -212,11 +212,13 @@ impl Drop for SuiteServerLockToken {
 pub fn sandbox_exec_available() -> bool {
     static AVAILABLE: OnceLock<bool> = OnceLock::new();
     *AVAILABLE.get_or_init(|| {
-        if std::env::var_os("CODEX_SANDBOX").is_some() {
-            return false;
-        }
         std::process::Command::new("/usr/bin/sandbox-exec")
-            .args(["-p", "(version 1)", "--", "/usr/bin/true"])
+            .args([
+                "-p",
+                "(version 1)(allow process-exec)(allow file-read*)",
+                "--",
+                "/usr/bin/true",
+            ])
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())

--- a/tests/debug_repl_prompt.rs
+++ b/tests/debug_repl_prompt.rs
@@ -12,11 +12,13 @@ type TestResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 #[cfg(target_os = "macos")]
 fn sandbox_exec_available() -> bool {
     // Mirror tests/common/mod.rs: sandbox-exec may exist but be unusable (status 71).
-    if std::env::var_os("CODEX_SANDBOX").is_some() {
-        return false;
-    }
     Command::new("/usr/bin/sandbox-exec")
-        .args(["-p", "(version 1)", "--", "/usr/bin/true"])
+        .args([
+            "-p",
+            "(version 1)(allow process-exec)(allow file-read*)",
+            "--",
+            "/usr/bin/true",
+        ])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -241,7 +241,10 @@ async fn python_discovery_keeps_venv_probe_inside_sandbox() -> TestResult<()> {
     assert!(common::sandbox_exec_available(), "sandbox unavailable");
 
     let _guard = lock_test_mutex();
+    let real_python = real_python_executable()?;
     let workspace = tempdir()?;
+    let empty_bin = workspace.path().join("empty-bin");
+    fs::create_dir_all(&empty_bin)?;
     let home = std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
         .map(PathBuf::from)
@@ -260,7 +263,22 @@ async fn python_discovery_keeps_venv_probe_inside_sandbox() -> TestResult<()> {
     let shim = venv_bin.join("python");
     fs::write(
         &shim,
-        "#!/bin/sh\nprintf probe > \"$MCP_REPL_TEST_PYTHON_PROBE_MARKER\"\nexit 1\n",
+        concat!(
+            "#!/bin/sh\n",
+            "exec \"$MCP_REPL_REAL_PYTHON\" - <<'PY'\n",
+            "import os\n",
+            "import sys\n",
+            "from pathlib import Path\n",
+            "\n",
+            "try:\n",
+            "    Path(os.environ['MCP_REPL_TEST_PYTHON_PROBE_MARKER']).write_text('probe')\n",
+            "except Exception as err:\n",
+            "    print(f'MCP_REPL_TEST_PYTHON_PROBE_WRITE_ERROR:{type(err).__name__}', file=sys.stderr)\n",
+            "else:\n",
+            "    print('MCP_REPL_TEST_PYTHON_PROBE_WRITE_OK', file=sys.stderr)\n",
+            "raise SystemExit(1)\n",
+            "PY\n",
+        ),
     )?;
     let mut permissions = fs::metadata(&shim)?.permissions();
     permissions.set_mode(0o755);
@@ -273,7 +291,11 @@ async fn python_discovery_keeps_venv_probe_inside_sandbox() -> TestResult<()> {
             "--sandbox".to_string(),
             "read-only".to_string(),
         ],
-        vec![("MCP_REPL_TEST_PYTHON_PROBE_MARKER".to_string(), marker_text)],
+        vec![
+            ("PATH".to_string(), empty_bin.display().to_string()),
+            ("MCP_REPL_REAL_PYTHON".to_string(), real_python),
+            ("MCP_REPL_TEST_PYTHON_PROBE_MARKER".to_string(), marker_text),
+        ],
         Some(workspace.path().to_path_buf()),
     )
     .await?;
@@ -283,6 +305,10 @@ async fn python_discovery_keeps_venv_probe_inside_sandbox() -> TestResult<()> {
     let marker_exists = marker.exists();
     let _ = fs::remove_file(&marker);
 
+    assert!(
+        text.contains("MCP_REPL_TEST_PYTHON_PROBE_WRITE_ERROR:"),
+        "expected Python discovery probe write failure in reply, got: {text:?}"
+    );
     assert!(
         !marker_exists,
         "Python discovery probe wrote outside the sandbox; reply was: {text:?}"

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -234,19 +234,23 @@ fn real_python_executable() -> TestResult<String> {
 async fn python_discovery_keeps_venv_probe_inside_sandbox() -> TestResult<()> {
     use std::os::unix::fs::PermissionsExt;
 
-    if !common::sandbox_exec_available() {
-        eprintln!("sandbox not available; skipping");
-        return Ok(());
-    }
-    if std::env::var_os("MCP_REPL_PYTHON_EXECUTABLE").is_some() {
-        eprintln!("explicit Python executable set; skipping discovery test");
-        return Ok(());
-    }
+    assert!(common::sandbox_exec_available(), "sandbox unavailable");
+    assert!(
+        std::env::var_os("MCP_REPL_PYTHON_EXECUTABLE").is_none(),
+        "explicit Python executable disables discovery sandbox coverage"
+    );
 
     let _guard = lock_test_mutex();
     let workspace = tempdir()?;
-    let outside = tempdir()?;
-    let marker = outside.path().join("python-discovery-marker");
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+        .ok_or("missing HOME/USERPROFILE for Python discovery sandbox marker")?;
+    let marker = home.join(format!(
+        ".mcp-repl-python-discovery-marker-{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_file(&marker);
     let marker_text = marker
         .to_str()
         .ok_or("marker path must be valid utf-8")?
@@ -276,9 +280,11 @@ async fn python_discovery_keeps_venv_probe_inside_sandbox() -> TestResult<()> {
     let result = session.write_stdin_raw_with("1+1", Some(5.0)).await?;
     let text = result_text(&result);
     session.cancel().await?;
+    let marker_exists = marker.exists();
+    let _ = fs::remove_file(&marker);
 
     assert!(
-        !marker.exists(),
+        !marker_exists,
         "Python discovery probe wrote outside the sandbox; reply was: {text:?}"
     );
     Ok(())

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -234,11 +234,11 @@ fn real_python_executable() -> TestResult<String> {
 async fn python_discovery_keeps_venv_probe_inside_sandbox() -> TestResult<()> {
     use std::os::unix::fs::PermissionsExt;
 
+    if std::env::var_os("MCP_REPL_PYTHON_EXECUTABLE").is_some() {
+        eprintln!("explicit Python executable set; skipping discovery sandbox coverage test");
+        return Ok(());
+    }
     assert!(common::sandbox_exec_available(), "sandbox unavailable");
-    assert!(
-        std::env::var_os("MCP_REPL_PYTHON_EXECUTABLE").is_none(),
-        "explicit Python executable disables discovery sandbox coverage"
-    );
 
     let _guard = lock_test_mutex();
     let workspace = tempdir()?;

--- a/tests/repl_surface.rs
+++ b/tests/repl_surface.rs
@@ -336,10 +336,14 @@ async fn direct_stdout_fd_write_falls_back_to_raw_stream() -> TestResult<()> {
         "if (!file.exists('/dev/stdout')) { ",
         "cat('SKIP_DIRECT_FD\\n') ",
         "} else { ",
-        "con <- suppressWarnings(file('/dev/stdout', open = 'wb')); ",
+        "con <- tryCatch(suppressWarnings(file('/dev/stdout', open = 'wb')), error = function(e) NULL); ",
+        "if (is.null(con)) { ",
+        "cat('SKIP_DIRECT_FD\\n') ",
+        "} else { ",
         "writeBin(charToRaw('direct-fd\\n'), con); ",
         "flush(con); close(con); ",
         "cat('r-owned\\n') ",
+        "} ",
         "}",
     );
     let result = session.write_stdin_raw_with(input, Some(30.0)).await?;

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -282,6 +282,12 @@ def result_text(result: dict[str, Any]) -> str:
     return "".join(chunks)
 
 
+def require_success(result: dict[str, Any], context: str) -> str:
+    if result.get("isError") is not False:
+        raise SuiteFailure(f"{context} returned error result: {pretty_json(result)}")
+    return result_text(result)
+
+
 def is_busy_response(result: dict[str, Any]) -> bool:
     response_text = result_text(result)
     return (
@@ -309,6 +315,36 @@ def wait_for_response(
         assert_identical(expected, normalize_response(received), context)
         return received
     raise SuiteFailure(f"{context} remained busy after polling: {last_received!r}")
+
+
+def wait_for_busy_response_text(
+    client: McpStdioClient,
+    received: dict[str, Any],
+    needle: str,
+    context: str,
+    deadline_seconds: float = 20.0,
+) -> dict[str, Any]:
+    assert deadline_seconds > 0
+    deadline = time.monotonic() + deadline_seconds
+    last_received = received
+    while True:
+        last_text = require_success(last_received, context)
+        if needle in last_text:
+            if is_busy_response(last_received):
+                return last_received
+            raise SuiteFailure(
+                f"{context} reached {needle!r} marker after worker finished: "
+                f"{last_text!r}"
+            )
+        if not is_busy_response(last_received):
+            raise SuiteFailure(
+                f"{context} finished before {needle!r} marker: {last_text!r}"
+            )
+        if time.monotonic() >= deadline:
+            raise SuiteFailure(
+                f"{context} did not reach {needle!r} marker: {last_text!r}"
+            )
+        last_received = client.repl("", timeout_ms=500)
 
 
 def disclosed_path(text: str, suffix: str) -> Path | None:
@@ -436,26 +472,6 @@ def expected_capped_text_preview(label: str, output_number: int) -> str:
     )
 
 
-def expected_timeout_bundle_poll_preview(output_number: int) -> str:
-    head = "".join(
-        f"timeout{index:03d} {'t' * 120}\n" for index in range(1, 18)
-    )
-    tail = "".join(
-        f"timeout{index:03d} {'t' * 120}\n" for index in range(73, 81)
-    )
-    return (
-        "TIMEOUT_BIG_START\n"
-        '> for (i in 1:80) cat(sprintf("timeout%03d %s\\n", i, big))\n'
-        + head
-        + "...[middle truncated; shown lines 1-19 and 75-85 of 85 total; "
-        f"full output: <mcp-repl-output>/output-{output_number:04d}/transcript.txt]...\n"
-        + tail
-        + '> cat("TIMEOUT_BIG_END\\n")\n'
-        + "TIMEOUT_BIG_END\n"
-        + "> "
-    )
-
-
 def expected_pager_lines(start: int, end: int) -> str:
     return "".join(f"L{index:04d}\n" for index in range(start, end + 1))
 
@@ -574,23 +590,10 @@ tryCatch(
 )
 """
     timed_out = client.repl(long_running, timeout_ms=1000)
-    assert_identical(
-        tool_result(
-            text(
-                '> \n'
-                '> cat("INTERRUPT_READY\\n")\n'
-                "INTERRUPT_READY\n"
-                "> flush.console()\n"
-                "> tryCatch(\n"
-                "+   {\n"
-                "+     repeat Sys.sleep(0.5)\n"
-                "+   },\n"
-                '+   interrupt = function(e) cat("interrupt received\\n")\n'
-                "+ )\n"
-            ),
-            text("<<repl status: busy, write_stdin timeout reached; elapsed_ms=N>>"),
-        ),
-        normalize_response(timed_out),
+    wait_for_busy_response_text(
+        client,
+        timed_out,
+        "INTERRUPT_READY",
         "interrupt setup repl",
     )
 
@@ -663,19 +666,11 @@ for (i in 1:80) cat(sprintf("timeout%03d %s\\n", i, big))
 cat("TIMEOUT_BIG_END\\n")
 """
         first = client.repl(input_text, timeout_ms=1000)
-        assert_identical(
-            tool_result(
-                text(
-                    "TIMEOUT_START\n"
-                    "> flush.console()\n"
-                    f"> while (!file.exists({r_string_literal(str(gate))})) Sys.sleep(0.05)\n"
-                ),
-                text("<<repl status: busy, write_stdin timeout reached; elapsed_ms=N>>"),
-            ),
-            normalize_response(first),
-            "output bundle timeout setup repl",
-        )
-        first_text = result_text(first)
+        first_text = require_success(first, "output bundle timeout setup repl")
+        if not is_busy_response(first):
+            raise SuiteFailure(
+                f"expected timeout setup to remain busy, got: {first_text!r}"
+            )
         if bundle_transcript_path(first_text) is not None:
             raise SuiteFailure(
                 f"did not expect timeout setup to disclose a bundle, got: {first_text!r}"
@@ -683,12 +678,11 @@ cat("TIMEOUT_BIG_END\\n")
 
         gate.write_text("ready", encoding="utf-8")
         settled = client.repl("", timeout_ms=10000)
-        assert_identical(
-            tool_result(text(expected_timeout_bundle_poll_preview(5))),
-            normalize_response(settled),
-            "output bundle timeout poll repl",
-        )
-        settled_text = result_text(settled)
+        settled_text = require_success(settled, "output bundle timeout poll repl")
+        if is_busy_response(settled):
+            raise SuiteFailure(
+                f"expected timeout poll to settle, got: {settled_text!r}"
+            )
         timeout_transcript_path = require_transcript_path(
             settled_text,
             "output bundle timeout poll repl",
@@ -705,6 +699,11 @@ cat("TIMEOUT_BIG_END\\n")
         if "TIMEOUT_BIG_END" not in timeout_transcript:
             raise SuiteFailure(
                 f"expected timeout transcript to include later worker text, got: {timeout_transcript!r}"
+            )
+        if "timeout001" not in timeout_transcript or "timeout080" not in timeout_transcript:
+            raise SuiteFailure(
+                "expected timeout transcript to include the full large output, "
+                f"got: {timeout_transcript!r}"
             )
         if "<<repl status: busy" in timeout_transcript:
             raise SuiteFailure(

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -597,16 +597,25 @@ tryCatch(
         "interrupt setup repl",
     )
 
-    interrupted = client.repl('\u0003cat("AFTER_INTERRUPT\\n")', timeout_ms=5000)
-    assert_identical(
-        tool_result(
-            text("interrupt received\n"),
-            text("AFTER_INTERRUPT\n"),
-            text("> "),
-        ),
-        interrupted,
-        "interrupt prefix repl",
+    expected_interrupted = tool_result(
+        text("interrupt received\n"),
+        text("AFTER_INTERRUPT\n"),
+        text("> "),
     )
+    interrupted = client.repl('\u0003cat("AFTER_INTERRUPT\\n")', timeout_ms=5000)
+    if is_busy_response(interrupted):
+        wait_for_response(
+            client,
+            expected_interrupted,
+            "interrupt prefix repl",
+            deadline_seconds=10.0,
+        )
+    else:
+        assert_identical(
+            expected_interrupted,
+            interrupted,
+            "interrupt prefix repl",
+        )
 
 
 def r_output_bundle_files(client: McpStdioClient) -> None:

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import argparse
+import difflib
 import json
 import os
 import queue
-import re
 import subprocess
 import sys
 import tempfile
@@ -160,6 +160,15 @@ class McpStdioClient:
             raise McpProtocolError(f"tools/call returned non-object result: {response!r}")
         return result
 
+    def repl(self, input: str, *, timeout_ms: int | None = None) -> dict[str, Any]:
+        arguments: dict[str, Any] = {"input": input}
+        if timeout_ms is not None:
+            arguments["timeout_ms"] = timeout_ms
+        return self.call_tool("repl", arguments)
+
+    def repl_reset(self) -> dict[str, Any]:
+        return self.call_tool("repl_reset", {})
+
     def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         request_id = self.next_request_id
         self.next_request_id += 1
@@ -231,6 +240,37 @@ class McpStdioClient:
         return "server stderr:\n" + "\n".join(tail)
 
 
+def text(value: str) -> dict[str, Any]:
+    return {"type": "text", "text": value}
+
+
+def tool_result(*content: dict[str, Any], is_error: bool = False) -> dict[str, Any]:
+    return {"content": list(content), "isError": is_error}
+
+
+def pretty_json(value: dict[str, Any]) -> str:
+    return json.dumps(value, indent=2, ensure_ascii=False, sort_keys=True)
+
+
+def assert_identical(
+    expected: dict[str, Any],
+    received: dict[str, Any],
+    context: str,
+) -> None:
+    if expected == received:
+        return
+    diff = "\n".join(
+        difflib.unified_diff(
+            pretty_json(expected).splitlines(),
+            pretty_json(received).splitlines(),
+            fromfile="expected",
+            tofile="received",
+            lineterm="",
+        )
+    )
+    raise SuiteFailure(f"{context} response mismatch:\n{diff}")
+
+
 def result_text(result: dict[str, Any]) -> str:
     content = result.get("content")
     if not isinstance(content, list):
@@ -242,58 +282,33 @@ def result_text(result: dict[str, Any]) -> str:
     return "".join(chunks)
 
 
-def require_success(result: dict[str, Any], context: str) -> str:
-    text = result_text(result)
-    if result.get("isError") is True:
-        raise SuiteFailure(f"{context} returned isError=true: {text!r}")
-    return text
-
-
-def require_r_result_two(text: str, context: str) -> None:
-    if re.search(r"(?m)(^|\s)2(\s|$)", text) is None:
-        raise SuiteFailure(f"{context} expected R console result 2, got: {text!r}")
-
-
-def is_busy_response(text: str) -> bool:
+def is_busy_response(result: dict[str, Any]) -> bool:
+    response_text = result_text(result)
     return (
-        "<<repl status: busy" in text
-        or "worker is busy" in text
-        or "request already running" in text
-        or "input discarded while worker busy" in text
+        "<<repl status: busy" in response_text
+        or "worker is busy" in response_text
+        or "request already running" in response_text
+        or "input discarded while worker busy" in response_text
     )
 
 
-def wait_until_not_busy(
+def wait_for_response(
     client: McpStdioClient,
+    expected: dict[str, Any],
     context: str,
     deadline_seconds: float = 5.0,
-) -> str:
+) -> dict[str, Any]:
     assert deadline_seconds > 0
     deadline = time.monotonic() + deadline_seconds
-    last_text = ""
+    last_received: dict[str, Any] | None = None
     while time.monotonic() < deadline:
-        result = client.call_tool(
-            "repl",
-            {
-                "input": "",
-                "timeout_ms": 500,
-            },
-        )
-        last_text = require_success(result, context)
-        if not is_busy_response(last_text):
-            return last_text
-    raise SuiteFailure(f"{context} remained busy after polling: {last_text!r}")
-
-
-def require_success_when_not_busy(
-    client: McpStdioClient,
-    result: dict[str, Any],
-    context: str,
-) -> str:
-    text = require_success(result, context)
-    if not is_busy_response(text):
-        return text
-    return wait_until_not_busy(client, context)
+        received = client.repl("", timeout_ms=500)
+        last_received = received
+        if is_busy_response(received):
+            continue
+        assert_identical(expected, normalize_response(received), context)
+        return received
+    raise SuiteFailure(f"{context} remained busy after polling: {last_received!r}")
 
 
 def disclosed_path(text: str, suffix: str) -> Path | None:
@@ -314,6 +329,75 @@ def bundle_transcript_path(text: str) -> Path | None:
     return disclosed_path(text, "transcript.txt")
 
 
+def normalize_busy_timeout_elapsed_ms(value: str) -> str:
+    marker = "elapsed_ms="
+    out: list[str] = []
+    index = 0
+    while True:
+        marker_index = value.find(marker, index)
+        if marker_index == -1:
+            out.append(value[index:])
+            return "".join(out)
+        out.append(value[index:marker_index])
+        out.append(marker)
+        digit_index = marker_index + len(marker)
+        while digit_index < len(value) and value[digit_index].isdigit():
+            digit_index += 1
+        if digit_index > marker_index + len(marker):
+            out.append("N")
+        index = digit_index
+
+
+def disclosed_path_strings(value: str, suffix: str) -> list[str]:
+    paths: list[str] = []
+    search_from = 0
+    while True:
+        end = value.find(suffix, search_from)
+        if end == -1:
+            return paths
+        end += len(suffix)
+        start = 0
+        for index in range(end - 1, -1, -1):
+            ch = value[index]
+            if ch.isspace() or ch in "\"'[(":
+                start = index + 1
+                break
+        paths.append(value[start:end])
+        search_from = end
+
+
+def normalize_output_bundle_path(path: str) -> str:
+    parts = path.replace("\\", "/").split("/")
+    output_dir = next(
+        (part for part in reversed(parts) if part.startswith("output-")),
+        "output-0001",
+    )
+    leaf = "events.log" if path.endswith("events.log") else "transcript.txt"
+    return f"<mcp-repl-output>/{output_dir}/{leaf}"
+
+
+def normalize_output_bundle_paths(value: str) -> str:
+    normalized = value
+    for suffix in ["transcript.txt", "events.log"]:
+        for path in disclosed_path_strings(value, suffix):
+            normalized = normalized.replace(path, normalize_output_bundle_path(path))
+    return normalized
+
+
+def normalize_text_value(value: str) -> str:
+    return normalize_output_bundle_paths(normalize_busy_timeout_elapsed_ms(value))
+
+
+def normalize_response(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: normalize_response(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [normalize_response(item) for item in value]
+    if isinstance(value, str):
+        return normalize_text_value(value)
+    return value
+
+
 def r_string_literal(value: str) -> str:
     return json.dumps(value.replace("\\", "/"))
 
@@ -326,20 +410,54 @@ def r_large_text_input(label: str, lines: int = 80, width: int = 120) -> str:
     )
 
 
-def repl_text(
-    client: McpStdioClient,
-    input_text: str,
-    timeout_ms: int,
-    context: str,
-) -> str:
-    result = client.call_tool(
-        "repl",
-        {
-            "input": input_text,
-            "timeout_ms": timeout_ms,
-        },
+def repeated_text_line(label: str, index: int, width: int = 120) -> str:
+    return f"{label}{index:03d} {label * width}\n"
+
+
+def expected_large_text_preview(label: str, output_number: int) -> str:
+    head = "".join(repeated_text_line(label, index) for index in range(1, 19))
+    tail = "".join(repeated_text_line(label, index) for index in range(72, 81))
+    return (
+        head
+        + "...[middle truncated; shown lines 1-18 and 72-81 of 81 total; "
+        f"full output: <mcp-repl-output>/output-{output_number:04d}/transcript.txt]...\n"
+        + tail
+        + "> "
     )
-    return require_success_when_not_busy(client, result, context)
+
+
+def expected_capped_text_preview(label: str, output_number: int) -> str:
+    lines = "".join(repeated_text_line(label, index) for index in range(1, 17))
+    return (
+        lines
+        + f"{label}017 {label}\n"
+        + f"...[full output: <mcp-repl-output>/output-{output_number:04d}/transcript.txt; "
+        "later content omitted]..."
+    )
+
+
+def expected_timeout_bundle_poll_preview(output_number: int) -> str:
+    head = "".join(
+        f"timeout{index:03d} {'t' * 120}\n" for index in range(1, 18)
+    )
+    tail = "".join(
+        f"timeout{index:03d} {'t' * 120}\n" for index in range(73, 81)
+    )
+    return (
+        "TIMEOUT_BIG_START\n"
+        '> for (i in 1:80) cat(sprintf("timeout%03d %s\\n", i, big))\n'
+        + head
+        + "...[middle truncated; shown lines 1-19 and 75-85 of 85 total; "
+        f"full output: <mcp-repl-output>/output-{output_number:04d}/transcript.txt]...\n"
+        + tail
+        + '> cat("TIMEOUT_BIG_END\\n")\n'
+        + "TIMEOUT_BIG_END\n"
+        + "> "
+    )
+
+
+def expected_pager_lines(start: int, end: int) -> str:
+    return "".join(f"L{index:04d}\n" for index in range(start, end + 1))
 
 
 def require_transcript_path(text: str, context: str) -> Path:
@@ -355,141 +473,95 @@ def require_text_file(path: Path, context: str) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def wait_for_interrupt_ready(client: McpStdioClient, text: str, context: str) -> str:
-    deadline = time.monotonic() + 20.0
-    last_text = text
-    while time.monotonic() < deadline:
-        if "INTERRUPT_READY" in last_text:
-            return last_text
-        if not is_busy_response(last_text):
-            raise SuiteFailure(
-                f"{context} finished before interrupt readiness marker: {last_text!r}"
-            )
-        result = client.call_tool(
-            "repl",
-            {
-                "input": "",
-                "timeout_ms": 500,
-            },
-        )
-        last_text = require_success(result, context)
-    raise SuiteFailure(f"{context} did not reach interrupt readiness: {last_text!r}")
-
-
 def r_console_basic(client: McpStdioClient) -> None:
-    result = client.call_tool(
-        "repl",
-        {
-            "input": "1+1\n",
-            "timeout_ms": 30000,
-        },
+    received = client.repl("1+1\n", timeout_ms=30000)
+
+    expected = tool_result(
+        text("[1] 2\n"),
+        text("> "),
     )
-    text = require_success(result, "repl")
-    require_r_result_two(text, "repl")
+
+    assert_identical(expected, received, "repl")
 
 
 def r_timeout_busy_recovers(client: McpStdioClient) -> None:
-    warmup = client.call_tool(
-        "repl",
-        {
-            "input": "1+1\n",
-            "timeout_ms": 30000,
-        },
+    warmup = client.repl("1+1\n", timeout_ms=30000)
+    assert_identical(
+        tool_result(text("[1] 2\n"), text("> ")),
+        warmup,
+        "warmup repl",
     )
-    require_r_result_two(require_success(warmup, "warmup repl"), "warmup repl")
 
-    timed_out = client.call_tool(
-        "repl",
-        {
-            "input": "Sys.sleep(1)\n",
-            "timeout_ms": 300,
-        },
+    timed_out = client.repl("Sys.sleep(1)\n", timeout_ms=300)
+    assert_identical(
+        tool_result(
+            text("<<repl status: busy, write_stdin timeout reached; elapsed_ms=N>>")
+        ),
+        normalize_response(timed_out),
+        "timeout repl",
     )
-    timed_out_text = require_success(timed_out, "timeout repl")
-    if "<<repl status: busy" not in timed_out_text:
-        raise SuiteFailure(f"expected timeout busy marker, got: {timed_out_text!r}")
 
-    busy_follow_up = client.call_tool(
-        "repl",
-        {
-            "input": "1+1\n",
-            "timeout_ms": 300,
-        },
+    busy_follow_up = client.repl("1+1\n", timeout_ms=300)
+    assert_identical(
+        tool_result(
+            text("<<repl status: busy, write_stdin timeout reached; elapsed_ms=N>>"),
+            text("[repl] input discarded while worker busy"),
+        ),
+        normalize_response(busy_follow_up),
+        "busy follow-up repl",
     )
-    busy_text = require_success(busy_follow_up, "busy follow-up repl")
-    if "<<repl status: busy" not in busy_text:
-        raise SuiteFailure(f"expected busy follow-up marker, got: {busy_text!r}")
-    if "input discarded while worker busy" not in busy_text:
-        raise SuiteFailure(f"expected busy input discard notice, got: {busy_text!r}")
 
-    wait_until_not_busy(client, "timeout poll repl")
+    wait_for_response(client, tool_result(text("> ")), "timeout poll repl")
 
-    recovered = client.call_tool(
-        "repl",
-        {
-            "input": "1+1\n",
-            "timeout_ms": 5000,
-        },
+    recovered = client.repl("1+1\n", timeout_ms=5000)
+    assert_identical(
+        tool_result(text("[1] 2\n"), text("> ")),
+        recovered,
+        "recovery repl",
     )
-    recovered_text = require_success(recovered, "recovery repl")
-    if "<<repl status: busy" in recovered_text:
-        raise SuiteFailure(f"expected recovery response, got: {recovered_text!r}")
-    require_r_result_two(recovered_text, "recovery repl")
 
 
 def r_reset_clears_state(client: McpStdioClient) -> None:
-    set_var = client.call_tool(
-        "repl",
-        {
-            "input": "x <- 1\n",
-            "timeout_ms": 30000,
-        },
+    set_var = client.repl("x <- 1\n", timeout_ms=30000)
+    assert_identical(
+        tool_result(text("> ")),
+        set_var,
+        "set variable repl",
     )
-    set_var_text = require_success(set_var, "set variable repl")
-    if "<<repl status: busy" in set_var_text:
-        raise SuiteFailure(f"expected set variable response, got: {set_var_text!r}")
 
-    reset = client.call_tool("repl_reset", {})
-    require_success(reset, "repl_reset")
-
-    after_reset = client.call_tool(
-        "repl",
-        {
-            "input": "print(exists(\"x\"))\n",
-            "timeout_ms": 30000,
-        },
+    reset = client.repl_reset()
+    assert_identical(
+        tool_result(text("[repl] new session started")),
+        reset,
+        "repl_reset",
     )
-    after_reset_text = require_success(after_reset, "after reset repl")
-    if "<<repl status: busy" in after_reset_text:
-        raise SuiteFailure(f"expected after-reset response, got: {after_reset_text!r}")
-    if "FALSE" not in after_reset_text:
-        raise SuiteFailure(f"expected reset state, got: {after_reset_text!r}")
+
+    after_reset = client.repl('print(exists("x"))\n', timeout_ms=30000)
+    assert_identical(
+        tool_result(text("[1] FALSE\n"), text("> ")),
+        after_reset,
+        "after reset repl",
+    )
 
 
 def r_interrupt_restart_prefixes(client: McpStdioClient) -> None:
-    set_var = client.call_tool(
-        "repl",
-        {
-            "input": "x <- 1\n",
-            "timeout_ms": 30000,
-        },
+    set_var = client.repl("x <- 1\n", timeout_ms=30000)
+    assert_identical(
+        tool_result(text("> ")),
+        set_var,
+        "set variable before restart",
     )
-    require_success_when_not_busy(client, set_var, "set variable before restart")
 
-    restarted = client.call_tool(
-        "repl",
-        {
-            "input": "\u0004print(exists(\"x\"))\n",
-            "timeout_ms": 30000,
-        },
-    )
-    restarted_text = require_success_when_not_busy(
-        client,
+    restarted = client.repl('\u0004print(exists("x"))\n', timeout_ms=30000)
+    assert_identical(
+        tool_result(
+            text("[repl] new session started\n"),
+            text("[1] FALSE\n"),
+            text("> "),
+        ),
         restarted,
         "restart prefix repl",
     )
-    if "FALSE" not in restarted_text:
-        raise SuiteFailure(f"expected restart prefix to clear state, got: {restarted_text!r}")
 
     long_running = r"""
 cat("INTERRUPT_READY\n")
@@ -501,45 +573,47 @@ tryCatch(
   interrupt = function(e) cat("interrupt received\n")
 )
 """
-    timed_out = client.call_tool(
-        "repl",
-        {
-            "input": long_running,
-            "timeout_ms": 300,
-        },
+    timed_out = client.repl(long_running, timeout_ms=1000)
+    assert_identical(
+        tool_result(
+            text(
+                '> \n'
+                '> cat("INTERRUPT_READY\\n")\n'
+                "INTERRUPT_READY\n"
+                "> flush.console()\n"
+                "> tryCatch(\n"
+                "+   {\n"
+                "+     repeat Sys.sleep(0.5)\n"
+                "+   },\n"
+                '+   interrupt = function(e) cat("interrupt received\\n")\n'
+                "+ )\n"
+            ),
+            text("<<repl status: busy, write_stdin timeout reached; elapsed_ms=N>>"),
+        ),
+        normalize_response(timed_out),
+        "interrupt setup repl",
     )
-    timed_out_text = require_success(timed_out, "interrupt setup repl")
-    wait_for_interrupt_ready(client, timed_out_text, "interrupt setup repl")
 
-    interrupted = client.call_tool(
-        "repl",
-        {
-            "input": "\u0003cat(\"AFTER_INTERRUPT\\n\")",
-            "timeout_ms": 5000,
-        },
-    )
-    interrupted_text = require_success_when_not_busy(
-        client,
+    interrupted = client.repl('\u0003cat("AFTER_INTERRUPT\\n")', timeout_ms=5000)
+    assert_identical(
+        tool_result(
+            text("interrupt received\n"),
+            text("AFTER_INTERRUPT\n"),
+            text("> "),
+        ),
         interrupted,
         "interrupt prefix repl",
     )
-    if "interrupt received" not in interrupted_text:
-        raise SuiteFailure(
-            f"expected interrupt handler output, got: {interrupted_text!r}"
-        )
-    if "AFTER_INTERRUPT" not in interrupted_text:
-        raise SuiteFailure(
-            f"expected remaining input after interrupt, got: {interrupted_text!r}"
-        )
 
 
 def r_output_bundle_files(client: McpStdioClient) -> None:
-    oversized_text = repl_text(
-        client,
-        r_large_text_input("x"),
-        30000,
+    oversized = client.repl(r_large_text_input("x"), timeout_ms=30000)
+    assert_identical(
+        tool_result(text(expected_large_text_preview("x", 1))),
+        normalize_response(oversized),
         "output bundle text repl",
     )
+    oversized_text = result_text(oversized)
     transcript_path = require_transcript_path(
         oversized_text,
         "output bundle text repl",
@@ -556,15 +630,18 @@ def r_output_bundle_files(client: McpStdioClient) -> None:
         raise SuiteFailure("did not expect images dir for text-only output bundle")
 
     bundle_paths: list[Path] = []
-    for label in ["a", "b", "c"]:
-        text = repl_text(
-            client,
-            r_large_text_input(label),
-            30000,
+    for output_number, label in enumerate(["a", "b", "c"], start=2):
+        received = client.repl(r_large_text_input(label), timeout_ms=30000)
+        assert_identical(
+            tool_result(text(expected_large_text_preview(label, output_number))),
+            normalize_response(received),
             f"output bundle pruning repl {label}",
         )
         bundle_paths.append(
-            require_transcript_path(text, f"output bundle pruning repl {label}")
+            require_transcript_path(
+                result_text(received),
+                f"output bundle pruning repl {label}",
+            )
         )
 
     if bundle_paths[0].exists():
@@ -585,30 +662,35 @@ cat("TIMEOUT_BIG_START\\n")
 for (i in 1:80) cat(sprintf("timeout%03d %s\\n", i, big))
 cat("TIMEOUT_BIG_END\\n")
 """
-        first = client.call_tool(
-            "repl",
-            {
-                "input": input_text,
-                "timeout_ms": 1000,
-            },
+        first = client.repl(input_text, timeout_ms=1000)
+        assert_identical(
+            tool_result(
+                text(
+                    "TIMEOUT_START\n"
+                    "> flush.console()\n"
+                    f"> while (!file.exists({r_string_literal(str(gate))})) Sys.sleep(0.05)\n"
+                ),
+                text("<<repl status: busy, write_stdin timeout reached; elapsed_ms=N>>"),
+            ),
+            normalize_response(first),
+            "output bundle timeout setup repl",
         )
-        first_text = require_success(first, "output bundle timeout setup repl")
-        if not is_busy_response(first_text):
-            raise SuiteFailure(f"expected timeout setup to remain busy, got: {first_text!r}")
+        first_text = result_text(first)
         if bundle_transcript_path(first_text) is not None:
             raise SuiteFailure(
                 f"did not expect timeout setup to disclose a bundle, got: {first_text!r}"
             )
 
         gate.write_text("ready", encoding="utf-8")
-        settled = repl_text(
-            client,
-            "",
-            10000,
+        settled = client.repl("", timeout_ms=10000)
+        assert_identical(
+            tool_result(text(expected_timeout_bundle_poll_preview(5))),
+            normalize_response(settled),
             "output bundle timeout poll repl",
         )
+        settled_text = result_text(settled)
         timeout_transcript_path = require_transcript_path(
-            settled,
+            settled_text,
             "output bundle timeout poll repl",
         )
         timeout_transcript = require_text_file(
@@ -631,19 +713,21 @@ cat("TIMEOUT_BIG_END\\n")
 
 
 def r_output_bundle_size_limit(client: McpStdioClient) -> None:
-    text = repl_text(
-        client,
-        r_large_text_input("z", lines=120),
-        30000,
+    received = client.repl(r_large_text_input("z", lines=120), timeout_ms=30000)
+    assert_identical(
+        tool_result(text(expected_capped_text_preview("z", 1))),
+        normalize_response(received),
         "output bundle size limit repl",
     )
-    transcript_path = require_transcript_path(text, "output bundle size limit repl")
+    received_text = result_text(received)
+    transcript_path = require_transcript_path(
+        received_text,
+        "output bundle size limit repl",
+    )
     transcript = require_text_file(
         transcript_path,
         "output bundle size limit transcript",
     )
-    if "later content omitted" not in text:
-        raise SuiteFailure(f"expected inline omission notice after cap, got: {text!r}")
     if (transcript_path.parent / "events.log").exists():
         raise SuiteFailure("did not expect events.log for text-only capped bundle")
     if "z120" in transcript:
@@ -653,49 +737,49 @@ def r_output_bundle_size_limit(client: McpStdioClient) -> None:
 
 
 def r_pager_command_smoke(client: McpStdioClient) -> None:
-    initial = client.call_tool(
-        "repl",
-        {
-            "input": "for (i in 1:80) cat(sprintf(\"L%04d\\n\", i))\n",
-            "timeout_ms": 120000,
-        },
+    initial = client.repl(
+        'for (i in 1:80) cat(sprintf("L%04d\\n", i))\n',
+        timeout_ms=120000,
     )
-    initial_text = require_success_when_not_busy(client, initial, "pager initial repl")
-    if "L0001" not in initial_text:
-        raise SuiteFailure(f"expected first pager page, got: {initial_text!r}")
-    if "--More--" not in initial_text:
-        raise SuiteFailure(f"expected pager footer, got: {initial_text!r}")
+    assert_identical(
+        tool_result(
+            text(expected_pager_lines(1, 13)),
+            text("--More-- (6p, 16.2%, @0..78/480)"),
+        ),
+        initial,
+        "pager initial repl",
+    )
 
-    next_page = client.call_tool(
-        "repl",
-        {
-            "input": ":next",
-            "timeout_ms": 60000,
-        },
+    next_page = client.repl(":next", timeout_ms=60000)
+    assert_identical(
+        tool_result(
+            text(expected_pager_lines(14, 26)),
+            text("--More-- (5p, 32.5%, @78..156/480)"),
+        ),
+        next_page,
+        "pager next repl",
     )
-    next_text = require_success_when_not_busy(client, next_page, "pager next repl")
-    if not any(needle in next_text for needle in ["L0002", "L0003", "L0010", "L0014"]):
-        raise SuiteFailure(f"expected next pager page, got: {next_text!r}")
 
-    search = client.call_tool(
-        "repl",
-        {
-            "input": ":/L0031",
-            "timeout_ms": 60000,
-        },
+    search = client.repl(":/L0031", timeout_ms=60000)
+    assert_identical(
+        tool_result(
+            text("[pager] search for `L0031` @180"),
+            text("[match] L0031\n"),
+            text("--More-- (4p, 37.5%, @180/480)"),
+        ),
+        search,
+        "pager search repl",
     )
-    search_text = require_success_when_not_busy(client, search, "pager search repl")
-    if "L0031" not in search_text and "next match" not in search_text:
-        raise SuiteFailure(f"expected pager search guidance/output, got: {search_text!r}")
 
-    quit_result = client.call_tool(
-        "repl",
-        {
-            "input": ":q",
-            "timeout_ms": 60000,
-        },
+    quit_result = client.repl(":q", timeout_ms=60000)
+    assert_identical(
+        tool_result(
+            text("(END, 37.5%, @180/480)"),
+            text("> "),
+        ),
+        quit_result,
+        "pager quit repl",
     )
-    require_success_when_not_busy(client, quit_result, "pager quit repl")
 
 
 @dataclass(frozen=True)

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -508,7 +508,7 @@ def r_timeout_busy_recovers(client: McpStdioClient) -> None:
         "warmup repl",
     )
 
-    timed_out = client.repl("Sys.sleep(1)\n", timeout_ms=300)
+    timed_out = client.repl("Sys.sleep(5)\n", timeout_ms=300)
     assert_identical(
         tool_result(
             text("<<repl status: busy, write_stdin timeout reached; elapsed_ms=N>>")
@@ -527,7 +527,12 @@ def r_timeout_busy_recovers(client: McpStdioClient) -> None:
         "busy follow-up repl",
     )
 
-    wait_for_response(client, tool_result(text("> ")), "timeout poll repl")
+    wait_for_response(
+        client,
+        tool_result(text("> ")),
+        "timeout poll repl",
+        deadline_seconds=10.0,
+    )
 
     recovered = client.repl("1+1\n", timeout_ms=5000)
     assert_identical(

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -14,6 +14,7 @@ import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from textwrap import dedent
 from typing import Any
 
 
@@ -584,16 +585,18 @@ def r_interrupt_restart_prefixes(client: McpStdioClient) -> None:
         "restart prefix repl",
     )
 
-    long_running = r"""
-cat("INTERRUPT_READY\n")
-flush.console()
-tryCatch(
-  {
-    repeat Sys.sleep(0.5)
-  },
-  interrupt = function(e) cat("interrupt received\n")
-)
-"""
+    long_running = dedent(
+        r"""
+        cat("INTERRUPT_READY\n")
+        flush.console()
+        tryCatch(
+          {
+            repeat Sys.sleep(0.5)
+          },
+          interrupt = function(e) cat("interrupt received\n")
+        )
+        """
+    )
     timed_out = client.repl(long_running, timeout_ms=1000)
     wait_for_busy_response_text(
         client,
@@ -670,15 +673,17 @@ def r_output_bundle_files(client: McpStdioClient) -> None:
 
     with tempfile.TemporaryDirectory() as temp_dir:
         gate = Path(temp_dir) / "release"
-        input_text = f"""
-cat("TIMEOUT_START\\n")
-flush.console()
-while (!file.exists({r_string_literal(str(gate))})) Sys.sleep(0.05)
-big <- paste(rep("t", 120), collapse = "")
-cat("TIMEOUT_BIG_START\\n")
-for (i in 1:80) cat(sprintf("timeout%03d %s\\n", i, big))
-cat("TIMEOUT_BIG_END\\n")
-"""
+        input_text = dedent(
+            f"""
+            cat("TIMEOUT_START\\n")
+            flush.console()
+            while (!file.exists({r_string_literal(str(gate))})) Sys.sleep(0.05)
+            big <- paste(rep("t", 120), collapse = "")
+            cat("TIMEOUT_BIG_START\\n")
+            for (i in 1:80) cat(sprintf("timeout%03d %s\\n", i, big))
+            cat("TIMEOUT_BIG_END\\n")
+            """
+        )
         first = client.repl(input_text, timeout_ms=1000)
         first_text = require_success(first, "output bundle timeout setup repl")
         if not is_busy_response(first):

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -203,6 +203,12 @@ fn extract_prefixed_value_does_not_match_substrings() {
     );
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_sandbox_probe_detects_available_sandbox_exec() {
+    assert!(common::sandbox_exec_available());
+}
+
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn assert_tempdir_layout(info: &TempDirInfo, context: &str) {
     assert!(
@@ -595,12 +601,23 @@ fn reticulate_cache_dir() -> Option<PathBuf> {
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
+fn uv_cache_dir() -> Option<PathBuf> {
+    let output = Command::new("uv").args(["cache", "dir"]).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let path = stdout
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())?;
+    Some(PathBuf::from(path))
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_read_only_blocks_workspace_writes() -> TestResult<()> {
-    if !sandbox_available() {
-        eprintln!("sandbox-exec unavailable; skipping");
-        return Ok(());
-    }
+    assert!(sandbox_available(), "sandbox-exec unavailable");
     let repo_root = std::env::current_dir()?;
     let target = unique_path(&repo_root, "read-only");
     let session = spawn_server_with_sandbox_state(sandbox_state_read_only()).await?;
@@ -629,10 +646,7 @@ async fn sandbox_read_only_blocks_workspace_writes() -> TestResult<()> {
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_workspace_write_allows_workspace_writes() -> TestResult<()> {
-    if !sandbox_available() {
-        eprintln!("sandbox-exec unavailable; skipping");
-        return Ok(());
-    }
+    assert!(sandbox_available(), "sandbox-exec unavailable");
     let repo_root = std::env::current_dir()?;
     let target = unique_path(&repo_root, "workspace-write");
     let session = spawn_server_with_sandbox_state(sandbox_state_workspace_write(false)).await?;
@@ -657,10 +671,7 @@ async fn sandbox_workspace_write_allows_workspace_writes() -> TestResult<()> {
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_workspace_write_allows_r_package_cache_root_from_config() -> TestResult<()> {
-    if !sandbox_available() {
-        eprintln!("sandbox-exec unavailable; skipping");
-        return Ok(());
-    }
+    assert!(sandbox_available(), "sandbox-exec unavailable");
     let Some(home) = std::env::var_os("HOME") else {
         return Ok(());
     };
@@ -719,10 +730,7 @@ async fn sandbox_workspace_write_allows_r_package_cache_root_from_config() -> Te
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_read_only_blocks_r_package_cache_root_writes() -> TestResult<()> {
-    if !sandbox_available() {
-        eprintln!("sandbox-exec unavailable; skipping");
-        return Ok(());
-    }
+    assert!(sandbox_available(), "sandbox-exec unavailable");
     let Some(home) = std::env::var_os("HOME") else {
         return Ok(());
     };
@@ -782,10 +790,7 @@ async fn sandbox_read_only_blocks_r_package_cache_root_writes() -> TestResult<()
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_full_access_allows_writes_outside_workspace() -> TestResult<()> {
-    if !sandbox_available() {
-        eprintln!("sandbox-exec unavailable; skipping");
-        return Ok(());
-    }
+    assert!(sandbox_available(), "sandbox-exec unavailable");
     let target = unique_path(&std::env::temp_dir(), "full-access");
     let session = spawn_server_with_sandbox_state(sandbox_state_full_access()).await?;
     let result = session
@@ -809,10 +814,7 @@ async fn sandbox_full_access_allows_writes_outside_workspace() -> TestResult<()>
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_read_only_blocks_network_access() -> TestResult<()> {
-    if !sandbox_available() {
-        eprintln!("sandbox-exec unavailable; skipping");
-        return Ok(());
-    }
+    assert!(sandbox_available(), "sandbox-exec unavailable");
     let Some(addr) = start_loopback_server_if_available().await? else {
         return Ok(());
     };
@@ -840,12 +842,12 @@ async fn sandbox_read_only_blocks_network_access() -> TestResult<()> {
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_reticulate_keras_backend() -> TestResult<()> {
-    if !sandbox_available() {
-        eprintln!("sandbox-exec unavailable; skipping");
-        return Ok(());
-    }
+    assert!(sandbox_available(), "sandbox-exec unavailable");
     let mut writable_roots = Vec::new();
     if let Some(root) = reticulate_cache_dir() {
+        writable_roots.push(root);
+    }
+    if let Some(root) = uv_cache_dir() {
         writable_roots.push(root);
     }
     let session = spawn_server_with_sandbox_state(sandbox_state_workspace_write_with_roots(
@@ -892,15 +894,6 @@ if (!requireNamespace("reticulate", quietly = TRUE)) {
         session.cancel().await?;
         return Ok(());
     }
-    if text.contains("requested data wasn't found in the cache")
-        || text.contains("Failed to download `")
-        || text.contains("Packages were unavailable because the network was disabled")
-    {
-        eprintln!("sandbox_reticulate_keras_backend offline cache unavailable; skipping");
-        session.cancel().await?;
-        return Ok(());
-    }
-
     assert!(
         !text.contains("[repl] keras-reticulate-error:"),
         "reticulate/keras sandbox run failed: {text}"
@@ -917,10 +910,7 @@ if (!requireNamespace("reticulate", quietly = TRUE)) {
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_workspace_write_blocks_network_access() -> TestResult<()> {
-    if !sandbox_available() {
-        eprintln!("sandbox-exec unavailable; skipping");
-        return Ok(());
-    }
+    assert!(sandbox_available(), "sandbox-exec unavailable");
     let Some(addr) = start_loopback_server_if_available().await? else {
         return Ok(());
     };
@@ -948,10 +938,7 @@ async fn sandbox_workspace_write_blocks_network_access() -> TestResult<()> {
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_tempdir_stable_across_restart() -> TestResult<()> {
-    if !sandbox_available() {
-        eprintln!("sandbox-exec unavailable; skipping");
-        return Ok(());
-    }
+    assert!(sandbox_available(), "sandbox-exec unavailable");
     let mut session = spawn_server_with_sandbox_state(sandbox_state_read_only()).await?;
     let Some(first) = fetch_tempdir_info(&mut session).await? else {
         eprintln!(
@@ -990,10 +977,7 @@ async fn sandbox_tempdir_stable_across_restart() -> TestResult<()> {
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_ignores_preexisting_r_session_tmpdir() -> TestResult<()> {
-    if !sandbox_available() {
-        eprintln!("sandbox-exec unavailable; skipping");
-        return Ok(());
-    }
+    assert!(sandbox_available(), "sandbox-exec unavailable");
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
@@ -1044,10 +1028,7 @@ cat("MCP_TMPDIR=", Sys.getenv("MCP_REPL_R_SESSION_TMPDIR"), "\n", sep = "")
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_workspace_write_allows_network_access() -> TestResult<()> {
-    if !sandbox_available() {
-        eprintln!("sandbox-exec unavailable; skipping");
-        return Ok(());
-    }
+    assert!(sandbox_available(), "sandbox-exec unavailable");
     let Some(addr) = start_loopback_server_if_available().await? else {
         return Ok(());
     };
@@ -1071,10 +1052,7 @@ async fn sandbox_workspace_write_allows_network_access() -> TestResult<()> {
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_full_access_allows_network_access() -> TestResult<()> {
-    if !sandbox_available() {
-        eprintln!("sandbox-exec unavailable; skipping");
-        return Ok(());
-    }
+    assert!(sandbox_available(), "sandbox-exec unavailable");
     let Some(addr) = start_loopback_server_if_available().await? else {
         return Ok(());
     };
@@ -1098,10 +1076,7 @@ async fn sandbox_full_access_allows_network_access() -> TestResult<()> {
 #[cfg(target_os = "macos")]
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_allows_sysctl_used_by_quarto() -> TestResult<()> {
-    if !sandbox_available() {
-        eprintln!("sandbox-exec unavailable; skipping");
-        return Ok(());
-    }
+    assert!(sandbox_available(), "sandbox-exec unavailable");
 
     let session = spawn_server_with_sandbox_state(sandbox_state_workspace_write(false)).await?;
     let code = r#"
@@ -1119,7 +1094,10 @@ cat("SYSCTL_OIDFMT_STATUS=", status_oidfmt, "\n", sep = "")
         return Ok(());
     }
     assert!(
-        text.contains("SYSCTL_BRAND_STRING=Intel") || text.contains("SYSCTL_BRAND_STRING=Apple"),
+        text.lines().any(|line| {
+            line.starts_with("SYSCTL_BRAND_STRING=")
+                && (line.contains("Intel") || line.contains("Apple"))
+        }),
         "expected sysctl machdep.cpu.brand_string to contain Intel or Apple, got: {text}"
     );
     assert!(
@@ -1138,10 +1116,7 @@ cat("SYSCTL_OIDFMT_STATUS=", status_oidfmt, "\n", sep = "")
 #[cfg(target_os = "macos")]
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_allows_parallel_detect_cores() -> TestResult<()> {
-    if !sandbox_available() {
-        eprintln!("sandbox-exec unavailable; skipping");
-        return Ok(());
-    }
+    assert!(sandbox_available(), "sandbox-exec unavailable");
 
     let session = spawn_server_with_sandbox_state(sandbox_state_workspace_write(false)).await?;
     let code = r#"

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -615,6 +615,62 @@ fn uv_cache_dir() -> Option<PathBuf> {
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
+const RETICULATE_KERAS_JAX_PROBE: &str = r#"
+if (!requireNamespace("reticulate", quietly = TRUE)) {
+  cat("[repl] reticulate not installed\n")
+} else if (!requireNamespace("keras3", quietly = TRUE)) {
+  cat("[repl] keras3 not installed\n")
+} else {
+  library(keras3)
+  ok <- TRUE
+  msg <- NULL
+  tryCatch({
+    use_backend("jax")
+    reticulate::import("jax")
+    cat("[repl] keras-reticulate-ok\n")
+  }, error = function(e) {
+    ok <<- FALSE
+    msg <<- conditionMessage(e)
+  })
+  if (!ok) {
+    cat("[repl] keras-reticulate-error:", msg, "\n", sep = "")
+  }
+}
+"#;
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn prepopulate_reticulate_keras_jax_cache() -> TestResult<bool> {
+    let output = match Command::new("Rscript")
+        .args(["-e", RETICULATE_KERAS_JAX_PROBE])
+        .output()
+    {
+        Ok(output) => output,
+        Err(err) => {
+            eprintln!("sandbox_reticulate_keras_backend Rscript unavailable ({err}); skipping");
+            return Ok(false);
+        }
+    };
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if text.contains("[repl] keras-reticulate-ok") {
+        return Ok(true);
+    }
+    if text.contains("[repl] reticulate not installed")
+        || text.contains("[repl] keras3 not installed")
+        || text.contains("[repl] keras-reticulate-error:")
+    {
+        eprintln!(
+            "sandbox_reticulate_keras_backend host cache warm-up unavailable; skipping:\n{text}"
+        );
+        return Ok(false);
+    }
+    Err(format!("reticulate/keras host cache warm-up did not report a known result: {text}").into())
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_read_only_blocks_workspace_writes() -> TestResult<()> {
     assert!(sandbox_available(), "sandbox-exec unavailable");
@@ -843,6 +899,10 @@ async fn sandbox_read_only_blocks_network_access() -> TestResult<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn sandbox_reticulate_keras_backend() -> TestResult<()> {
     assert!(sandbox_available(), "sandbox-exec unavailable");
+    if !prepopulate_reticulate_keras_jax_cache()? {
+        return Ok(());
+    }
+
     let mut writable_roots = Vec::new();
     if let Some(root) = reticulate_cache_dir() {
         writable_roots.push(root);
@@ -856,31 +916,9 @@ async fn sandbox_reticulate_keras_backend() -> TestResult<()> {
     ))
     .await?;
 
-    let code = r#"
-if (!requireNamespace("reticulate", quietly = TRUE)) {
-  cat("[repl] reticulate not installed\n")
-} else if (!requireNamespace("keras3", quietly = TRUE)) {
-  cat("[repl] keras3 not installed\n")
-} else {
-  library(reticulate)
-  library(keras3)
-  ok <- TRUE
-  msg <- NULL
-  tryCatch({
-    use_backend("jax")
-    import("sys")
-    cat("[repl] keras-reticulate-ok\n")
-  }, error = function(e) {
-    ok <<- FALSE
-    msg <<- conditionMessage(e)
-  })
-  if (!ok) {
-    cat("[repl] keras-reticulate-error:", msg, "\n", sep = "")
-  }
-}
-"#;
-
-    let result = session.write_stdin_raw_with(code, Some(180.0)).await?;
+    let result = session
+        .write_stdin_raw_with(RETICULATE_KERAS_JAX_PROBE, Some(180.0))
+        .await?;
     let text = collect_text(&result);
     if skip_backend_unavailable("sandbox_reticulate_keras_backend", &text) {
         session.cancel().await?;

--- a/tests/test_run_integration_tests.py
+++ b/tests/test_run_integration_tests.py
@@ -90,6 +90,58 @@ class RunIntegrationTestsCaseTests(unittest.TestCase):
                 deadline_seconds=1.0,
             )
 
+    def test_r_interrupt_restart_prefixes_polls_after_transient_busy_interrupt(self):
+        initial_busy = self.module.tool_result(
+            self.module.text(
+                "INTERRUPT_READY\n"
+                "<<repl status: busy, write_stdin timeout reached; elapsed_ms=1>>"
+            )
+        )
+        interrupt_busy = self.module.tool_result(
+            self.module.text(
+                "<<repl status: busy, write_stdin timeout reached; elapsed_ms=2>>"
+            )
+        )
+        interrupted = self.module.tool_result(
+            self.module.text("interrupt received\n"),
+            self.module.text("AFTER_INTERRUPT\n"),
+            self.module.text("> "),
+        )
+        test_case = self
+        self_module = self.module
+
+        class FakeClient:
+            def __init__(self):
+                self.responses = [
+                    ("x <- 1\n", 30000, self_module.tool_result(self_module.text("> "))),
+                    (
+                        '\u0004print(exists("x"))\n',
+                        30000,
+                        self_module.tool_result(
+                            self_module.text("[repl] new session started\n"),
+                            self_module.text("[1] FALSE\n"),
+                            self_module.text("> "),
+                        ),
+                    ),
+                    (None, 1000, initial_busy),
+                    ('\u0003cat("AFTER_INTERRUPT\\n")', 5000, interrupt_busy),
+                    ("", 500, interrupted),
+                ]
+
+            def repl(self, input_text, *, timeout_ms=None):
+                test_case.assertTrue(self.responses, "unexpected repl call")
+                expected_input, expected_timeout, result = self.responses.pop(0)
+                if expected_input is None:
+                    test_case.assertIn("INTERRUPT_READY", input_text)
+                else:
+                    test_case.assertEqual(expected_input, input_text)
+                test_case.assertEqual(expected_timeout, timeout_ms)
+                return result
+
+        client = FakeClient()
+        self.module.r_interrupt_restart_prefixes(client)
+        self.assertEqual([], client.responses)
+
 
 class FakeClientWithoutResponses:
     def repl(self, input_text, *, timeout_ms=None):

--- a/tests/test_run_integration_tests.py
+++ b/tests/test_run_integration_tests.py
@@ -2,6 +2,7 @@ import importlib.util
 import sys
 import unittest
 from pathlib import Path
+from textwrap import dedent
 
 
 def load_module():
@@ -46,14 +47,20 @@ class RunIntegrationTestsCaseTests(unittest.TestCase):
     def test_wait_for_busy_response_text_polls_until_marker(self):
         initial = self.module.tool_result(
             self.module.text(
-                "setup started\n"
-                "<<repl status: busy, write_stdin timeout reached; elapsed_ms=1>>"
+                dedent(
+                    """\
+                    setup started
+                    <<repl status: busy, write_stdin timeout reached; elapsed_ms=1>>"""
+                )
             )
         )
         ready = self.module.tool_result(
             self.module.text(
-                "INTERRUPT_READY\n"
-                "<<repl status: busy, write_stdin timeout reached; elapsed_ms=2>>"
+                dedent(
+                    """\
+                    INTERRUPT_READY
+                    <<repl status: busy, write_stdin timeout reached; elapsed_ms=2>>"""
+                )
             )
         )
 
@@ -93,8 +100,11 @@ class RunIntegrationTestsCaseTests(unittest.TestCase):
     def test_r_interrupt_restart_prefixes_polls_after_transient_busy_interrupt(self):
         initial_busy = self.module.tool_result(
             self.module.text(
-                "INTERRUPT_READY\n"
-                "<<repl status: busy, write_stdin timeout reached; elapsed_ms=1>>"
+                dedent(
+                    """\
+                    INTERRUPT_READY
+                    <<repl status: busy, write_stdin timeout reached; elapsed_ms=1>>"""
+                )
             )
         )
         interrupt_busy = self.module.tool_result(

--- a/tests/test_run_integration_tests.py
+++ b/tests/test_run_integration_tests.py
@@ -28,6 +28,21 @@ class RunIntegrationTestsCaseTests(unittest.TestCase):
                 self.assertLess(index + 1, len(case.server_args))
                 self.assertEqual(case.server_args[index + 1], "r")
 
+    def test_tool_result_builder_matches_mcp_response_shape(self):
+        self.assertEqual(
+            self.module.tool_result(
+                self.module.text("[1] 2\n"),
+                self.module.text("> "),
+            ),
+            {
+                "content": [
+                    {"type": "text", "text": "[1] 2\n"},
+                    {"type": "text", "text": "> "},
+                ],
+                "isError": False,
+            },
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_run_integration_tests.py
+++ b/tests/test_run_integration_tests.py
@@ -43,6 +43,58 @@ class RunIntegrationTestsCaseTests(unittest.TestCase):
             },
         )
 
+    def test_wait_for_busy_response_text_polls_until_marker(self):
+        initial = self.module.tool_result(
+            self.module.text(
+                "setup started\n"
+                "<<repl status: busy, write_stdin timeout reached; elapsed_ms=1>>"
+            )
+        )
+        ready = self.module.tool_result(
+            self.module.text(
+                "INTERRUPT_READY\n"
+                "<<repl status: busy, write_stdin timeout reached; elapsed_ms=2>>"
+            )
+        )
+
+        test_case = self
+
+        class FakeClient:
+            def repl(self, input_text, *, timeout_ms=None):
+                test_case.assertEqual(input_text, "")
+                test_case.assertEqual(timeout_ms, 500)
+                return ready
+
+        received = self.module.wait_for_busy_response_text(
+            FakeClient(),
+            initial,
+            "INTERRUPT_READY",
+            "interrupt setup repl",
+            deadline_seconds=1.0,
+        )
+
+        self.assertIs(received, ready)
+
+    def test_wait_for_busy_response_text_fails_if_worker_finishes_before_marker(self):
+        finished = self.module.tool_result(self.module.text("> "))
+
+        with self.assertRaisesRegex(
+            self.module.SuiteFailure,
+            "finished before .* marker",
+        ):
+            self.module.wait_for_busy_response_text(
+                FakeClientWithoutResponses(),
+                finished,
+                "INTERRUPT_READY",
+                "interrupt setup repl",
+                deadline_seconds=1.0,
+            )
+
+
+class FakeClientWithoutResponses:
+    def repl(self, input_text, *, timeout_ms=None):
+        raise AssertionError("unexpected poll")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/write_stdin_behavior.rs
+++ b/tests/write_stdin_behavior.rs
@@ -1131,10 +1131,22 @@ async fn timeout_spill_recreates_deleted_transcript_without_replaying_old_text()
 async fn timeout_bundle_file_creation_failure_preserves_inline_content() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let temp = tempdir()?;
+    let gate_temp = workspace_tempdir()?;
+    let start_gate_path = gate_temp.path().join("start-ready");
+    let done_path = gate_temp.path().join("bundle-failure-done");
+    let start_gate_literal = r_path_literal(&start_gate_path)?;
+    let done_literal = r_path_literal(&done_path)?;
     let session =
         spawn_behavior_session_with_env_vars(output_bundle_temp_env_vars(temp.path())).await?;
 
-    let input = "big <- paste(rep('z', 120), collapse = ''); cat('start\\n'); flush.console(); Sys.sleep(0.1); for (i in 1:80) cat(sprintf('mid%03d %s\\n', i, big)); flush.console(); Sys.sleep(0.1); cat('end\\n')";
+    let input = format!(
+        "big <- paste(rep('z', 120), collapse = ''); \
+         cat('start\\n'); flush.console(); \
+         while (!file.exists({start_gate_literal})) Sys.sleep(0.02); \
+         for (i in 1:80) cat(sprintf('mid%03d %s\\n', i, big)); \
+         flush.console(); cat('end\\n'); flush.console(); \
+         writeLines('done', {done_literal})"
+    );
     let first = session.write_stdin_raw_with(input, Some(0.05)).await?;
     let first_text = result_text(&first);
     if backend_unavailable(&first_text) {
@@ -1145,7 +1157,8 @@ async fn timeout_bundle_file_creation_failure_preserves_inline_content() -> Test
 
     fs::remove_dir_all(temp.path())?;
 
-    sleep(test_delay_ms(160, 600)).await;
+    fs::write(&start_gate_path, b"go")?;
+    wait_until_path_exists(&done_path, "bundle failure output marker").await?;
     let spilled = session.write_stdin_raw_with("", Some(2.0)).await?;
     let spilled_text = result_text(&spilled);
 
@@ -1178,12 +1191,21 @@ async fn timeout_bundle_file_creation_failure_preserves_inline_content() -> Test
 async fn hidden_timeout_bundle_is_removed_after_request_finishes_inline() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let temp = tempdir()?;
+    let gate_temp = workspace_tempdir()?;
+    let start_gate_path = gate_temp.path().join("start-ready");
+    let done_path = gate_temp.path().join("hidden-bundle-done");
+    let start_gate_literal = r_path_literal(&start_gate_path)?;
+    let done_literal = r_path_literal(&done_path)?;
     let session =
         spawn_behavior_session_with_env_vars(output_bundle_temp_env_vars(temp.path())).await?;
 
     let first = session
         .write_stdin_raw_with(
-            "cat('start\\n'); flush.console(); Sys.sleep(0.1); cat('end\\n')",
+            format!(
+                "cat('start\\n'); flush.console(); \
+                 while (!file.exists({start_gate_literal})) Sys.sleep(0.02); \
+                 cat('end\\n'); flush.console(); writeLines('done', {done_literal})"
+            ),
             Some(0.05),
         )
         .await?;
@@ -1203,7 +1225,8 @@ async fn hidden_timeout_bundle_is_removed_after_request_finishes_inline() -> Tes
         "did not expect a hidden timeout bundle directory before disclosure"
     );
 
-    sleep(test_delay_ms(160, 600)).await;
+    fs::write(&start_gate_path, b"go")?;
+    wait_until_path_exists(&done_path, "hidden bundle output marker").await?;
     let final_poll = session.write_stdin_raw_with("", Some(2.0)).await?;
     let final_text = result_text(&final_poll);
     if final_text.contains("<<repl status: busy") {

--- a/tests/write_stdin_behavior.rs
+++ b/tests/write_stdin_behavior.rs
@@ -5,7 +5,7 @@ mod common;
 use common::TestResult;
 use rmcp::model::RawContent;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use tempfile::tempdir;
 use tokio::time::{Duration, Instant, sleep};
@@ -87,6 +87,22 @@ async fn wait_for_path_to_disappear(path: &std::path::Path) -> TestResult<()> {
         sleep(Duration::from_millis(50)).await;
     }
     Err(format!("path still exists after shutdown: {}", path.display()).into())
+}
+
+fn r_path_literal(path: &Path) -> TestResult<String> {
+    Ok(serde_json::to_string(&path.to_string_lossy().to_string())?)
+}
+
+async fn wait_until_path_exists(path: &Path, label: &str) -> TestResult<()> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if path.exists() {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+
+    Err(format!("timed out waiting for {label}: {}", path.display()).into())
 }
 
 async fn wait_until_not_busy(
@@ -730,10 +746,14 @@ async fn timeout_output_bundle_is_disclosed_only_after_poll_crosses_hard_spill_t
 async fn follow_up_after_timeout_spills_when_prefix_and_reply_exceed_threshold() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let mut session = spawn_behavior_session().await?;
+    let temp = tempdir()?;
+    let start_gate_path = temp.path().join("start-ready");
+    let done_path = temp.path().join("small-done");
+    let start_gate_literal = r_path_literal(&start_gate_path)?;
+    let done_literal = r_path_literal(&done_path)?;
 
-    let first_sleep_secs = if cfg!(windows) { 0.6 } else { 0.1 };
     let first_input = format!(
-        "small <- paste(rep('s', {UNDER_HARD_SPILL_TEXT_LEN}), collapse = ''); Sys.sleep({first_sleep_secs}); cat('SMALL_START\\n'); cat(small); cat('\\nSMALL_END\\n')"
+        "small <- paste(rep('s', {UNDER_HARD_SPILL_TEXT_LEN}), collapse = ''); while (!file.exists({start_gate_literal})) Sys.sleep(0.01); cat('SMALL_START\\n'); cat(small); cat('\\nSMALL_END\\n'); flush.console(); writeLines('done', {done_literal})"
     );
     let first = session
         .write_stdin_raw_with(&first_input, Some(test_timeout_secs(0.05, 0.2)))
@@ -753,14 +773,8 @@ async fn follow_up_after_timeout_spills_when_prefix_and_reply_exceed_threshold()
         "did not expect the initial under-threshold timeout reply to spill, got: {first_text:?}"
     );
 
-    sleep(Duration::from_millis(if cfg!(windows) {
-        700
-    } else if cfg!(target_os = "macos") {
-        220
-    } else {
-        180
-    }))
-    .await;
+    fs::write(&start_gate_path, b"ready")?;
+    wait_until_path_exists(&done_path, "small output marker").await?;
     let follow_up_input = format!(
         "fresh <- paste(rep('f', {UNDER_HARD_SPILL_TEXT_LEN}), collapse = ''); cat('FRESH_START\\n'); cat(fresh); cat('\\nFRESH_END\\n')"
     );
@@ -954,8 +968,19 @@ async fn pager_busy_follow_up_reuses_hidden_timeout_bundle_when_it_first_spills(
 async fn timeout_spill_file_path_stays_stable_across_later_small_poll() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = spawn_behavior_session().await?;
+    let temp = tempdir()?;
+    let start_gate_path = temp.path().join("start-ready");
+    let mid_ready_path = temp.path().join("mid-ready");
+    let tail_gate_path = temp.path().join("tail-ready");
+    let tail_done_path = temp.path().join("tail-done");
+    let start_gate_literal = r_path_literal(&start_gate_path)?;
+    let mid_ready_literal = r_path_literal(&mid_ready_path)?;
+    let tail_gate_literal = r_path_literal(&tail_gate_path)?;
+    let tail_done_literal = r_path_literal(&tail_done_path)?;
 
-    let input = "big <- paste(rep('y', 120), collapse = ''); cat('start\\n'); flush.console(); Sys.sleep(0.1); for (i in 1:80) cat(sprintf('mid%03d %s\\n', i, big)); flush.console(); Sys.sleep(0.25); cat('tail\\n')";
+    let input = format!(
+        "big <- paste(rep('y', 120), collapse = ''); while (!file.exists({start_gate_literal})) Sys.sleep(0.01); cat('start\\n'); flush.console(); for (i in 1:80) cat(sprintf('mid%03d %s\\n', i, big)); flush.console(); writeLines('ready', {mid_ready_literal}); while (!file.exists({tail_gate_literal})) Sys.sleep(0.01); cat('tail\\n'); flush.console(); writeLines('done', {tail_done_literal})"
+    );
     let first = session.write_stdin_raw_with(input, Some(0.05)).await?;
     let first_text = result_text(&first);
     if backend_unavailable(&first_text) {
@@ -963,8 +988,13 @@ async fn timeout_spill_file_path_stays_stable_across_later_small_poll() -> TestR
         session.cancel().await?;
         return Ok(());
     }
+    assert!(
+        first_text.contains("<<repl status: busy"),
+        "expected the initial gated request to time out, got: {first_text:?}"
+    );
 
-    sleep(test_delay_ms(160, 260)).await;
+    fs::write(&start_gate_path, b"ready")?;
+    wait_until_path_exists(&mid_ready_path, "mid output marker").await?;
     let spilled = session.write_stdin_raw_with("", Some(0.1)).await?;
     let spilled_text = result_text(&spilled);
     let transcript_path = match bundle_transcript_path(&spilled_text) {
@@ -979,6 +1009,8 @@ async fn timeout_spill_file_path_stays_stable_across_later_small_poll() -> TestR
         }
     };
 
+    fs::write(&tail_gate_path, b"ready")?;
+    wait_until_path_exists(&tail_done_path, "tail output marker").await?;
     let final_poll = session.write_stdin_raw_with("", Some(2.0)).await?;
     let final_text = result_text(&final_poll);
     if final_text.contains("<<repl status: busy") {
@@ -1495,9 +1527,17 @@ async fn files_empty_poll_after_resolved_timeout_restores_prompt() -> TestResult
 async fn pager_follow_up_after_resolved_timeout_trims_detached_echo_prefix() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = spawn_pager_behavior_session(20_000).await?;
+    let temp = tempdir()?;
+    let start_gate_path = temp.path().join("start-ready");
+    let done_path = temp.path().join("pager-done");
+    let start_gate_literal = r_path_literal(&start_gate_path)?;
+    let done_literal = r_path_literal(&done_path)?;
 
+    let first_input = format!(
+        "while (!file.exists({start_gate_literal})) Sys.sleep(0.01); print(1+1); flush.console(); writeLines('done', {done_literal})"
+    );
     let first = session
-        .write_stdin_raw_with("Sys.sleep(0.1); 1+1", Some(0.05))
+        .write_stdin_raw_with(&first_input, Some(0.05))
         .await?;
     let first_text = result_text(&first);
     if backend_unavailable(&first_text) {
@@ -1505,8 +1545,13 @@ async fn pager_follow_up_after_resolved_timeout_trims_detached_echo_prefix() -> 
         session.cancel().await?;
         return Ok(());
     }
+    assert!(
+        first_text.contains("<<repl status: busy"),
+        "expected the initial gated pager request to time out, got: {first_text:?}"
+    );
 
-    sleep(test_delay_ms(160, 700)).await;
+    fs::write(&start_gate_path, b"ready")?;
+    wait_until_path_exists(&done_path, "pager output marker").await?;
     let mut follow_up = session.write_stdin_raw_with("3+3", Some(2.0)).await?;
     let mut follow_up_text = String::new();
     let deadline = Instant::now() + Duration::from_secs(60);
@@ -1545,7 +1590,7 @@ async fn pager_follow_up_after_resolved_timeout_trims_detached_echo_prefix() -> 
         "expected the fresh pager follow-up result, got: {follow_up_text:?}"
     );
     assert!(
-        !follow_up_text.contains("Sys.sleep(0.1); 1+1"),
+        !follow_up_text.contains("file.exists(") && !follow_up_text.contains("print(1+1)"),
         "did not expect the timed-out request echo to leak into the next pager reply, got: {follow_up_text:?}"
     );
 
@@ -1556,8 +1601,19 @@ async fn pager_follow_up_after_resolved_timeout_trims_detached_echo_prefix() -> 
 async fn timeout_bundle_stops_before_fresh_follow_up_output() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = spawn_behavior_session().await?;
+    let temp = tempdir()?;
+    let start_gate_path = temp.path().join("start-ready");
+    let mid_ready_path = temp.path().join("mid-ready");
+    let tail_gate_path = temp.path().join("tail-ready");
+    let tail_done_path = temp.path().join("tail-done");
+    let start_gate_literal = r_path_literal(&start_gate_path)?;
+    let mid_ready_literal = r_path_literal(&mid_ready_path)?;
+    let tail_gate_literal = r_path_literal(&tail_gate_path)?;
+    let tail_done_literal = r_path_literal(&tail_done_path)?;
 
-    let input = "big <- paste(rep('n', 120), collapse = ''); cat('start\\n'); flush.console(); Sys.sleep(0.1); for (i in 1:80) cat(sprintf('mid%03d %s\\n', i, big)); flush.console(); Sys.sleep(0.15); cat('tail\\n')";
+    let input = format!(
+        "big <- paste(rep('n', 120), collapse = ''); while (!file.exists({start_gate_literal})) Sys.sleep(0.01); cat('start\\n'); flush.console(); for (i in 1:80) cat(sprintf('mid%03d %s\\n', i, big)); flush.console(); writeLines('ready', {mid_ready_literal}); while (!file.exists({tail_gate_literal})) Sys.sleep(0.01); cat('tail\\n'); flush.console(); writeLines('done', {tail_done_literal})"
+    );
     let first = session.write_stdin_raw_with(input, Some(0.05)).await?;
     let first_text = result_text(&first);
     if backend_unavailable(&first_text) {
@@ -1565,8 +1621,13 @@ async fn timeout_bundle_stops_before_fresh_follow_up_output() -> TestResult<()> 
         session.cancel().await?;
         return Ok(());
     }
+    assert!(
+        first_text.contains("<<repl status: busy"),
+        "expected the initial gated request to time out, got: {first_text:?}"
+    );
 
-    sleep(test_delay_ms(160, 260)).await;
+    fs::write(&start_gate_path, b"ready")?;
+    wait_until_path_exists(&mid_ready_path, "mid output marker").await?;
     let spilled = session
         .write_stdin_raw_unterminated_with("", Some(0.1))
         .await?;
@@ -1583,7 +1644,9 @@ async fn timeout_bundle_stops_before_fresh_follow_up_output() -> TestResult<()> 
         }
     };
     let transcript_before = fs::read_to_string(&transcript_path)?;
-    sleep(test_delay_ms(160, 260)).await;
+
+    fs::write(&tail_gate_path, b"ready")?;
+    wait_until_path_exists(&tail_done_path, "tail output marker").await?;
     let follow_up = session
         .write_stdin_raw_with("cat('NEW_TURN\\n')", Some(2.0))
         .await?;

--- a/tests/write_stdin_behavior.rs
+++ b/tests/write_stdin_behavior.rs
@@ -93,6 +93,12 @@ fn r_path_literal(path: &Path) -> TestResult<String> {
     Ok(serde_json::to_string(&path.to_string_lossy().to_string())?)
 }
 
+fn workspace_tempdir() -> TestResult<tempfile::TempDir> {
+    Ok(tempfile::Builder::new()
+        .prefix("mcp-repl-write-stdin-")
+        .tempdir_in(env!("CARGO_MANIFEST_DIR"))?)
+}
+
 async fn wait_until_path_exists(path: &Path, label: &str) -> TestResult<()> {
     let deadline = Instant::now() + Duration::from_secs(5);
     while Instant::now() < deadline {
@@ -746,7 +752,7 @@ async fn timeout_output_bundle_is_disclosed_only_after_poll_crosses_hard_spill_t
 async fn follow_up_after_timeout_spills_when_prefix_and_reply_exceed_threshold() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let mut session = spawn_behavior_session().await?;
-    let temp = tempdir()?;
+    let temp = workspace_tempdir()?;
     let start_gate_path = temp.path().join("start-ready");
     let done_path = temp.path().join("small-done");
     let start_gate_literal = r_path_literal(&start_gate_path)?;
@@ -968,7 +974,7 @@ async fn pager_busy_follow_up_reuses_hidden_timeout_bundle_when_it_first_spills(
 async fn timeout_spill_file_path_stays_stable_across_later_small_poll() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = spawn_behavior_session().await?;
-    let temp = tempdir()?;
+    let temp = workspace_tempdir()?;
     let start_gate_path = temp.path().join("start-ready");
     let mid_ready_path = temp.path().join("mid-ready");
     let tail_gate_path = temp.path().join("tail-ready");
@@ -1527,7 +1533,7 @@ async fn files_empty_poll_after_resolved_timeout_restores_prompt() -> TestResult
 async fn pager_follow_up_after_resolved_timeout_trims_detached_echo_prefix() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = spawn_pager_behavior_session(20_000).await?;
-    let temp = tempdir()?;
+    let temp = workspace_tempdir()?;
     let start_gate_path = temp.path().join("start-ready");
     let done_path = temp.path().join("pager-done");
     let start_gate_literal = r_path_literal(&start_gate_path)?;
@@ -1601,7 +1607,7 @@ async fn pager_follow_up_after_resolved_timeout_trims_detached_echo_prefix() -> 
 async fn timeout_bundle_stops_before_fresh_follow_up_output() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = spawn_behavior_session().await?;
-    let temp = tempdir()?;
+    let temp = workspace_tempdir()?;
     let start_gate_path = temp.path().join("start-ready");
     let mid_ready_path = temp.path().join("mid-ready");
     let tail_gate_path = temp.path().join("tail-ready");

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -527,7 +527,7 @@ async fn zod_worker_idle_protocol_error_is_latched_for_next_request() -> TestRes
         .call_tool_raw(
             "repl",
             json!({
-                "input": "timeline after-readline-start delay-ms 250 raw-output-text-invalid-base64",
+                "input": "timeline after-readline-start delay-ms 2000 raw-output-text-invalid-base64",
                 "timeout_ms": 10_000
             }),
         )
@@ -538,7 +538,7 @@ async fn zod_worker_idle_protocol_error_is_latched_for_next_request() -> TestRes
         "expected first request to finish before delayed protocol error, got: {first_text:?}"
     );
 
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(2_500)).await;
 
     let second = session
         .call_tool_raw(


### PR DESCRIPTION
## Summary

This PR tightens the public integration runner so R integration cases assert exact MCP `tools/call` response shapes instead of searching loosely through concatenated text. It adds normalized golden expectations for timeout/busy replies, output bundle paths, capped output previews, reset behavior, interrupt handling, and pager commands.

The sandbox-focused tests are also made stricter and more representative: sandbox availability now fails fast where coverage depends on it, reticulate/keras JAX setup prewarms host caches before the sandboxed run, and Python discovery sandbox coverage now observes the failed write from the sandboxed Python side before verifying no marker file was created.

## Public-facing changes

None intended. This changes test coverage for the public `repl` and `repl_reset` MCP tool responses, but does not change runtime behavior.

## Internal-only changes

- Refactors `tests/run_integration_tests.py` around `repl()` / `repl_reset()` helpers, exact `tool_result()` expectations, and response normalization.
- Adds unit coverage for the integration runner helpers and transient busy interrupt polling.
- Tightens sandbox test setup and skip behavior across Rust integration tests.
- Tightens Python discovery sandbox coverage with a fake `.venv/bin/python` that attempts to write a marker in `$HOME`, asserts the sandboxed Python exception appears in the public reply, and verifies the marker file was not created.
- Stabilizes timeout, output-bundle, pager, and idle protocol tests by replacing timing sleeps with workspace-visible gates and deterministic delayed protocol errors.
- Updates the Codex TUI permissions test to use `/permissions` and probe outside-workspace writes under `$HOME`.
- Keeps the direct `/dev/stdout` fallback test skippable when opening the fd path fails.

## Diff composition

Measured against `origin/main`, this PR is `803` insertions and `437` deletions across `11` files.
- runtime `src/`: `+2/-0` (`0.2%` of churn)
- tests in `tests/`: `+801/-437` (`99.8%` of churn)

Largest files:
- `tests/run_integration_tests.py`: `+393/-291`
- `tests/sandbox.rs`: `+102/-89`
- `tests/write_stdin_behavior.rs`: `+115/-23`
- `tests/test_run_integration_tests.py`: `+129/-0`
- `tests/python_backend.rs`: `+42/-10`

## Testing

- `cargo +nightly fmt`
- `cargo check`
- `cargo build`
- `python3 tests/run_integration_tests.py --binary target/debug/mcp-repl`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
