### PR TITLE
Move test scratch artifacts out of the repo root

### DIFF
--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -7242,6 +7242,15 @@ mod tests {
             .unwrap_or_else(|err| err.into_inner())
     }
 
+    #[cfg(target_family = "unix")]
+    fn worker_process_test_temp_parent(label: &str) -> PathBuf {
+        let root = std::env::temp_dir()
+            .join("mcp-repl-test-scratch")
+            .join(label);
+        std::fs::create_dir_all(&root).expect("create worker process test temp parent");
+        root
+    }
+
     #[test]
     fn python_backend_prepares_windows_sandbox_launch() {
         assert!(
@@ -9859,7 +9868,7 @@ mod tests {
         let _guard = cwd_test_mutex().lock().expect("cwd mutex");
         let temp = tempfile::Builder::new()
             .prefix(".tmp-interrupt-tail-current-sandbox-")
-            .tempdir_in(env!("CARGO_MANIFEST_DIR"))
+            .tempdir_in(worker_process_test_temp_parent("worker-process"))
             .expect("tempdir");
         let sandbox_cwd = temp.path().to_path_buf();
         let plan = SandboxCliPlan {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -36,6 +36,15 @@ const WINDOWS_TEST_TIMEOUT_CAP_SECS: f64 = 60.0;
 #[cfg(windows)]
 const WINDOWS_TEST_SERVER_MUTEX_NAME: &str = "Local\\mcp_repl_test_server_mutex";
 
+pub(crate) fn checkout_test_temp_parent(label: &str) -> TestResult<PathBuf> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("test-scratch")
+        .join(label);
+    std::fs::create_dir_all(&root)?;
+    Ok(root)
+}
+
 #[cfg(windows)]
 struct WindowsSuiteServerMutexOwner {
     release_tx: std::sync::mpsc::Sender<()>,

--- a/tests/sandbox_state_updates.rs
+++ b/tests/sandbox_state_updates.rs
@@ -200,7 +200,28 @@ fn home_scratch_dir(label: &str) -> TestResult<TempDir> {
 fn repo_scratch_dir(label: &str) -> TestResult<TempDir> {
     Ok(Builder::new()
         .prefix(&format!(".tmp-{label}-"))
-        .tempdir_in(env!("CARGO_MANIFEST_DIR"))?)
+        .tempdir_in(common::checkout_test_temp_parent("sandbox-state-updates")?)?)
+}
+
+#[test]
+fn repo_scratch_dir_uses_non_temp_checkout_scratch_parent() -> TestResult<()> {
+    let scratch = repo_scratch_dir("parent")?;
+    assert_ne!(
+        scratch.path().parent(),
+        Some(Path::new(env!("CARGO_MANIFEST_DIR"))),
+        "test scratch dirs must not be created directly in the repo root"
+    );
+    assert!(
+        scratch
+            .path()
+            .starts_with(common::checkout_test_temp_parent("sandbox-state-updates")?),
+        "sandbox cwd scratch dirs should stay under target/test-scratch"
+    );
+    assert!(
+        !scratch.path().starts_with(std::env::temp_dir()),
+        "sandbox cwd scratch dirs must stay outside OS temp so read-only sandbox tests can observe blocked cwd writes"
+    );
+    Ok(())
 }
 
 fn write_file_code(path: &Path) -> TestResult<String> {

--- a/tests/write_stdin_behavior.rs
+++ b/tests/write_stdin_behavior.rs
@@ -96,7 +96,27 @@ fn r_path_literal(path: &Path) -> TestResult<String> {
 fn workspace_tempdir() -> TestResult<tempfile::TempDir> {
     Ok(tempfile::Builder::new()
         .prefix("mcp-repl-write-stdin-")
-        .tempdir_in(env!("CARGO_MANIFEST_DIR"))?)
+        .tempdir_in(common::checkout_test_temp_parent("write-stdin")?)?)
+}
+
+#[test]
+fn workspace_tempdir_uses_non_temp_checkout_scratch_parent() -> TestResult<()> {
+    let temp = workspace_tempdir()?;
+    assert_ne!(
+        temp.path().parent(),
+        Some(Path::new(env!("CARGO_MANIFEST_DIR"))),
+        "test scratch dirs must not be created directly in the repo root"
+    );
+    assert!(
+        temp.path()
+            .starts_with(common::checkout_test_temp_parent("write-stdin")?),
+        "workspace scratch dirs should stay under target/test-scratch"
+    );
+    assert!(
+        !temp.path().starts_with(std::env::temp_dir()),
+        "workspace scratch dirs must stay outside OS temp because some tests remove or override worker temp env"
+    );
+    Ok(())
 }
 
 async fn wait_until_path_exists(path: &Path, label: &str) -> TestResult<()> {


### PR DESCRIPTION
## Summary
This moves test scratch directories out of the repository root so interrupted or failed test runs do not leave `.tmp-*` or similar artifacts in the working tree. The change keeps sandbox-sensitive scratch under `target/test-scratch` instead of OS temp because those tests need cwd writes to be blocked under read-only sandbox policy, and some timeout tests intentionally remove or override temp env paths.

## User-facing changes
None. This only affects test scratch placement.

## Internal changes
- Added a shared checkout-local scratch parent helper under `target/test-scratch`.
- Moved write-stdin and sandbox-state scratch dirs to that helper.
- Added regressions that assert scratch dirs are not created directly in the repo root and stay outside OS temp where required.
- Moved one worker-process unit-test scratch path to OS temp because it does not rely on sandbox cwd/temp semantics.
