### PR TITLE
Preserve raw worker stdin at the server boundary

### DIFF
--- a/docs/plans/active/worker-server-protocol-zod.md
+++ b/docs/plans/active/worker-server-protocol-zod.md
@@ -753,6 +753,10 @@ a small deterministic command language through stdin:
   poll behavior can be tested.
 - `interruptible <millis>` delays until either the timer finishes or an
   OS interrupt arrives.
+- `slow-shutdown <millis>` delays a later `exit` or EOF `session_end`
+  so reset and shutdown graceful-exit timing can be tested.
+- `hang-shutdown` accepts a later `exit` or EOF but never emits
+  `session_end`, so reset and shutdown OS escalation can be tested.
 - `image` emits a tiny deterministic PNG if Zod advertises image
   support.
 - `exit` emits `session_end`.

--- a/docs/plans/active/worker-server-protocol-zod.md
+++ b/docs/plans/active/worker-server-protocol-zod.md
@@ -664,7 +664,9 @@ emits an unsatisfied `readline_start`, the server uses that explicit
 event to finalize the poll reply.
 
 A later non-empty `repl()` call after an unsatisfied `readline_start` is
-written to worker stdin after the same trailing-newline normalization.
+written to worker stdin after the same trailing-newline rule: if the input is
+non-empty and does not end in `\n`, append one `\n`. The server does not
+otherwise canonicalize supplied stdin bytes such as `\r\n` or bare `\r`.
 The worker/runtime decides whether those bytes answer an
 interpreter-level prompt, continue an incomplete expression, or start a
 new top-level evaluation.

--- a/docs/plans/active/worker-server-protocol-zod.md
+++ b/docs/plans/active/worker-server-protocol-zod.md
@@ -751,8 +751,10 @@ a small deterministic command language through stdin:
   bytes.
 - `sleep <millis>` delays the next unsatisfied prompt so timeout and
   poll behavior can be tested.
-- `interruptible <millis>` delays until either the timer finishes or an
-  OS interrupt arrives.
+- `interruptible <millis>` delays until either the timer finishes or a
+  sideband or OS interrupt arrives.
+- `interrupt-report <millis>` delays while recording sideband and OS
+  interrupt delivery as separate output facts.
 - `slow-shutdown <millis>` delays a later `exit` or EOF `session_end`
   so reset and shutdown graceful-exit timing can be tested.
 - `hang-shutdown` accepts a later `exit` or EOF but never emits

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -461,6 +461,14 @@ impl ServerIpcConnection {
                         reason,
                         message_b64,
                     } => {
+                        if let Err(err) =
+                            validate_session_end(reason.as_deref(), message_b64.as_deref())
+                        {
+                            let mut guard = reader_inbox.lock().unwrap();
+                            latch_protocol_error(&mut guard, err);
+                            reader_cvar.notify_all();
+                            break;
+                        }
                         let mut guard = reader_inbox.lock().unwrap();
                         guard.session_end = true;
                         guard.session_end_final = true;
@@ -1905,6 +1913,23 @@ fn latch_protocol_error(guard: &mut ServerIpcInbox, message: impl Into<String>) 
         message: message.into(),
         observed_at: Instant::now(),
     });
+}
+
+fn validate_session_end(reason: Option<&str>, message_b64: Option<&str>) -> Result<(), String> {
+    if let Some(reason) = reason {
+        match reason {
+            "shutdown" | "reset" | "runtime_exit" | "crash" | "protocol_error" => {}
+            other => return Err(format!("invalid session_end reason: {other}")),
+        }
+    }
+    if let Some(message_b64) = message_b64
+        && base64::engine::general_purpose::STANDARD
+            .decode(message_b64)
+            .is_err()
+    {
+        return Err("invalid session_end message_b64 base64".to_string());
+    }
+    Ok(())
 }
 
 fn take_latched_protocol_error(guard: &mut ServerIpcInbox) -> Option<String> {

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -186,15 +186,6 @@ pub(crate) fn timeout_bundle_reuse_for_input(input: &str) -> TimeoutBundleReuse 
         return TimeoutBundleReuse::FullReply;
     };
     let tail = &input[first.len_utf8()..];
-    let tail = if let Some(rest) = tail.strip_prefix("\r\n") {
-        rest
-    } else if let Some(rest) = tail.strip_prefix('\n') {
-        rest
-    } else if let Some(rest) = tail.strip_prefix('\r') {
-        rest
-    } else {
-        tail
-    };
 
     match first {
         '\u{3}' if tail.is_empty() => TimeoutBundleReuse::FullReply,

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -197,6 +197,22 @@ fn timeout_bundle_reuse_treats_blank_lines_as_fresh_input() {
     ));
 }
 
+#[test]
+fn timeout_bundle_reuse_treats_newline_ctrl_c_as_follow_up_input() {
+    assert!(matches!(
+        super::response::timeout_bundle_reuse_for_input("\u{3}"),
+        super::response::TimeoutBundleReuse::FullReply
+    ));
+    assert!(matches!(
+        super::response::timeout_bundle_reuse_for_input("\u{3}\n"),
+        super::response::TimeoutBundleReuse::FollowUpInput
+    ));
+    assert!(matches!(
+        super::response::timeout_bundle_reuse_for_input("\u{3}\r\n"),
+        super::response::TimeoutBundleReuse::FollowUpInput
+    ));
+}
+
 fn split_lines(text: &str) -> Vec<String> {
     if text.is_empty() {
         return Vec::new();

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -475,7 +475,8 @@ fn driver_refresh_worker_ready(
 
 impl BackendDriver for RBackendDriver {
     fn prepare_input_payload(&self, text: &str) -> Vec<u8> {
-        let mut payload = text.as_bytes().to_vec();
+        let normalized = normalize_input_newlines(text);
+        let mut payload = normalized.into_bytes();
         if !payload.is_empty() && !payload.ends_with(b"\n") {
             payload.push(b'\n');
         }
@@ -852,7 +853,8 @@ fn strip_one_line_ending(text: &str) -> Option<&str> {
 #[cfg(not(target_family = "unix"))]
 impl BackendDriver for PythonBackendDriver {
     fn prepare_input_payload(&self, text: &str) -> Vec<u8> {
-        let mut payload = text.as_bytes().to_vec();
+        let normalized = normalize_input_newlines(text);
+        let mut payload = normalized.into_bytes();
         if !payload.is_empty() && !payload.ends_with(b"\n") {
             payload.push(b'\n');
         }
@@ -2565,7 +2567,6 @@ impl WorkerManager {
         worker_timeout: Duration,
         server_timeout: Duration,
     ) -> Result<RequestState, WorkerError> {
-        let text = normalize_input_newlines(&text);
         let started_at = std::time::Instant::now();
         let prompt = self.current_prompt_hint();
         self.remember_prompt(prompt);

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -475,7 +475,8 @@ fn driver_refresh_worker_ready(
 
 impl BackendDriver for RBackendDriver {
     fn prepare_input_payload(&self, text: &str) -> Vec<u8> {
-        let mut payload = text.as_bytes().to_vec();
+        let normalized = normalize_input_newlines(text);
+        let mut payload = normalized.into_bytes();
         if !payload.is_empty() && !payload.ends_with(b"\n") {
             payload.push(b'\n');
         }

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -475,8 +475,7 @@ fn driver_refresh_worker_ready(
 
 impl BackendDriver for RBackendDriver {
     fn prepare_input_payload(&self, text: &str) -> Vec<u8> {
-        let normalized = normalize_input_newlines(text);
-        let mut payload = normalized.into_bytes();
+        let mut payload = text.as_bytes().to_vec();
         if !payload.is_empty() && !payload.ends_with(b"\n") {
             payload.push(b'\n');
         }
@@ -853,8 +852,7 @@ fn strip_one_line_ending(text: &str) -> Option<&str> {
 #[cfg(not(target_family = "unix"))]
 impl BackendDriver for PythonBackendDriver {
     fn prepare_input_payload(&self, text: &str) -> Vec<u8> {
-        let normalized = normalize_input_newlines(text);
-        let mut payload = normalized.into_bytes();
+        let mut payload = text.as_bytes().to_vec();
         if !payload.is_empty() && !payload.ends_with(b"\n") {
             payload.push(b'\n');
         }
@@ -938,13 +936,6 @@ impl ProtocolBackendDriver {
 
 impl BackendDriver for ProtocolBackendDriver {
     fn prepare_input_payload(&self, text: &str) -> Vec<u8> {
-        #[cfg(target_family = "unix")]
-        let mut payload = if self.python_request_generation.is_some() {
-            normalize_input_newlines(text).into_bytes()
-        } else {
-            text.as_bytes().to_vec()
-        };
-        #[cfg(not(target_family = "unix"))]
         let mut payload = text.as_bytes().to_vec();
         if !payload.is_empty() && !payload.ends_with(b"\n") {
             payload.push(b'\n');

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -3471,13 +3471,23 @@ impl WorkerManager {
                 MISSING_INHERITED_SANDBOX_STATE_MESSAGE.to_string(),
             ));
         }
+        self.maybe_emit_pending_server_notice();
+        let pre_shutdown_output = self
+            .process
+            .is_some()
+            .then(|| self.drain_sealed_formatted_output());
         if let Some(process) = self.process.take() {
             let _ = process.shutdown_graceful(timeout);
+            self.pending_output_tape.clear();
         }
         self.guardrail.busy.store(false, Ordering::Relaxed);
-        self.maybe_emit_pending_server_notice();
 
-        let reply = self.build_session_reset_reply_files("new session started");
+        let reply = match pre_shutdown_output {
+            Some(output) => {
+                self.build_session_reset_reply_files_from_formatted("new session started", output)
+            }
+            None => self.build_session_reset_reply_files("new session started"),
+        };
         self.clear_preserved_prefixes();
         self.reset_output_state_files(true);
         self.note_respawn_during_write();
@@ -3644,14 +3654,32 @@ impl WorkerManager {
                 MISSING_INHERITED_SANDBOX_STATE_MESSAGE.to_string(),
             ));
         }
+        self.maybe_emit_pending_server_notice();
+        let pre_shutdown_end_offset = self
+            .process
+            .is_some()
+            .then(|| self.output.end_offset().unwrap_or(0));
         if let Some(process) = self.process.take() {
             let _ = process.shutdown_graceful(timeout);
         }
+        let post_shutdown_end_offset = self.output.end_offset();
         self.guardrail.busy.store(false, Ordering::Relaxed);
-        self.maybe_emit_pending_server_notice();
 
         let page_bytes = pager::resolve_page_bytes(None);
-        let reply = self.build_session_reset_reply_pager(page_bytes, "new session started");
+        let reply = match pre_shutdown_end_offset {
+            Some(end_offset) => {
+                let reply = self.build_session_reset_reply_pager_to_offset(
+                    page_bytes,
+                    "new session started",
+                    end_offset,
+                );
+                if let Some(end_offset) = post_shutdown_end_offset {
+                    self.output.advance_offset_to(end_offset);
+                }
+                reply
+            }
+            None => self.build_session_reset_reply_pager(page_bytes, "new session started"),
+        };
         self.clear_preserved_prefixes();
         self.reset_output_state_pager(true, false);
         self.note_respawn_during_write();
@@ -4577,10 +4605,19 @@ impl WorkerManager {
     }
 
     fn build_session_reset_reply_files(&mut self, meta: &str) -> ReplyWithOffset {
+        let formatted = self.drain_sealed_formatted_output();
+        self.build_session_reset_reply_files_from_formatted(meta, formatted)
+    }
+
+    fn build_session_reset_reply_files_from_formatted(
+        &mut self,
+        meta: &str,
+        formatted: FormattedPendingOutput,
+    ) -> ReplyWithOffset {
         let FormattedPendingOutput {
             mut contents,
             saw_stderr,
-        } = self.drain_sealed_formatted_output();
+        } = formatted;
         contents.retain(|content| match content {
             WorkerContent::ContentText { text, .. } => !text.trim().is_empty(),
             _ => true,
@@ -4604,6 +4641,15 @@ impl WorkerManager {
 
     fn build_session_reset_reply_pager(&mut self, page_bytes: u64, meta: &str) -> ReplyWithOffset {
         let end_offset = self.output.end_offset().unwrap_or(0);
+        self.build_session_reset_reply_pager_to_offset(page_bytes, meta, end_offset)
+    }
+
+    fn build_session_reset_reply_pager_to_offset(
+        &mut self,
+        page_bytes: u64,
+        meta: &str,
+        end_offset: u64,
+    ) -> ReplyWithOffset {
         let mut is_error = false;
 
         let SnapshotWithImages {

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -938,6 +938,13 @@ impl ProtocolBackendDriver {
 
 impl BackendDriver for ProtocolBackendDriver {
     fn prepare_input_payload(&self, text: &str) -> Vec<u8> {
+        #[cfg(target_family = "unix")]
+        let mut payload = if self.python_request_generation.is_some() {
+            normalize_input_newlines(text).into_bytes()
+        } else {
+            text.as_bytes().to_vec()
+        };
+        #[cfg(not(target_family = "unix"))]
         let mut payload = text.as_bytes().to_vec();
         if !payload.is_empty() && !payload.ends_with(b"\n") {
             payload.push(b'\n');

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -1234,17 +1234,7 @@ pub(crate) fn split_write_stdin_control_prefix(
         _ => return None,
     };
 
-    let tail = &input[first.len_utf8()..];
-    let tail = if let Some(rest) = tail.strip_prefix("\r\n") {
-        rest
-    } else if let Some(rest) = tail.strip_prefix('\n') {
-        rest
-    } else if let Some(rest) = tail.strip_prefix('\r') {
-        rest
-    } else {
-        tail
-    };
-    Some((action, tail))
+    Some((action, &input[first.len_utf8()..]))
 }
 
 fn worker_context_event_payload(
@@ -7603,11 +7593,11 @@ mod tests {
     }
 
     #[test]
-    fn control_prefix_strips_single_separator_newline() {
+    fn control_prefix_preserves_immediate_newline_tail() {
         let (action, remaining) =
             split_write_stdin_control_prefix("\u{4}\nprint(1)").expect("expected control prefix");
         assert!(matches!(action, WriteStdinControlAction::Restart));
-        assert_eq!(remaining, "print(1)");
+        assert_eq!(remaining, "\nprint(1)");
     }
 
     #[test]

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,6 +25,6 @@ snapshot.session("default", mcp_script! {
     write_stdin("x <- 1");
     write_stdin("x <- x + 2");
     write_stdin("x", timeout = 0.2);
-    write_stdin("\u{4}");
+    write_stdin_raw_unterminated("\u{4}");
 }).await?;
 ```

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -279,6 +279,21 @@ macro_rules! mcp_calls_inner {
         $crate::mcp_calls_inner!($session, $($rest)*);
     }};
 
+    ($session:ident, write_stdin_raw_unterminated($input:expr $(, timeout = $timeout:expr)? ); $($rest:tt)*) => {{
+        let mut args = serde_json::Map::new();
+        args.insert("input".to_string(), serde_json::Value::String($input.to_string()));
+        if let Some(timeout) = $crate::common::normalized_test_timeout($crate::mcp_timeout_opt!($($timeout)?)) {
+            args.insert(
+                "timeout_ms".to_string(),
+                serde_json::json!((timeout * 1000.0).round() as i64),
+            );
+        }
+        $session
+            .call_tool($session.repl_tool_name(), serde_json::Value::Object(args))
+            .await;
+        $crate::mcp_calls_inner!($session, $($rest)*);
+    }};
+
 }
 
 #[macro_export]
@@ -440,7 +455,7 @@ fn compact_json(value: &Value) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| value.to_string())
 }
 
-fn normalized_test_timeout(timeout: Option<f64>) -> Option<f64> {
+pub(crate) fn normalized_test_timeout(timeout: Option<f64>) -> Option<f64> {
     #[cfg(windows)]
     {
         timeout.map(|value| value.min(WINDOWS_TEST_TIMEOUT_CAP_SECS))

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -73,6 +73,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         next_prompt: "zod> ".to_string(),
         shutdown_mode: ShutdownMode::Normal,
         previous_line_empty: false,
+        shutdown_log_path: shutdown_log_path.clone(),
     };
     let mut timeline = Timeline::default();
     loop {
@@ -116,7 +117,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &writer,
             &sideband_interrupted,
             &mut reader,
-            shutdown_log_path.as_deref(),
             command,
             &line,
             &mut command_state,
@@ -136,7 +136,6 @@ fn run_command(
     writer: &IpcWriter,
     sideband_interrupted: &AtomicBool,
     reader: &mut dyn BufRead,
-    shutdown_log_path: Option<&Path>,
     command: &str,
     raw_line: &str,
     state: &mut CommandState,
@@ -236,10 +235,10 @@ fn run_command(
         let mut user_line = String::new();
         let bytes = reader.read_line(&mut user_line)?;
         if bytes == 0 {
-            append_shutdown_log(shutdown_log_path, "user-stdin:<eof>")?;
+            append_shutdown_log(state.shutdown_log_path.as_deref(), "user-stdin:<eof>")?;
         } else {
             append_shutdown_log(
-                shutdown_log_path,
+                state.shutdown_log_path.as_deref(),
                 format!("user-stdin:{}", user_line.trim_end_matches(['\r', '\n'])).as_str(),
             )?;
         }
@@ -299,6 +298,7 @@ struct CommandState {
     next_prompt: String,
     shutdown_mode: ShutdownMode,
     previous_line_empty: bool,
+    shutdown_log_path: Option<PathBuf>,
 }
 
 #[derive(Clone, Copy)]

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -260,6 +260,12 @@ fn run_command(
         return Ok(());
     }
 
+    if command == "report-raw-line" || command.starts_with("report-raw-line ") {
+        let text = format!("raw-line-debug: {}\n", raw_line.escape_debug());
+        writer.output_text("stdout", text.as_bytes())?;
+        return Ok(());
+    }
+
     if command == "bad-output-base64" {
         writer.send_raw_json(INVALID_OUTPUT_TEXT_BASE64)?;
         return Ok(());

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -38,12 +38,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let transport = IpcTransport::connect_from_env()?;
     let writer = IpcWriter::new(transport.writer);
-    let interrupted = Arc::new(AtomicBool::new(false));
+    let sideband_interrupted = Arc::new(AtomicBool::new(false));
     let control_session_end = Arc::new(AtomicBool::new(false));
     let shutdown_log_path = std::env::var_os(SHUTDOWN_LOG_ENV).map(PathBuf::from);
     start_control_reader(
         transport.reader,
-        interrupted.clone(),
+        sideband_interrupted.clone(),
         control_session_end.clone(),
         shutdown_log_path.clone(),
     );
@@ -113,7 +113,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         timeline.run(LifecyclePoint::BeforeCommand, &writer)?;
         run_command(
             &writer,
-            &interrupted,
+            &sideband_interrupted,
             &mut reader,
             command,
             &line,
@@ -131,7 +131,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 fn run_command(
     writer: &IpcWriter,
-    interrupted: &AtomicBool,
+    sideband_interrupted: &AtomicBool,
     reader: &mut dyn BufRead,
     command: &str,
     raw_line: &str,
@@ -151,7 +151,7 @@ fn run_command(
     }
 
     if let Some(millis) = command.strip_prefix("sleep ") {
-        sleep_for(parse_millis(millis)?, interrupted, false);
+        sleep_for(parse_millis(millis)?, sideband_interrupted, false);
         return Ok(());
     }
 
@@ -159,7 +159,7 @@ fn run_command(
         let mut stdout = io::stdout().lock();
         stdout.write_all(b"zod> raw stdout\n")?;
         stdout.flush()?;
-        sleep_for(parse_millis(millis)?, interrupted, false);
+        sleep_for(parse_millis(millis)?, sideband_interrupted, false);
         return Ok(());
     }
 
@@ -167,7 +167,7 @@ fn run_command(
         writer.send(&WorkerToServer::ReadlineStart {
             prompt: "buffered> ".to_string(),
         })?;
-        sleep_for(parse_millis(millis)?, interrupted, false);
+        sleep_for(parse_millis(millis)?, sideband_interrupted, false);
         return Ok(());
     }
 
@@ -186,13 +186,28 @@ fn run_command(
     }
 
     if let Some(millis) = command.strip_prefix("bad-output-after-sleep ") {
-        sleep_for(parse_millis(millis)?, interrupted, false);
+        sleep_for(parse_millis(millis)?, sideband_interrupted, false);
         writer.send_raw_json(INVALID_OUTPUT_TEXT_BASE64)?;
         return Ok(());
     }
 
     if let Some(millis) = command.strip_prefix("interruptible ") {
-        sleep_for(parse_millis(millis)?, interrupted, true);
+        sleep_for(parse_millis(millis)?, sideband_interrupted, true);
+        return Ok(());
+    }
+
+    if let Some(millis) = command.strip_prefix("interrupt-report ") {
+        let report = observe_interrupts_for(parse_millis(millis)?, sideband_interrupted);
+        let text = format!(
+            "sideband interrupt: {}\nos interrupt: {}\n",
+            if report.sideband {
+                "observed"
+            } else {
+                "missing"
+            },
+            if report.os { "observed" } else { "missing" },
+        );
+        writer.output_text("stdout", text.as_bytes())?;
         return Ok(());
     }
 
@@ -207,7 +222,7 @@ fn run_command(
     }
 
     if let Some(millis) = command.strip_prefix("discard-on-interrupt ") {
-        if sleep_for(parse_millis(millis)?, interrupted, true) {
+        if sleep_for(parse_millis(millis)?, sideband_interrupted, true) {
             discard_buffered_stdin(reader, writer)?;
         }
         return Ok(());
@@ -478,6 +493,43 @@ fn sleep_for(millis: u64, interrupted: &AtomicBool, interruptible: bool) -> bool
     }
     false
 }
+
+struct InterruptReport {
+    sideband: bool,
+    os: bool,
+}
+
+fn observe_interrupts_for(millis: u64, sideband_interrupted: &AtomicBool) -> InterruptReport {
+    sideband_interrupted.store(false, Ordering::SeqCst);
+    clear_os_interrupted();
+
+    let deadline = Instant::now() + Duration::from_millis(millis);
+    let mut report = InterruptReport {
+        sideband: false,
+        os: false,
+    };
+    while Instant::now() < deadline {
+        report.sideband |= sideband_interrupted.swap(false, Ordering::SeqCst);
+        report.os |= os_interrupted().unwrap_or(false);
+        if report.sideband && (report.os || !os_interrupts_supported()) {
+            return report;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    report
+}
+
+fn os_interrupts_supported() -> bool {
+    cfg!(target_family = "unix")
+}
+
+#[cfg(target_family = "unix")]
+fn clear_os_interrupted() {
+    INTERRUPTED_BY_OS.store(false, Ordering::SeqCst);
+}
+
+#[cfg(not(target_family = "unix"))]
+fn clear_os_interrupted() {}
 
 #[cfg(target_family = "unix")]
 fn os_interrupted() -> Option<bool> {

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -26,6 +26,8 @@ const STARTUP_PROTOCOL_ERROR_ENV: &str = "MCP_REPL_ZOD_STARTUP_PROTOCOL_ERROR";
 const SHUTDOWN_LOG_ENV: &str = "MCP_REPL_ZOD_SHUTDOWN_LOG";
 const INVALID_OUTPUT_TEXT_BASE64: &str =
     r#"{"type":"output_text","stream":"stdout","data_b64":"***"}"#;
+const INVALID_SESSION_END_REASON: &str =
+    r#"{"type":"session_end","reason":"not-a-recognized-reason"}"#;
 
 #[cfg(target_family = "unix")]
 static INTERRUPTED_BY_OS: AtomicBool = AtomicBool::new(false);
@@ -214,6 +216,11 @@ fn run_command(
 
     if command == "bad-output-base64" {
         writer.send_raw_json(INVALID_OUTPUT_TEXT_BASE64)?;
+        return Ok(());
+    }
+
+    if command == "bad-session-end-reason" {
+        writer.send_raw_json(INVALID_SESSION_END_REASON)?;
         return Ok(());
     }
 

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -69,7 +69,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let stdin = io::stdin();
     let mut reader = BufReader::new(stdin.lock());
     let mut line = String::new();
-    let mut next_prompt = "zod> ".to_string();
+    let mut command_state = CommandState {
+        next_prompt: "zod> ".to_string(),
+        shutdown_mode: ShutdownMode::Normal,
+    };
     let mut timeline = Timeline::default();
     loop {
         line.clear();
@@ -81,6 +84,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "stdin_eof"
             };
             append_shutdown_log(shutdown_log_path.as_deref(), shutdown_event)?;
+            apply_shutdown_mode(shutdown_log_path.as_deref(), command_state.shutdown_mode)?;
             send_session_end(&writer, &mut timeline, "shutdown")?;
             return Ok(());
         }
@@ -96,6 +100,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         })?;
         timeline.run(LifecyclePoint::AfterReadlineInput, &writer)?;
         if command == "exit" {
+            append_shutdown_log(shutdown_log_path.as_deref(), "user-stdin:exit")?;
+            apply_shutdown_mode(shutdown_log_path.as_deref(), command_state.shutdown_mode)?;
             send_session_end(&writer, &mut timeline, "runtime_exit")?;
             return Ok(());
         }
@@ -111,14 +117,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &mut reader,
             command,
             &line,
-            &mut next_prompt,
+            &mut command_state,
             &mut timeline,
         )?;
         timeline.run(LifecyclePoint::AfterCommand, &writer)?;
         send_readline_start(
             &writer,
             &mut timeline,
-            std::mem::replace(&mut next_prompt, "zod> ".to_string()),
+            std::mem::replace(&mut command_state.next_prompt, "zod> ".to_string()),
         )?;
     }
 }
@@ -129,11 +135,11 @@ fn run_command(
     reader: &mut dyn BufRead,
     command: &str,
     raw_line: &str,
-    next_prompt: &mut String,
+    state: &mut CommandState,
     timeline: &mut Timeline,
 ) -> io::Result<()> {
     if let Some(prompt) = command.strip_prefix("wait ") {
-        *next_prompt = prompt.to_string();
+        state.next_prompt = prompt.to_string();
         return Ok(());
     }
 
@@ -190,6 +196,16 @@ fn run_command(
         return Ok(());
     }
 
+    if let Some(millis) = command.strip_prefix("slow-shutdown ") {
+        state.shutdown_mode = ShutdownMode::Delay(Duration::from_millis(parse_millis(millis)?));
+        return Ok(());
+    }
+
+    if command == "hang-shutdown" {
+        state.shutdown_mode = ShutdownMode::Hang;
+        return Ok(());
+    }
+
     if let Some(millis) = command.strip_prefix("discard-on-interrupt ") {
         if sleep_for(parse_millis(millis)?, interrupted, true) {
             discard_buffered_stdin(reader, writer)?;
@@ -225,6 +241,35 @@ fn run_command(
     }
 
     writer.output_text("stdout", raw_line.as_bytes())
+}
+
+struct CommandState {
+    next_prompt: String,
+    shutdown_mode: ShutdownMode,
+}
+
+#[derive(Clone, Copy)]
+enum ShutdownMode {
+    Normal,
+    Delay(Duration),
+    Hang,
+}
+
+fn apply_shutdown_mode(path: Option<&Path>, mode: ShutdownMode) -> io::Result<()> {
+    match mode {
+        ShutdownMode::Normal => Ok(()),
+        ShutdownMode::Delay(delay) => {
+            append_shutdown_log(path, &format!("shutdown:delay-ms:{}", delay.as_millis()))?;
+            thread::sleep(delay);
+            append_shutdown_log(path, "shutdown:delay-complete")
+        }
+        ShutdownMode::Hang => {
+            append_shutdown_log(path, "shutdown:hang")?;
+            loop {
+                thread::sleep(Duration::from_secs(60));
+            }
+        }
+    }
 }
 
 fn discard_buffered_stdin(reader: &mut dyn BufRead, writer: &IpcWriter) -> io::Result<()> {

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -72,6 +72,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut command_state = CommandState {
         next_prompt: "zod> ".to_string(),
         shutdown_mode: ShutdownMode::Normal,
+        previous_line_empty: false,
     };
     let mut timeline = Timeline::default();
     loop {
@@ -121,6 +122,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &mut timeline,
         )?;
         timeline.run(LifecyclePoint::AfterCommand, &writer)?;
+        command_state.previous_line_empty = command.is_empty();
         send_readline_start(
             &writer,
             &mut timeline,
@@ -245,6 +247,19 @@ fn run_command(
         return Ok(());
     }
 
+    if command == "report-leading-empty" {
+        let status = if state.previous_line_empty {
+            "observed"
+        } else {
+            "missing"
+        };
+        writer.output_text(
+            "stdout",
+            format!("previous empty line: {status}\n").as_bytes(),
+        )?;
+        return Ok(());
+    }
+
     if command == "bad-output-base64" {
         writer.send_raw_json(INVALID_OUTPUT_TEXT_BASE64)?;
         return Ok(());
@@ -261,6 +276,7 @@ fn run_command(
 struct CommandState {
     next_prompt: String,
     shutdown_mode: ShutdownMode,
+    previous_line_empty: bool,
 }
 
 #[derive(Clone, Copy)]

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -116,6 +116,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &writer,
             &sideband_interrupted,
             &mut reader,
+            shutdown_log_path.as_deref(),
             command,
             &line,
             &mut command_state,
@@ -135,6 +136,7 @@ fn run_command(
     writer: &IpcWriter,
     sideband_interrupted: &AtomicBool,
     reader: &mut dyn BufRead,
+    shutdown_log_path: Option<&Path>,
     command: &str,
     raw_line: &str,
     state: &mut CommandState,
@@ -226,6 +228,20 @@ fn run_command(
     if let Some(millis) = command.strip_prefix("discard-on-interrupt ") {
         if sleep_for(parse_millis(millis)?, sideband_interrupted, true) {
             discard_buffered_stdin(reader, writer)?;
+        }
+        return Ok(());
+    }
+
+    if command == "read-user-stdin" {
+        let mut user_line = String::new();
+        let bytes = reader.read_line(&mut user_line)?;
+        if bytes == 0 {
+            append_shutdown_log(shutdown_log_path, "user-stdin:<eof>")?;
+        } else {
+            append_shutdown_log(
+                shutdown_log_path,
+                format!("user-stdin:{}", user_line.trim_end_matches(['\r', '\n'])).as_str(),
+            )?;
         }
         return Ok(());
     }

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -106,6 +106,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         run_command(
             &writer,
             &interrupted,
+            &mut reader,
             command,
             &line,
             &mut next_prompt,
@@ -123,6 +124,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn run_command(
     writer: &IpcWriter,
     interrupted: &AtomicBool,
+    reader: &mut dyn BufRead,
     command: &str,
     raw_line: &str,
     next_prompt: &mut String,
@@ -186,6 +188,13 @@ fn run_command(
         return Ok(());
     }
 
+    if let Some(millis) = command.strip_prefix("discard-on-interrupt ") {
+        if sleep_for(parse_millis(millis)?, interrupted, true) {
+            discard_buffered_stdin(reader, writer)?;
+        }
+        return Ok(());
+    }
+
     if command == "image" {
         writer.send(&WorkerToServer::OutputImage {
             image_id: "zod-image".to_string(),
@@ -209,6 +218,21 @@ fn run_command(
     }
 
     writer.output_text("stdout", raw_line.as_bytes())
+}
+
+fn discard_buffered_stdin(reader: &mut dyn BufRead, writer: &IpcWriter) -> io::Result<()> {
+    let (text, len) = {
+        let buffer = reader.fill_buf()?;
+        let text = std::str::from_utf8(buffer)
+            .map_err(io::Error::other)?
+            .to_string();
+        (text, buffer.len())
+    };
+    if len == 0 {
+        return Ok(());
+    }
+    reader.consume(len);
+    writer.send(&WorkerToServer::ReadlineDiscard { text })
 }
 
 fn send_readline_start(
@@ -390,16 +414,17 @@ fn parse_millis(raw: &str) -> io::Result<u64> {
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))
 }
 
-fn sleep_for(millis: u64, interrupted: &AtomicBool, interruptible: bool) {
+fn sleep_for(millis: u64, interrupted: &AtomicBool, interruptible: bool) -> bool {
     let deadline = Instant::now() + Duration::from_millis(millis);
     while Instant::now() < deadline {
         if interruptible
             && (interrupted.swap(false, Ordering::SeqCst) || os_interrupted().unwrap_or(false))
         {
-            return;
+            return true;
         }
         thread::sleep(Duration::from_millis(10));
     }
+    false
 }
 
 #[cfg(target_family = "unix")]
@@ -443,6 +468,9 @@ enum WorkerToServer {
         prompt: String,
     },
     ReadlineInput {
+        text: String,
+    },
+    ReadlineDiscard {
         text: String,
     },
     OutputText {

--- a/tests/interrupt.rs
+++ b/tests/interrupt.rs
@@ -107,7 +107,9 @@ async fn interrupt_unblocks_long_running_request() -> TestResult<()> {
         "expected sleep call to time out, got: {timeout_text:?}"
     );
 
-    let interrupt_result = session.write_stdin_raw_with("\u{3}", Some(5.0)).await?;
+    let interrupt_result = session
+        .write_stdin_raw_unterminated_with("\u{3}", Some(5.0))
+        .await?;
     let interrupt_text = result_text(&interrupt_result);
     if backend_unavailable(&interrupt_text) {
         eprintln!("interrupt test backend unavailable in this environment; skipping");
@@ -183,7 +185,9 @@ async fn assert_interrupt_drain_preserves_prompt_shaped_child_stdout(
         sleep(Duration::from_millis(50)).await;
     }
 
-    let interrupt_result = session.write_stdin_raw_with("\u{3}", Some(5.0)).await?;
+    let interrupt_result = session
+        .write_stdin_raw_unterminated_with("\u{3}", Some(5.0))
+        .await?;
     let interrupt_text = result_text(&interrupt_result);
     if backend_unavailable(&interrupt_text) {
         eprintln!("interrupt test backend unavailable in this environment; skipping");

--- a/tests/manage_session_behavior.rs
+++ b/tests/manage_session_behavior.rs
@@ -52,7 +52,9 @@ async fn interrupt_without_active_request_returns_prompt() -> TestResult<()> {
     let session = spawn_manage_session().await?;
 
     let _ = session.write_stdin_raw_with("1+1", Some(5.0)).await?;
-    let result = session.write_stdin_raw_with("\u{3}", Some(5.0)).await?;
+    let result = session
+        .write_stdin_raw_unterminated_with("\u{3}", Some(5.0))
+        .await?;
 
     let text = result_text(&result);
     if backend_unavailable(&text) {
@@ -113,7 +115,9 @@ async fn restart_while_busy_resets_session() -> TestResult<()> {
         .write_stdin_raw_with("x <- 1; Sys.sleep(5)", Some(0.1))
         .await?;
 
-    let restart = session.write_stdin_raw_with("\u{4}", Some(5.0)).await?;
+    let restart = session
+        .write_stdin_raw_unterminated_with("\u{4}", Some(5.0))
+        .await?;
     let restart_text = result_text(&restart);
     if backend_unavailable(&restart_text) {
         eprintln!("restart test backend unavailable in this environment; skipping");

--- a/tests/mcp_transcripts.rs
+++ b/tests/mcp_transcripts.rs
@@ -15,7 +15,7 @@ async fn snapshots_support_multiple_calls_and_sessions() -> TestResult<()> {
             mcp_script! {
                 write_stdin("x <- 40 + 2", timeout = 10.0);
                 write_stdin("x", timeout = 10.0);
-                write_stdin("\u{4}");
+                write_stdin_raw_unterminated("\u{4}");
             },
         )
         .await?;
@@ -125,9 +125,9 @@ cat("TEMPDIR_UNDER_TMPDIR=", startsWith(tempdir(), Sys.getenv("TMPDIR")), "\n", 
             "tempdir_session",
             mcp_script! {
                 write_stdin(setup, timeout = 10.0);
-                write_stdin("\u{4}");
+                write_stdin_raw_unterminated("\u{4}");
                 write_stdin(after_restart, timeout = 10.0);
-                write_stdin("\u{4}");
+                write_stdin_raw_unterminated("\u{4}");
                 write_stdin(after_restart, timeout = 10.0);
             },
         )
@@ -166,7 +166,9 @@ async fn transcripts_smoke() -> TestResult<()> {
         return Ok(());
     }
 
-    let _ = session.write_stdin_raw_with("\u{4}", Some(10.0)).await?;
+    let _ = session
+        .write_stdin_raw_unterminated_with("\u{4}", Some(10.0))
+        .await?;
     if !common::assert_eventually_contains(
         &mut session,
         "print(exists(\"x\"))",

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -2579,7 +2579,9 @@ async fn python_interrupt_unblocks_input_prompt() -> TestResult<()> {
         "expected input prompt, got: {text:?}"
     );
 
-    let interrupt = session.write_stdin_raw_with("\u{3}", Some(5.0)).await?;
+    let interrupt = session
+        .write_stdin_raw_unterminated_with("\u{3}", Some(5.0))
+        .await?;
     let interrupt_text = result_text(&interrupt);
     if is_busy_response(&interrupt_text) {
         eprintln!("input prompt interrupt stayed busy in this Python runtime; skipping");
@@ -2635,7 +2637,9 @@ async fn python_interrupt_unblocks_primary_shaped_input_prompt() -> TestResult<(
         "expected primary-shaped input prompt, got: {text:?}"
     );
 
-    let interrupt = session.write_stdin_raw_with("\u{3}", Some(1.0)).await?;
+    let interrupt = session
+        .write_stdin_raw_unterminated_with("\u{3}", Some(1.0))
+        .await?;
     let interrupt_text = result_text(&interrupt);
     if is_busy_response(&interrupt_text) || interrupt_text.contains("timed out") {
         eprintln!(
@@ -2681,7 +2685,9 @@ async fn python_interrupt_at_custom_primary_prompt_reaches_worker() -> TestResul
         "expected custom primary prompt after setup, got: {setup_text:?}"
     );
 
-    let interrupt = session.write_stdin_raw_with("\u{3}", Some(1.0)).await?;
+    let interrupt = session
+        .write_stdin_raw_unterminated_with("\u{3}", Some(1.0))
+        .await?;
     let interrupt_text = result_text(&interrupt);
     if is_busy_response(&interrupt_text) || interrupt_text.contains("timed out") {
         eprintln!("idle custom prompt interrupt stayed busy in this Python runtime; skipping");
@@ -2742,7 +2748,9 @@ print("SIGINT_FINAL", sigint_count)
         "expected SIGINT handler loop to time out, got: {timeout_text:?}"
     );
 
-    let interrupt = session.write_stdin_raw_with("\u{3}", Some(5.0)).await?;
+    let interrupt = session
+        .write_stdin_raw_unterminated_with("\u{3}", Some(5.0))
+        .await?;
     let interrupt_text = result_text(&interrupt);
     assert!(
         !is_busy_response(&interrupt_text),
@@ -2835,7 +2843,9 @@ async fn python_interrupt_aborts_continuation_prompt_without_running_block() -> 
         "expected continuation prompt before interrupt, got: {text:?}"
     );
 
-    let interrupt = session.write_stdin_raw_with("\u{3}", Some(5.0)).await?;
+    let interrupt = session
+        .write_stdin_raw_unterminated_with("\u{3}", Some(5.0))
+        .await?;
     let interrupt_text = result_text(&interrupt);
     if is_busy_response(&interrupt_text) {
         eprintln!("continuation prompt interrupt stayed busy in this Python runtime; skipping");
@@ -2892,7 +2902,9 @@ async fn python_interrupt_unblocks_empty_input_prompt() -> TestResult<()> {
         "did not expect a fabricated prompt for empty input, got: {prompt_text:?}"
     );
 
-    let interrupt = session.write_stdin_raw_with("\u{3}", Some(5.0)).await?;
+    let interrupt = session
+        .write_stdin_raw_unterminated_with("\u{3}", Some(5.0))
+        .await?;
     let interrupt_text = result_text(&interrupt);
     if is_busy_response(&interrupt_text) {
         eprintln!("empty input prompt interrupt stayed busy in this Python runtime; skipping");
@@ -3370,7 +3382,9 @@ async fn python_interrupt_unblocks_long_running_request() -> TestResult<()> {
         "expected sleep call to time out, got: {timeout_text:?}"
     );
 
-    let interrupt_result = session.write_stdin_raw_with("\u{3}", Some(5.0)).await?;
+    let interrupt_result = session
+        .write_stdin_raw_unterminated_with("\u{3}", Some(5.0))
+        .await?;
     let interrupt_text = result_text(&interrupt_result);
     assert!(
         !is_busy_response(&interrupt_text) && interrupt_text.contains(">>>"),
@@ -3449,7 +3463,11 @@ except KeyboardInterrupt:
     }
 
     let interrupt_deadline = interrupt_recovery_deadline();
-    text = result_text(&session.write_stdin_raw_with("\u{3}", Some(5.0)).await?);
+    text = result_text(
+        &session
+            .write_stdin_raw_unterminated_with("\u{3}", Some(5.0))
+            .await?,
+    );
     while is_busy_response(&text) {
         if Instant::now() >= interrupt_deadline {
             session.cancel().await?;
@@ -3687,7 +3705,9 @@ async fn python_restart_does_not_leak_old_generation_output() -> TestResult<()> 
         return Ok(());
     }
 
-    let restart = session.write_stdin_raw_with("\u{4}", Some(10.0)).await?;
+    let restart = session
+        .write_stdin_raw_unterminated_with("\u{4}", Some(10.0))
+        .await?;
     let restart_text = result_text(&restart);
     if is_busy_response(&restart_text) {
         eprintln!(
@@ -3848,7 +3868,9 @@ async fn python_interrupt_discards_buffered_tail_after_timeout() -> TestResult<(
         "expected sleep call to time out, got: {timeout_text:?}"
     );
 
-    let interrupt_result = session.write_stdin_raw_with("\u{3}", Some(5.0)).await?;
+    let interrupt_result = session
+        .write_stdin_raw_unterminated_with("\u{3}", Some(5.0))
+        .await?;
     let interrupt_text = result_text(&interrupt_result);
     assert!(
         !is_busy_response(&interrupt_text) && interrupt_text.contains(">>>"),

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -1972,6 +1972,38 @@ async fn python_multiline_block() -> TestResult<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn python_crlf_multiline_block_executes() -> TestResult<()> {
+    let _guard = lock_test_mutex();
+    let Some(session) = start_python_session().await? else {
+        return Ok(());
+    };
+
+    let result = session
+        .write_stdin_raw_unterminated_with(
+            "if True:\r\n    print('CRLF_BLOCK_OK')\r\n\r\n",
+            Some(5.0),
+        )
+        .await?;
+    let text = result_text(&result);
+    session.cancel().await?;
+
+    assert!(
+        !is_busy_response(&text),
+        "expected CRLF multiline block to finish, got: {text:?}"
+    );
+    assert!(
+        text.contains("CRLF_BLOCK_OK"),
+        "expected CRLF multiline block output, got: {text:?}"
+    );
+    assert!(
+        !text.contains("IndentationError"),
+        "CRLF multiline block injected a blank line before the body: {text:?}"
+    );
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn python_multiline_block_does_not_echo_input_in_visible_reply() -> TestResult<()> {
     let _guard = lock_test_mutex();

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -1972,38 +1972,6 @@ async fn python_multiline_block() -> TestResult<()> {
     Ok(())
 }
 
-#[cfg(unix)]
-#[tokio::test(flavor = "multi_thread")]
-async fn python_crlf_multiline_block_executes() -> TestResult<()> {
-    let _guard = lock_test_mutex();
-    let Some(session) = start_python_session().await? else {
-        return Ok(());
-    };
-
-    let result = session
-        .write_stdin_raw_unterminated_with(
-            "if True:\r\n    print('CRLF_BLOCK_OK')\r\n\r\n",
-            Some(5.0),
-        )
-        .await?;
-    let text = result_text(&result);
-    session.cancel().await?;
-
-    assert!(
-        !is_busy_response(&text),
-        "expected CRLF multiline block to finish, got: {text:?}"
-    );
-    assert!(
-        text.contains("CRLF_BLOCK_OK"),
-        "expected CRLF multiline block output, got: {text:?}"
-    );
-    assert!(
-        !text.contains("IndentationError"),
-        "CRLF multiline block injected a blank line before the body: {text:?}"
-    );
-    Ok(())
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn python_multiline_block_does_not_echo_input_in_visible_reply() -> TestResult<()> {
     let _guard = lock_test_mutex();

--- a/tests/refactor_coverage.rs
+++ b/tests/refactor_coverage.rs
@@ -21,10 +21,10 @@ plot(1:5, type = "l")
 plot(5:1, type = "l")
 cat("plots_done\n")
 "#, timeout = 10.0);
-                write_stdin("\u{4}");
+                write_stdin_raw_unterminated("\u{4}");
                 write_stdin("1+1", timeout = 10.0);
                 write_stdin("Sys.sleep(5)", timeout = 0.2);
-                write_stdin("\u{3}", timeout = 5.0);
+                write_stdin_raw_unterminated("\u{3}", timeout = 5.0);
                 write_stdin("1+1", timeout = 10.0);
             },
         )
@@ -193,7 +193,9 @@ async fn restart_interrupt_plot_smoke() -> TestResult<()> {
         return Err(format!("expected plot command output marker, got: {text:?}").into());
     }
 
-    let _ = session.write_stdin_raw_with("\u{4}", Some(10.0)).await?;
+    let _ = session
+        .write_stdin_raw_unterminated_with("\u{4}", Some(10.0))
+        .await?;
     if !common::assert_eventually_contains(
         &mut session,
         "1+1",
@@ -213,7 +215,9 @@ async fn restart_interrupt_plot_smoke() -> TestResult<()> {
     let _ = session
         .write_stdin_raw_with("Sys.sleep(5)", Some(0.2))
         .await?;
-    let _ = session.write_stdin_raw_with("\u{3}", Some(10.0)).await?;
+    let _ = session
+        .write_stdin_raw_unterminated_with("\u{3}", Some(10.0))
+        .await?;
     if !common::assert_eventually_contains(
         &mut session,
         "1+1",

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -988,7 +988,9 @@ async fn sandbox_tempdir_stable_across_restart() -> TestResult<()> {
     let marker_path = PathBuf::from(&first.tmpdir).join(SESSION_MARKER_FILE);
     let marker_path = marker_path.to_string_lossy().to_string();
 
-    session.write_stdin("\u{4}").await;
+    let _ = session
+        .write_stdin_raw_unterminated_with("\u{4}", Some(10.0))
+        .await?;
     let Some(after_restart) = fetch_tempdir_status(&mut session, &marker_path).await? else {
         eprintln!(
             "sandbox_tempdir_stable_across_restart backend unavailable in this environment; skipping"
@@ -1811,7 +1813,9 @@ cat("READ_BEFORE_MOVE=", paste(readLines(source, warn = FALSE), collapse = "|"),
 
     std::fs::rename(&source, &target)?;
 
-    let restart = session.write_stdin_raw_with("\u{4}", Some(10.0)).await?;
+    let restart = session
+        .write_stdin_raw_unterminated_with("\u{4}", Some(10.0))
+        .await?;
     let restart_text = collect_text(&restart);
     if windows_sandbox_backend_unavailable(&restart_text) {
         eprintln!("windows restricted token setup unavailable; skipping");
@@ -1912,7 +1916,9 @@ cat("READ_BEFORE_MOVE=", paste(readLines(source, warn = FALSE), collapse = "|"),
 
     std::fs::rename(&source, &target)?;
 
-    let restart = session.write_stdin_raw_with("\u{4}", Some(10.0)).await?;
+    let restart = session
+        .write_stdin_raw_unterminated_with("\u{4}", Some(10.0))
+        .await?;
     let restart_text = collect_text(&restart);
     if windows_sandbox_backend_unavailable(&restart_text) {
         eprintln!("windows restricted token setup unavailable; skipping");
@@ -2372,7 +2378,9 @@ cat("WRITE_OK=", file.exists(source), "\n", sep = "")
 
     std::fs::rename(&restored, &protected)?;
 
-    let first_restart = session.write_stdin_raw_with("\u{4}", Some(10.0)).await?;
+    let first_restart = session
+        .write_stdin_raw_unterminated_with("\u{4}", Some(10.0))
+        .await?;
     let first_restart_text = collect_text(&first_restart);
     if windows_sandbox_backend_unavailable(&first_restart_text) {
         eprintln!("windows restricted token setup unavailable; skipping");
@@ -2408,7 +2416,9 @@ tryCatch({{
 
     std::fs::rename(&protected, &restored)?;
 
-    let second_restart = session.write_stdin_raw_with("\u{4}", Some(10.0)).await?;
+    let second_restart = session
+        .write_stdin_raw_unterminated_with("\u{4}", Some(10.0))
+        .await?;
     let second_restart_text = collect_text(&second_restart);
     assert!(
         second_restart_text.contains("new session started"),

--- a/tests/sandbox_state_updates.rs
+++ b/tests/sandbox_state_updates.rs
@@ -807,7 +807,7 @@ async fn sandbox_inherit_interrupt_follow_up_ignores_local_meta_errors() -> Test
     }
 
     let interrupt = session
-        .write_stdin_raw_with_meta(
+        .write_stdin_raw_unterminated_with_meta(
             "\u{3}",
             Some(2.0),
             Some(json!({ SANDBOX_STATE_META_CAPABILITY: "invalid" })),
@@ -856,7 +856,9 @@ async fn sandbox_inherit_pending_bare_interrupt_ignores_missing_state_meta() -> 
         "expected interrupt setup request to time out, got: {timeout_text}"
     );
 
-    let interrupt = session.write_stdin_raw_with("\u{3}", Some(10.0)).await?;
+    let interrupt = session
+        .write_stdin_raw_unterminated_with("\u{3}", Some(10.0))
+        .await?;
     let interrupt_text = collect_text(&interrupt);
     session.cancel().await?;
 
@@ -1820,7 +1822,11 @@ async fn sandbox_inherit_bare_interrupt_after_session_end_uses_current_state_met
     tokio::time::sleep(std::time::Duration::from_millis(260)).await;
 
     let interrupt = session
-        .write_stdin_raw_with_meta("\u{3}", Some(2.0), Some(read_only_meta(scratch.path())))
+        .write_stdin_raw_unterminated_with_meta(
+            "\u{3}",
+            Some(2.0),
+            Some(read_only_meta(scratch.path())),
+        )
         .await?;
     let interrupt_text = common::result_text(&interrupt);
     assert!(
@@ -1877,7 +1883,9 @@ async fn sandbox_inherit_bare_interrupt_after_session_end_without_state_meta_doe
     let _ = fs::remove_file(&startup_target);
     tokio::time::sleep(std::time::Duration::from_millis(260)).await;
 
-    let interrupt = session.write_stdin_raw_with("\u{3}", Some(2.0)).await?;
+    let interrupt = session
+        .write_stdin_raw_unterminated_with("\u{3}", Some(2.0))
+        .await?;
     let interrupt_text = common::result_text(&interrupt);
     assert!(
         !interrupt_text.contains(MISSING_INHERITED_STATE_MESSAGE),
@@ -2298,7 +2306,11 @@ async fn sandbox_inherit_bare_restart_stays_restart_after_sandbox_respawn() -> T
     tokio::time::sleep(test_delay_ms(260, 700)).await;
 
     let restart = session
-        .write_stdin_raw_with_meta("\u{4}", Some(1.0), Some(read_only_meta(scratch.path())))
+        .write_stdin_raw_unterminated_with_meta(
+            "\u{4}",
+            Some(1.0),
+            Some(read_only_meta(scratch.path())),
+        )
         .await?;
     let restart_text = common::result_text(&restart);
     assert!(
@@ -2364,7 +2376,11 @@ async fn sandbox_inherit_active_pager_bare_restart_stays_restart_after_sandbox_r
     );
 
     let restart = session
-        .write_stdin_raw_with_meta("\u{4}", Some(10.0), Some(read_only_meta(scratch.path())))
+        .write_stdin_raw_unterminated_with_meta(
+            "\u{4}",
+            Some(10.0),
+            Some(read_only_meta(scratch.path())),
+        )
         .await?;
     let restart_text = common::result_text(&restart);
     session.cancel().await?;
@@ -2915,7 +2931,11 @@ async fn sandbox_inherit_ctrl_d_does_not_spawn_worker_just_to_stage_state() -> T
     )
     .await?;
     let result = session
-        .write_stdin_raw_with_meta("\u{4}", Some(2.0), Some(workspace_write_meta(temp.path())))
+        .write_stdin_raw_unterminated_with_meta(
+            "\u{4}",
+            Some(2.0),
+            Some(workspace_write_meta(temp.path())),
+        )
         .await?;
     let text = collect_text(&result);
     assert!(
@@ -3083,7 +3103,11 @@ async fn sandbox_inherit_pending_bare_ctrl_c_stages_current_meta_before_session_
     );
 
     let interrupt = session
-        .write_stdin_raw_with_meta("\u{3}", Some(10.0), Some(read_only_meta(temp.path())))
+        .write_stdin_raw_unterminated_with_meta(
+            "\u{3}",
+            Some(10.0),
+            Some(read_only_meta(temp.path())),
+        )
         .await?;
     let interrupt_text = collect_text(&interrupt);
     session.cancel().await?;
@@ -3137,7 +3161,11 @@ async fn sandbox_inherit_pending_bare_ctrl_c_keeps_old_meta_when_worker_survives
     );
 
     let interrupt = session
-        .write_stdin_raw_with_meta("\u{3}", Some(10.0), Some(read_only_meta(temp.path())))
+        .write_stdin_raw_unterminated_with_meta(
+            "\u{3}",
+            Some(10.0),
+            Some(read_only_meta(temp.path())),
+        )
         .await?;
     let interrupt_text = collect_text(&interrupt);
     if interrupt_text.contains("<<repl status: busy") {
@@ -3302,7 +3330,9 @@ async fn sandbox_inherit_idle_ctrl_d_without_state_meta_does_not_restart() -> Te
         return Ok(());
     }
 
-    let restart_error = session.write_stdin_raw_with("\u{4}", Some(2.0)).await?;
+    let restart_error = session
+        .write_stdin_raw_unterminated_with("\u{4}", Some(2.0))
+        .await?;
     assert_eq!(
         restart_error.is_error,
         Some(true),
@@ -3351,7 +3381,7 @@ async fn sandbox_inherit_idle_ctrl_d_with_bad_meta_does_not_restart() -> TestRes
     }
 
     let restart_error = session
-        .write_stdin_raw_with_meta(
+        .write_stdin_raw_unterminated_with_meta(
             "\u{4}",
             Some(2.0),
             Some(json!({ SANDBOX_STATE_META_CAPABILITY: "invalid" })),

--- a/tests/session_endings.rs
+++ b/tests/session_endings.rs
@@ -29,7 +29,7 @@ async fn snapshots_session_endings() -> TestResult<()> {
             "restart_timeout_zero",
             mcp_script! {
                 write_stdin("x <- 1", timeout = 10.0);
-                write_stdin("\u{4}", timeout = 0.0);
+                write_stdin_raw_unterminated("\u{4}", timeout = 0.0);
                 write_stdin("print(exists(\"x\"))", timeout = 10.0);
             },
         )
@@ -40,7 +40,7 @@ async fn snapshots_session_endings() -> TestResult<()> {
             "restart_timeout_thirty",
             mcp_script! {
                 write_stdin("x <- 1", timeout = 10.0);
-                write_stdin("\u{4}", timeout = 30.0);
+                write_stdin_raw_unterminated("\u{4}", timeout = 30.0);
                 write_stdin("print(exists(\"x\"))", timeout = 10.0);
             },
         )
@@ -50,7 +50,7 @@ async fn snapshots_session_endings() -> TestResult<()> {
         .session(
             "eof_input",
             mcp_script! {
-                write_stdin("\u{4}", timeout = 10.0);
+                write_stdin_raw_unterminated("\u{4}", timeout = 10.0);
                 write_stdin("1+1", timeout = 10.0);
             },
         )
@@ -106,7 +106,9 @@ async fn session_endings_smoke() -> TestResult<()> {
     let mut session = common::spawn_server().await?;
 
     let _ = session.write_stdin_raw_with("x <- 1", Some(10.0)).await?;
-    let restart = session.write_stdin_raw_with("\u{4}", Some(10.0)).await?;
+    let restart = session
+        .write_stdin_raw_unterminated_with("\u{4}", Some(10.0))
+        .await?;
     let restart_text = common::result_text(&restart);
     if common::backend_unavailable(&restart_text) {
         eprintln!("session_endings backend unavailable in this environment; skipping");

--- a/tests/snapshots/mcp_transcripts__snapshots_support_multiple_calls_and_sessions.snap
+++ b/tests/snapshots/mcp_transcripts__snapshots_support_multiple_calls_and_sessions.snap
@@ -52,7 +52,7 @@ call:
 {
   "tool": "r_repl",
   "arguments": {
-    "input": "\u0004\n"
+    "input": "\u0004"
   }
 }
 response:

--- a/tests/snapshots/mcp_transcripts__snapshots_tempdir_session_restart.snap
+++ b/tests/snapshots/mcp_transcripts__snapshots_tempdir_session_restart.snap
@@ -32,7 +32,7 @@ call:
 {
   "tool": "r_repl",
   "arguments": {
-    "input": "\u0004\n"
+    "input": "\u0004"
   }
 }
 response:
@@ -75,7 +75,7 @@ call:
 {
   "tool": "r_repl",
   "arguments": {
-    "input": "\u0004\n"
+    "input": "\u0004"
   }
 }
 response:

--- a/tests/snapshots/refactor_coverage__snapshots_restart_and_interrupt_with_plots.snap
+++ b/tests/snapshots/refactor_coverage__snapshots_restart_and_interrupt_with_plots.snap
@@ -62,7 +62,7 @@ call:
 {
   "tool": "r_repl",
   "arguments": {
-    "input": "\u0004\n"
+    "input": "\u0004"
   }
 }
 response:
@@ -125,7 +125,7 @@ call:
 {
   "tool": "r_repl",
   "arguments": {
-    "input": "\u0003\n",
+    "input": "\u0003",
     "timeout_ms": 5000
   }
 }

--- a/tests/snapshots/session_endings__snapshots_session_endings.snap
+++ b/tests/snapshots/session_endings__snapshots_session_endings.snap
@@ -28,7 +28,7 @@ call:
 {
   "tool": "r_repl",
   "arguments": {
-    "input": "\u0004\n",
+    "input": "\u0004",
     "timeout_ms": 0
   }
 }
@@ -94,7 +94,7 @@ call:
 {
   "tool": "r_repl",
   "arguments": {
-    "input": "\u0004\n",
+    "input": "\u0004",
     "timeout_ms": 30000
   }
 }
@@ -140,7 +140,7 @@ call:
 {
   "tool": "r_repl",
   "arguments": {
-    "input": "\u0004\n",
+    "input": "\u0004",
     "timeout_ms": 10000
   }
 }

--- a/tests/write_stdin_behavior.rs
+++ b/tests/write_stdin_behavior.rs
@@ -1517,18 +1517,29 @@ async fn disclosed_timeout_bundle_keeps_appending_after_idle_busy_follow_up() ->
 async fn files_empty_poll_after_resolved_timeout_restores_prompt() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = spawn_behavior_session().await?;
+    let temp = workspace_tempdir()?;
+    let start_path = temp.path().join("started");
+    let release_path = temp.path().join("release");
+    let start_literal = r_path_literal(&start_path)?;
+    let release_literal = r_path_literal(&release_path)?;
+    let input = format!(
+        "writeLines('started', {start_literal}); while (!file.exists({release_literal})) Sys.sleep(0.01); 1+1"
+    );
 
-    let first = session
-        .write_stdin_raw_with("Sys.sleep(0.1); 1+1", Some(0.05))
-        .await?;
+    let first = session.write_stdin_raw_with(&input, Some(0.05)).await?;
     let first_text = result_text(&first);
     if backend_unavailable(&first_text) {
         eprintln!("write_stdin_behavior backend unavailable in this environment; skipping");
         session.cancel().await?;
         return Ok(());
     }
+    assert!(
+        first_text.contains("<<repl status: busy"),
+        "expected gated request to time out before release, got: {first_text:?}"
+    );
 
-    sleep(test_delay_ms(160, 700)).await;
+    wait_until_path_exists(&start_path, "gated request start").await?;
+    fs::write(&release_path, "go")?;
     let follow_up = session
         .write_stdin_raw_unterminated_with("", Some(2.0))
         .await?;

--- a/tests/write_stdin_edge_cases.rs
+++ b/tests/write_stdin_edge_cases.rs
@@ -6,7 +6,6 @@ use common::TestResult;
 use rmcp::model::RawContent;
 use rmcp::service::ServiceError;
 use std::sync::{Mutex, MutexGuard, OnceLock};
-#[cfg(windows)]
 use std::time::{Duration, Instant};
 
 fn test_mutex() -> &'static Mutex<()> {
@@ -109,8 +108,7 @@ async fn write_stdin_timeout_zero_is_non_blocking() -> TestResult<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg(windows)]
-async fn write_stdin_accepts_crlf_input_on_windows() -> TestResult<()> {
+async fn write_stdin_accepts_crlf_input() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = common::spawn_server().await?;
 

--- a/tests/write_stdin_edge_cases.rs
+++ b/tests/write_stdin_edge_cases.rs
@@ -6,6 +6,7 @@ use common::TestResult;
 use rmcp::model::RawContent;
 use rmcp::service::ServiceError;
 use std::sync::{Mutex, MutexGuard, OnceLock};
+#[cfg(windows)]
 use std::time::{Duration, Instant};
 
 fn test_mutex() -> &'static Mutex<()> {
@@ -108,7 +109,8 @@ async fn write_stdin_timeout_zero_is_non_blocking() -> TestResult<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn write_stdin_accepts_crlf_input() -> TestResult<()> {
+#[cfg(windows)]
+async fn write_stdin_accepts_crlf_input_on_windows() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = common::spawn_server().await?;
 

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -743,6 +743,29 @@ async fn zod_worker_output_after_session_end_is_protocol_error() -> TestResult<(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_invalid_session_end_reason_is_protocol_error() -> TestResult<()> {
+    let session = spawn_zod_server().await?;
+
+    let result = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "bad-session-end-reason",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let text = result_text(&result);
+    assert!(
+        text.contains("invalid session_end reason"),
+        "expected invalid session_end reason protocol error, got: {text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn zod_worker_preserves_mixed_output_order() -> TestResult<()> {
     let session = spawn_zod_server().await?;
 

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -964,6 +964,44 @@ async fn zod_worker_interrupt_tail_runs_after_recovery() -> TestResult<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_control_prefix_preserves_immediate_newline_tail() -> TestResult<()> {
+    let session = spawn_zod_server().await?;
+
+    let first = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "interruptible 1000",
+                "timeout_ms": 10
+            }),
+        )
+        .await?;
+    let first_text = result_text(&first);
+    assert!(
+        first_text.contains("<<repl status: busy"),
+        "expected timeout busy status, got: {first_text:?}"
+    );
+
+    let interrupted = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "\u{3}\nreport-leading-empty",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let text = result_text(&interrupted);
+    assert!(
+        text.contains("previous empty line: observed\n"),
+        "expected Zod to receive the immediate newline before the tail, got: {text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
 #[cfg(target_family = "unix")]
 #[tokio::test(flavor = "multi_thread")]
 async fn zod_worker_reports_sideband_and_os_interrupt_facts() -> TestResult<()> {

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -830,3 +830,45 @@ async fn zod_worker_interrupt_tail_runs_after_recovery() -> TestResult<()> {
     session.cancel().await?;
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_interrupt_discards_buffered_tail_before_follow_up() -> TestResult<()> {
+    let session = spawn_zod_server().await?;
+
+    let first = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "discard-on-interrupt 1000\nSHOULD_NOT_RUN",
+                "timeout_ms": 10
+            }),
+        )
+        .await?;
+    let first_text = result_text(&first);
+    assert!(
+        first_text.contains("<<repl status: busy"),
+        "expected timeout busy status, got: {first_text:?}"
+    );
+
+    let interrupted = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "\u{3}after discard",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let text = result_text(&interrupted);
+    assert!(
+        text.contains("after discard\n"),
+        "expected follow-up tail to run after recovery, got: {text:?}"
+    );
+    assert!(
+        !text.contains("SHOULD_NOT_RUN"),
+        "expected buffered pre-interrupt tail to be discarded, got: {text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -343,6 +343,42 @@ async fn zod_worker_reset_requests_shutdown_by_closing_stdin_only() -> TestResul
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_preserves_crlf_stdin_and_appended_newline() -> TestResult<()> {
+    let session = spawn_zod_server().await?;
+
+    let result = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "report-raw-line supplied crlf\r\nreport-raw-line trailing carriage\r",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let text = result_text(&result);
+
+    assert!(
+        text.contains("raw-line-debug: report-raw-line supplied crlf\\r\\n\n"),
+        "expected supplied CRLF bytes to reach Zod unchanged, got: {text:?}"
+    );
+    assert!(
+        text.contains("raw-line-debug: report-raw-line trailing carriage\\r\\n\n"),
+        "expected server to append one newline after trailing carriage return, got: {text:?}"
+    );
+    assert!(
+        !text.contains("raw-line-debug: report-raw-line trailing carriage\\r\\n\\n\n"),
+        "server must not append more than one newline, got: {text:?}"
+    );
+    assert!(
+        text.contains("zod> "),
+        "expected worker prompt after CRLF input, got: {text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn zod_worker_preserves_prompt_shaped_stdout() -> TestResult<()> {
     let session = spawn_zod_server().await?;
 

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -766,6 +766,116 @@ async fn zod_worker_invalid_session_end_reason_is_protocol_error() -> TestResult
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_repl_reset_can_exercise_slow_graceful_shutdown() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let shutdown_log = tempdir.path().join("shutdown.log");
+    let shutdown_log_env = shutdown_log.display().to_string();
+    let session = spawn_zod_server_with_env(vec![(
+        "MCP_REPL_ZOD_SHUTDOWN_LOG",
+        shutdown_log_env.as_str(),
+    )])
+    .await?;
+
+    let configured = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "slow-shutdown 25",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let configured_text = result_text(&configured);
+    assert!(
+        configured_text.contains("zod> "),
+        "expected Zod to accept slow shutdown hook, got: {configured_text:?}"
+    );
+
+    let reset = session.call_tool_raw("repl_reset", json!({})).await?;
+    let reset_text = result_text(&reset);
+    assert!(
+        reset_text.contains("new session started"),
+        "expected repl_reset to respawn after slow shutdown, got: {reset_text:?}"
+    );
+
+    let shutdown_log_text = fs::read_to_string(&shutdown_log).unwrap_or_default();
+    assert!(
+        shutdown_log_text.contains("stdin_eof\n"),
+        "expected repl_reset to close worker stdin, got: {shutdown_log_text:?}"
+    );
+    assert!(
+        !shutdown_log_text.contains("user-stdin:exit\n"),
+        "reset must not send shutdown text to stdin, got: {shutdown_log_text:?}"
+    );
+    assert!(
+        shutdown_log_text.contains("shutdown:delay-ms:25\n"),
+        "expected Zod to record the slow shutdown hook, got: {shutdown_log_text:?}"
+    );
+    assert!(
+        shutdown_log_text.contains("shutdown:delay-complete\n"),
+        "expected Zod to complete the slow shutdown hook, got: {shutdown_log_text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_can_hold_shutdown_open_for_escalation_tests() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let shutdown_log = tempdir.path().join("shutdown.log");
+    let shutdown_log_env = shutdown_log.display().to_string();
+    let session = spawn_zod_server_with_env(vec![(
+        "MCP_REPL_ZOD_SHUTDOWN_LOG",
+        shutdown_log_env.as_str(),
+    )])
+    .await?;
+
+    let configured = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "hang-shutdown",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let configured_text = result_text(&configured);
+    assert!(
+        configured_text.contains("zod> "),
+        "expected Zod to accept hanging shutdown hook, got: {configured_text:?}"
+    );
+
+    let exiting = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "exit",
+                "timeout_ms": 100
+            }),
+        )
+        .await?;
+    let exiting_text = result_text(&exiting);
+    assert!(
+        exiting_text.contains("<<repl status: busy"),
+        "expected hanging shutdown hook to leave exit pending, got: {exiting_text:?}"
+    );
+
+    let shutdown_log_text = fs::read_to_string(&shutdown_log).unwrap_or_default();
+    assert!(
+        shutdown_log_text.contains("user-stdin:exit\n"),
+        "expected Zod to receive exit before hanging, got: {shutdown_log_text:?}"
+    );
+    assert!(
+        shutdown_log_text.contains("shutdown:hang\n"),
+        "expected Zod to record the hanging shutdown hook, got: {shutdown_log_text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn zod_worker_preserves_mixed_output_order() -> TestResult<()> {
     let session = spawn_zod_server().await?;
 

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -802,6 +802,53 @@ async fn zod_worker_invalid_session_end_reason_is_protocol_error() -> TestResult
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_repl_reset_closes_active_stdin_without_shutdown_text() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let shutdown_log = tempdir.path().join("shutdown.log");
+    let shutdown_log_env = shutdown_log.display().to_string();
+    let session = spawn_zod_server_with_env(vec![(
+        "MCP_REPL_ZOD_SHUTDOWN_LOG",
+        shutdown_log_env.as_str(),
+    )])
+    .await?;
+
+    let active = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "read-user-stdin",
+                "timeout_ms": 10
+            }),
+        )
+        .await?;
+    let active_text = result_text(&active);
+    assert!(
+        active_text.contains("<<repl status: busy"),
+        "expected active stdin read to time out before reset, got: {active_text:?}"
+    );
+
+    let reset = session.call_tool_raw("repl_reset", json!({})).await?;
+    let reset_text = result_text(&reset);
+    assert!(
+        reset_text.contains("new session started"),
+        "expected repl_reset to respawn the Zod worker, got: {reset_text:?}"
+    );
+
+    let shutdown_log_text = fs::read_to_string(&shutdown_log).unwrap_or_default();
+    assert!(
+        !shutdown_log_text.contains("user-stdin:exit\n"),
+        "repl_reset must not send shutdown text to an active request, got: {shutdown_log_text:?}"
+    );
+    assert!(
+        shutdown_log_text.contains("user-stdin:<eof>\n"),
+        "expected reset to close active stdin instead, got: {shutdown_log_text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn zod_worker_repl_reset_can_exercise_slow_graceful_shutdown() -> TestResult<()> {
     let tempdir = tempfile::tempdir()?;
     let shutdown_log = tempdir.path().join("shutdown.log");

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -343,7 +343,7 @@ async fn zod_worker_reset_requests_shutdown_by_closing_stdin_only() -> TestResul
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn zod_worker_preserves_crlf_stdin_and_appended_newline() -> TestResult<()> {
+async fn zod_worker_preserves_client_stdin_bytes_and_appended_newline() -> TestResult<()> {
     let session = spawn_zod_server().await?;
 
     let result = session
@@ -359,11 +359,11 @@ async fn zod_worker_preserves_crlf_stdin_and_appended_newline() -> TestResult<()
 
     assert!(
         text.contains("raw-line-debug: report-raw-line supplied crlf\\r\\n\n"),
-        "expected supplied CRLF bytes to reach Zod unchanged, got: {text:?}"
+        "expected client-supplied newline bytes to reach Zod unchanged, got: {text:?}"
     );
     assert!(
         text.contains("raw-line-debug: report-raw-line trailing carriage\\r\\n\n"),
-        "expected server to append one newline after trailing carriage return, got: {text:?}"
+        "expected server to append one final newline after trailing carriage return, got: {text:?}"
     );
     assert!(
         !text.contains("raw-line-debug: report-raw-line trailing carriage\\r\\n\\n\n"),

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -964,6 +964,53 @@ async fn zod_worker_interrupt_tail_runs_after_recovery() -> TestResult<()> {
     Ok(())
 }
 
+#[cfg(target_family = "unix")]
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_reports_sideband_and_os_interrupt_facts() -> TestResult<()> {
+    let session = spawn_zod_server().await?;
+
+    let first = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "interrupt-report 1000",
+                "timeout_ms": 10
+            }),
+        )
+        .await?;
+    let first_text = result_text(&first);
+    assert!(
+        first_text.contains("<<repl status: busy"),
+        "expected timeout busy status, got: {first_text:?}"
+    );
+
+    let interrupted = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "\u{3}tail after interrupt facts",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let text = result_text(&interrupted);
+    assert!(
+        text.contains("sideband interrupt: observed\n"),
+        "expected Zod to report the sideband interrupt notification, got: {text:?}"
+    );
+    assert!(
+        text.contains("os interrupt: observed\n"),
+        "expected Zod to report the OS interrupt, got: {text:?}"
+    );
+    assert!(
+        text.contains("tail after interrupt facts\n"),
+        "expected interrupt tail to run after recovery, got: {text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn zod_worker_interrupt_discards_buffered_tail_before_follow_up() -> TestResult<()> {
     let session = spawn_zod_server().await?;


### PR DESCRIPTION
## Summary

This PR tightens the worker stdin contract so the server no longer canonicalizes client-supplied line endings before handing input to the worker. Non-empty input still gets one trailing `\n` when it is not already newline-terminated, but supplied `\r\n` and bare `\r` bytes are preserved.

It also updates control-prefixed input handling so `Ctrl-C`/`Ctrl-D` consume only the control byte. Any immediate newline remains part of the follow-up input, so `Ctrl-D` is a bare restart, while `Ctrl-D\n` is a restart followed by a blank input and `Ctrl-D\nfoo` is a restart followed by the leading blank line plus `foo`.

Protocol-worker shutdown handling is hardened by validating `session_end.reason` and optional `message_b64`, and reset handling now snapshots output before graceful shutdown so teardown-only output does not leak into the `new session started` reply.

## Public Facing Changes

- `repl` stdin preserves supplied CRLF and bare-CR bytes at the server boundary, with only the final-newline append rule.
- `Ctrl-C`/`Ctrl-D` followed by newline is treated as a control action with follow-up input, not as a bare control.
- Invalid protocol-worker `session_end` metadata now fails as a protocol error instead of being accepted as a clean shutdown.

## Internal Changes

- Expanded the Zod fixture with deterministic hooks for raw stdin reporting, interrupt facts, buffered-stdin discard, active stdin reads, delayed/hanging shutdown, and malformed `session_end` frames.
- Added Zod protocol coverage for stdin preservation, control-tail newlines, interrupt delivery, reset EOF behavior, shutdown hooks, and protocol validation.
- Updated tests and snapshots to use unterminated raw control bytes where they mean bare `Ctrl-C`/`Ctrl-D`.
- Updated protocol docs and test README examples to match the raw stdin contract.

## Diff Composition

Measured against `main`, this PR is `783` insertions and `100` deletions across `22` files.

- runtime `src/`: `+93/-26` (`13.5%` of churn)
- inline tests inside `src/`: `+2/-2` (`0.5%` of churn)
- tests in `tests/`: `+669/-61` (`82.7%` of churn)
- docs: `+11/-3` (`1.6%` of churn)
- snapshots: `+8/-8` (`1.8%` of churn)

Largest files:

- `tests/zod_protocol.rs`: `+343/-0`
- `tests/fixtures/zod-worker.rs`: `+186/-16`
- `src/worker_process.rs`: `+54/-19`
- `tests/sandbox_state_updates.rs`: `+41/-11`
- `tests/python_backend.rs`: `+32/-10`
