### PR TITLE
Stabilize Windows integration test harness

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1571,6 +1571,8 @@ pub async fn spawn_server_with_args_env_and_cwd(
         cmd.env_remove("R_ENVIRON");
         cmd.env_remove("R_ENVIRON_USER");
         cmd.env_remove("MCP_REPL_UPDATE_PLOT_IMAGES");
+        cmd.env("PAGER", "cat");
+        cmd.env("MANPAGER", "cat");
         if let Some(cwd) = &current_dir {
             cmd.current_dir(cwd);
         }

--- a/tests/r_startup.rs
+++ b/tests/r_startup.rs
@@ -105,3 +105,35 @@ cat("RENVIRON=", Sys.getenv("MCP_REPL_RENVIRON_TEST"), "\n", sep = "")
     session.cancel().await?;
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_server_spawns_with_plain_pager_env() -> TestResult<()> {
+    let session = common::spawn_server_with_files().await?;
+
+    let result = session
+        .write_stdin_raw_with(
+            r#"
+cat("PAGER=", Sys.getenv("PAGER"), "\n", sep = "")
+cat("MANPAGER=", Sys.getenv("MANPAGER"), "\n", sep = "")
+"#,
+            Some(10.0),
+        )
+        .await?;
+    let text = result_text(&result);
+    if backend_unavailable(&text) {
+        eprintln!("r_startup backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert!(
+        text.contains("PAGER=cat"),
+        "expected PAGER=cat in test server environment, got: {text:?}"
+    );
+    assert!(
+        text.contains("MANPAGER=cat"),
+        "expected MANPAGER=cat in test server environment, got: {text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}

--- a/tests/reticulate_py_help.rs
+++ b/tests/reticulate_py_help.rs
@@ -3,6 +3,11 @@ mod common;
 use common::TestResult;
 use rmcp::model::RawContent;
 
+const REPL_STARTUP_TIMEOUT_SECS: f64 = 30.0;
+const RETICULATE_INIT_TIMEOUT_SECS: f64 = 30.0;
+const PY_HELP_TIMEOUT_SECS: f64 = 5.0;
+const RETICULATE_READY_MARKER: &str = "[repl] reticulate python ready";
+
 fn result_text(result: &rmcp::model::CallToolResult) -> String {
     result
         .content
@@ -21,6 +26,13 @@ fn should_skip_reticulate_py_help_output(text: &str) -> bool {
         || text.trim() == ">"
 }
 
+fn assert_not_busy(label: &str, text: &str) -> TestResult<()> {
+    if common::is_busy_response(text) {
+        return Err(format!("{label} exceeded its timeout budget: {text:?}").into());
+    }
+    Ok(())
+}
+
 #[test]
 fn prompt_only_reticulate_output_is_skipped() {
     assert!(should_skip_reticulate_py_help_output(">"));
@@ -30,7 +42,22 @@ fn prompt_only_reticulate_output_is_skipped() {
 async fn reticulate_py_help_is_rendered() -> TestResult<()> {
     let session = common::spawn_server_with_files().await?;
 
-    let result = session
+    let startup = session
+        .write_stdin_raw_with("1+1", Some(REPL_STARTUP_TIMEOUT_SECS))
+        .await?;
+    let startup_text = result_text(&startup);
+    if common::backend_unavailable(&startup_text) {
+        eprintln!("reticulate_py_help backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert_not_busy("R startup", &startup_text)?;
+    assert!(
+        startup_text.contains("[1] 2"),
+        "expected R startup smoke output, got: {startup_text:?}"
+    );
+
+    let setup = session
         .write_stdin_raw_with(
             r#"
 {
@@ -39,22 +66,56 @@ async fn reticulate_py_help_is_rendered() -> TestResult<()> {
     invisible(NULL)
   } else {
     ok <- TRUE
-    tryCatch({ reticulate::py_config() }, error = function(e) { ok <<- FALSE })
+    tryCatch({
+      reticulate::py_config()
+      assign(
+        ".mcp_repl_reticulate_builtins",
+        reticulate::import_builtins(),
+        envir = .GlobalEnv
+      )
+    }, error = function(e) { ok <<- FALSE })
     if (!ok) {
       cat("[repl] reticulate python unavailable\n")
       invisible(NULL)
     } else {
-      builtins <- reticulate::import_builtins()
-      reticulate::py_help(builtins$len)
+      cat("[repl] reticulate python ready\n")
       invisible(NULL)
     }
   }
 }
 "#,
-            Some(60.0),
+            Some(RETICULATE_INIT_TIMEOUT_SECS),
+        )
+        .await?;
+    let setup_text = result_text(&setup);
+    assert_not_busy("reticulate Python initialization", &setup_text)?;
+    if should_skip_reticulate_py_help_output(&setup_text) {
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert!(
+        setup_text.contains(RETICULATE_READY_MARKER),
+        "expected reticulate Python initialization marker, got: {setup_text:?}"
+    );
+
+    let result = session
+        .write_stdin_raw_with(
+            "reticulate::py_help(.mcp_repl_reticulate_builtins$len); invisible(NULL)",
+            Some(PY_HELP_TIMEOUT_SECS),
         )
         .await?;
     let text = result_text(&result);
+    if common::is_busy_response(&text) {
+        session.cancel().await?;
+        if cfg!(windows) {
+            eprintln!("reticulate::py_help() exceeded its short Windows budget; skipping");
+            return Ok(());
+        }
+        return Err(format!(
+            "reticulate::py_help() exceeded its {PY_HELP_TIMEOUT_SECS}s timeout budget: {text:?}"
+        )
+        .into());
+    }
 
     if should_skip_reticulate_py_help_output(&text) {
         session.cancel().await?;

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -41,6 +41,22 @@ def collect_stdout(stream: Any, sink: queue.Queue[bytes | None]) -> None:
     sink.put(None)
 
 
+def server_process_env(server_env: Sequence[tuple[str, str]]) -> dict[str, str]:
+    env = os.environ.copy()
+    for key in [
+        "R_PROFILE_USER",
+        "R_PROFILE_SITE",
+        "R_ENVIRON",
+        "R_ENVIRON_USER",
+        "MCP_REPL_UPDATE_PLOT_IMAGES",
+    ]:
+        env.pop(key, None)
+    env["PAGER"] = "cat"
+    env["MANPAGER"] = "cat"
+    env.update(server_env)
+    return env
+
+
 class McpStdioClient:
     def __init__(
         self,
@@ -65,24 +81,13 @@ class McpStdioClient:
         if not self.binary.is_file():
             raise SuiteFailure(f"binary does not exist: {self.binary}")
 
-        env = os.environ.copy()
-        for key in [
-            "R_PROFILE_USER",
-            "R_PROFILE_SITE",
-            "R_ENVIRON",
-            "R_ENVIRON_USER",
-            "MCP_REPL_UPDATE_PLOT_IMAGES",
-        ]:
-            env.pop(key, None)
-        env.update(self.server_env)
-
         command = [str(self.binary), *self.server_args]
         self.process = subprocess.Popen(
             command,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            env=env,
+            env=server_process_env(tuple(self.server_env.items())),
         )
         assert self.process.stdout is not None
         assert self.process.stderr is not None
@@ -881,11 +886,22 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def resolve_binary_path(path: Path) -> Path:
+    if path.is_file():
+        return path
+    if sys.platform == "win32" and path.suffix == "":
+        exe_path = path.with_name(f"{path.name}.exe")
+        if exe_path.is_file():
+            return exe_path
+    return path
+
+
 def main(argv: Sequence[str]) -> int:
     args = parse_args(argv)
     if args.timeout <= 0:
         print("--timeout must be positive", file=sys.stderr)
         return 2
+    binary = resolve_binary_path(args.binary)
 
     selected = args.case or sorted(CASES)
     failures = 0
@@ -893,7 +909,7 @@ def main(argv: Sequence[str]) -> int:
         case = CASES[case_name]
         try:
             with McpStdioClient(
-                args.binary,
+                binary,
                 ["--sandbox", args.sandbox, *case.server_args],
                 case.server_env,
                 args.timeout,

--- a/tests/test_run_integration_tests.py
+++ b/tests/test_run_integration_tests.py
@@ -1,8 +1,10 @@
 import importlib.util
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from textwrap import dedent
+from unittest.mock import patch
 
 
 def load_module():
@@ -43,6 +45,21 @@ class RunIntegrationTestsCaseTests(unittest.TestCase):
                 "isError": False,
             },
         )
+
+    def test_resolve_binary_path_accepts_extensionless_windows_path(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            binary = Path(temp_dir) / "mcp-repl"
+            exe_binary = Path(temp_dir) / "mcp-repl.exe"
+            exe_binary.write_text("", encoding="utf-8")
+
+            with patch.object(self.module.sys, "platform", "win32"):
+                self.assertEqual(exe_binary, self.module.resolve_binary_path(binary))
+
+    def test_server_process_env_uses_plain_pagers_by_default(self):
+        env = self.module.server_process_env(())
+
+        self.assertEqual("cat", env["PAGER"])
+        self.assertEqual("cat", env["MANPAGER"])
 
     def test_wait_for_busy_response_text_polls_until_marker(self):
         initial = self.module.tool_result(


### PR DESCRIPTION
## Summary

- Resolve extensionless integration-test binary paths to `.exe` on Windows.
- Spawn test server processes with plain pager environment defaults: `PAGER=cat` and `MANPAGER=cat`.
- Split the reticulate `py_help()` regression into separate budgets for R startup, reticulate/Python initialization, and the final short help-render call.

## Public-facing changes

- None.

## Internal-only changes

- Windows integration test harness path resolution.
- Shared Rust and Python integration test launchers now default external pager environment variables to plain output.
- Reticulate help test timing now isolates startup and Python initialization from the behavior under assertion.

## Testing

- `cargo test --test r_startup test_server_spawns_with_plain_pager_env -- --nocapture`
- `cargo test --test reticulate_py_help -- --nocapture`
- `python3 -m unittest tests/test_run_integration_tests.py`
- `python3 tests/run_integration_tests.py --binary target/debug/mcp-repl`
- `cargo check`
- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo +nightly fmt`
