### PR TITLE
Split Claude and Codex integration drift

### DIFF
--- a/tests/claude_integration.rs
+++ b/tests/claude_integration.rs
@@ -666,6 +666,40 @@ fn assert_arg_pair(args: &[String], flag: &str, expected: &str) -> TestResult<()
     Err(format!("missing argument pair {flag} {expected} in {:?}", args).into())
 }
 
+#[test]
+fn extract_tool_call_rejects_unexpected_mcp_tools() {
+    let events = vec![serde_json::json!({
+        "message": {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "ToolSearch",
+                    "input": { "query": "mcp__r__repl" }
+                },
+                {
+                    "type": "tool_use",
+                    "name": "mcp__r__repl_reset",
+                    "input": {}
+                },
+                {
+                    "type": "tool_use",
+                    "name": "mcp__r__repl",
+                    "input": { "input": TOOL_INPUT }
+                }
+            ]
+        }
+    })];
+
+    let err = extract_tool_call(&events)
+        .expect_err("expected unexpected MCP tool uses to fail the Claude contract");
+
+    assert!(
+        err.to_string()
+            .contains("unexpected Claude tool call: mcp__r__repl_reset"),
+        "unexpected error: {err}"
+    );
+}
+
 fn stage_bedrock_env(
     temp_home: &Path,
     host_settings_env: &std::collections::BTreeMap<String, String>,
@@ -844,8 +878,11 @@ fn extract_tool_call(events: &[JsonValue]) -> TestResult<ClaudeToolCallSnapshot>
                 .and_then(JsonValue::as_str)
                 .ok_or_else(|| "Claude tool_use missing name".to_string())?
                 .to_string();
-            if name != "mcp__r__repl" {
+            if name == "ToolSearch" {
                 continue;
+            }
+            if name != "mcp__r__repl" {
+                return Err(format!("unexpected Claude tool call: {name}").into());
             }
             let input = content
                 .get("input")

--- a/tests/claude_integration.rs
+++ b/tests/claude_integration.rs
@@ -95,6 +95,8 @@ struct ClaudeMcpServerSnapshot {
 
 #[derive(Debug, Serialize)]
 struct ClaudeToolCallSnapshot {
+    #[serde(skip_serializing)]
+    id: String,
     name: String,
     input: String,
 }
@@ -673,16 +675,19 @@ fn extract_tool_call_rejects_unexpected_mcp_tools() {
             "content": [
                 {
                     "type": "tool_use",
+                    "id": "toolu_search",
                     "name": "ToolSearch",
                     "input": { "query": "mcp__r__repl" }
                 },
                 {
                     "type": "tool_use",
+                    "id": "toolu_reset",
                     "name": "mcp__r__repl_reset",
                     "input": {}
                 },
                 {
                     "type": "tool_use",
+                    "id": "toolu_repl",
                     "name": "mcp__r__repl",
                     "input": { "input": TOOL_INPUT }
                 }
@@ -698,6 +703,88 @@ fn extract_tool_call_rejects_unexpected_mcp_tools() {
             .contains("unexpected Claude tool call: mcp__r__repl_reset"),
         "unexpected error: {err}"
     );
+}
+
+#[test]
+fn parse_snapshot_skips_tool_search_tool_results() -> TestResult<()> {
+    let events = serde_json::json!([
+        {
+            "type": "system",
+            "cwd": "/tmp/claude-workspace",
+            "tools": ["ToolSearch", "mcp__r__repl"],
+            "mcp_servers": [
+                { "name": "r", "status": "connected" }
+            ],
+            "model": CLAUDE_MODEL,
+            "permissionMode": CLAUDE_PERMISSION_MODE
+        },
+        {
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_search",
+                        "name": "ToolSearch",
+                        "input": { "query": "mcp__r__repl" }
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_repl",
+                        "name": "mcp__r__repl",
+                        "input": { "input": TOOL_INPUT }
+                    }
+                ]
+            }
+        },
+        {
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_search",
+                        "content": [
+                            { "type": "text", "text": "ToolSearch found mcp__r__repl\n" }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_repl",
+                        "content": [
+                            { "type": "text", "text": "CLAUDE_MCP_OK\n" }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "message": {
+                "content": [
+                    { "type": "text", "text": FINAL_RESULT }
+                ]
+            }
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": false,
+            "result": FINAL_RESULT,
+            "stop_reason": "end_turn",
+            "permission_denials": []
+        }
+    ]);
+    let stdout = serde_json::to_string(&events)?;
+
+    let snapshot = parse_snapshot(&stdout, Path::new("/tmp/claude-workspace"))?
+        .expect("expected Claude snapshot");
+
+    assert_eq!(snapshot.tool_result, "CLAUDE_MCP_OK\n");
+    Ok(())
 }
 
 fn stage_bedrock_env(
@@ -828,7 +915,7 @@ fn parse_snapshot(stdout: &str, workspace: &Path) -> TestResult<Option<ClaudeSna
     };
 
     let tool_call = extract_tool_call(&events)?;
-    let tool_result = extract_tool_result(&events)?;
+    let tool_result = extract_tool_result(&events, &tool_call.id)?;
     let final_text = normalize_done_text(&extract_final_text(&events)?);
     let result = extract_result(&events)?;
 
@@ -884,6 +971,11 @@ fn extract_tool_call(events: &[JsonValue]) -> TestResult<ClaudeToolCallSnapshot>
             if name != "mcp__r__repl" {
                 return Err(format!("unexpected Claude tool call: {name}").into());
             }
+            let id = content
+                .get("id")
+                .and_then(JsonValue::as_str)
+                .ok_or_else(|| "Claude mcp__r__repl tool_use missing id".to_string())?
+                .to_string();
             let input = content
                 .get("input")
                 .and_then(JsonValue::as_object)
@@ -891,7 +983,7 @@ fn extract_tool_call(events: &[JsonValue]) -> TestResult<ClaudeToolCallSnapshot>
                 .and_then(JsonValue::as_str)
                 .ok_or_else(|| "Claude tool_use missing input.input".to_string())?
                 .to_string();
-            calls.push(ClaudeToolCallSnapshot { name, input });
+            calls.push(ClaudeToolCallSnapshot { id, name, input });
         }
     }
 
@@ -902,42 +994,77 @@ fn extract_tool_call(events: &[JsonValue]) -> TestResult<ClaudeToolCallSnapshot>
     }
 }
 
-fn extract_tool_result(events: &[JsonValue]) -> TestResult<String> {
+fn extract_tool_result(events: &[JsonValue], tool_use_id: &str) -> TestResult<String> {
     for event in events {
-        if let Some(contents) = event
-            .get("tool_use_result")
-            .and_then(JsonValue::as_array)
-            .or_else(|| {
-                event
-                    .get("message")
-                    .and_then(JsonValue::as_object)
-                    .and_then(|message| message.get("content"))
-                    .and_then(JsonValue::as_array)
-                    .and_then(|contents| {
-                        contents.iter().find_map(|content| {
-                            content
-                                .get("content")
-                                .and_then(JsonValue::as_array)
-                                .filter(|_| {
-                                    content.get("type").and_then(JsonValue::as_str)
-                                        == Some("tool_result")
-                                })
-                        })
-                    })
-            })
+        if event_tool_use_result_matches(event, tool_use_id)
+            && let Some(contents) = event.get("tool_use_result").and_then(JsonValue::as_array)
+            && let Some(text) = tool_result_text(contents)
         {
-            let text = contents
-                .iter()
-                .filter_map(|item| item.get("text").and_then(JsonValue::as_str))
-                .filter(|text| *text != "> ")
-                .collect::<String>();
-            if !text.is_empty() {
+            return Ok(text);
+        }
+
+        let Some(contents) = event
+            .get("message")
+            .and_then(JsonValue::as_object)
+            .and_then(|message| message.get("content"))
+            .and_then(JsonValue::as_array)
+        else {
+            continue;
+        };
+
+        for content in contents {
+            if content.get("type").and_then(JsonValue::as_str) != Some("tool_result") {
+                continue;
+            }
+            if content.get("tool_use_id").and_then(JsonValue::as_str) != Some(tool_use_id) {
+                continue;
+            }
+            let result_contents = content
+                .get("content")
+                .and_then(JsonValue::as_array)
+                .ok_or_else(|| "Claude mcp__r__repl tool_result missing content".to_string())?;
+            if let Some(text) = tool_result_text(result_contents) {
                 return Ok(text);
             }
         }
     }
 
-    Err("Claude output did not contain a tool result".into())
+    Err("Claude output did not contain an mcp__r__repl tool result".into())
+}
+
+fn event_tool_use_result_matches(event: &JsonValue, tool_use_id: &str) -> bool {
+    if event
+        .get("tool_use_result")
+        .and_then(JsonValue::as_array)
+        .is_none()
+    {
+        return false;
+    }
+    if event.get("tool_use_id").and_then(JsonValue::as_str) == Some(tool_use_id) {
+        return true;
+    }
+
+    event
+        .get("message")
+        .and_then(JsonValue::as_object)
+        .and_then(|message| message.get("content"))
+        .and_then(JsonValue::as_array)
+        .is_some_and(|contents| {
+            contents.iter().any(|content| {
+                content.get("type").and_then(JsonValue::as_str) == Some("tool_use")
+                    && content.get("id").and_then(JsonValue::as_str) == Some(tool_use_id)
+            })
+        })
+}
+
+fn tool_result_text(contents: &[JsonValue]) -> Option<String> {
+    let text = contents
+        .iter()
+        .filter_map(|item| item.get("text").and_then(JsonValue::as_str))
+        .filter(|text| *text != "> ")
+        .collect::<String>();
+
+    (!text.is_empty()).then_some(text)
 }
 
 fn extract_final_text(events: &[JsonValue]) -> TestResult<String> {

--- a/tests/claude_integration.rs
+++ b/tests/claude_integration.rs
@@ -197,8 +197,6 @@ fn run_claude_snapshot(staged: &StagedClaudeEnv) -> TestResult<ClaudeSnapshot> {
     cmd.arg(CLAUDE_PERMISSION_MODE);
     cmd.arg("--output-format");
     cmd.arg("json");
-    cmd.arg("--tools");
-    cmd.arg("");
 
     let output = run_command_with_timeout(cmd, CLAUDE_PROMPT, CLAUDE_TIMEOUT)?;
     let stdout = String::from_utf8(output.stdout)
@@ -214,7 +212,8 @@ fn run_claude_snapshot(staged: &StagedClaudeEnv) -> TestResult<ClaudeSnapshot> {
         .into());
     }
 
-    parse_snapshot(stdout.trim(), &staged.workspace)?
+    parse_snapshot(stdout.trim(), &staged.workspace)
+        .map_err(|err| format!("{err}\nstdout:\n{stdout}\nstderr:\n{stderr}"))?
         .ok_or_else(|| "Claude snapshot unexpectedly missing".into())
 }
 
@@ -751,6 +750,7 @@ fn parse_snapshot(stdout: &str, workspace: &Path) -> TestResult<Option<ClaudeSna
         .ok_or_else(|| "Claude init event missing tools".to_string())?
         .iter()
         .filter_map(JsonValue::as_str)
+        .filter(|tool| tool.starts_with("mcp__r__") || *tool == "ToolSearch")
         .map(ToOwned::to_owned)
         .collect::<Vec<_>>();
     tools.sort();
@@ -844,6 +844,9 @@ fn extract_tool_call(events: &[JsonValue]) -> TestResult<ClaudeToolCallSnapshot>
                 .and_then(JsonValue::as_str)
                 .ok_or_else(|| "Claude tool_use missing name".to_string())?
                 .to_string();
+            if name != "mcp__r__repl" {
+                continue;
+            }
             let input = content
                 .get("input")
                 .and_then(JsonValue::as_object)
@@ -1006,7 +1009,7 @@ fn render_transcript(snapshot: &ClaudeSnapshot) -> String {
 }
 
 fn snapshot_command() -> String {
-    "$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json --tools \"\"".to_string()
+    "$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json".to_string()
 }
 
 fn normalize_workspace_path(path: &str, workspace: &Path) -> String {

--- a/tests/codex_integration.rs
+++ b/tests/codex_integration.rs
@@ -1986,6 +1986,13 @@ tryCatch({
                     .eq(suffix.iter().copied())
         }
 
+        fn is_default_codex_memories_root(item: &Value) -> bool {
+            matches!(
+                item.as_str(),
+                Some("<CODEX_HOME>/memories" | "<CODEX_HOME>\\memories")
+            )
+        }
+
         fn normalize_wire_string(text: &str, workspace: &Path, codex_home: &Path) -> String {
             let workspace_display = workspace.display().to_string();
             let workspace_private = format!("/private{workspace_display}");
@@ -2043,9 +2050,7 @@ tryCatch({
                             && matches!(
                                 &child,
                                 Value::Array(items)
-                                    if items.iter().all(|item| {
-                                        item.as_str() == Some("<CODEX_HOME>/memories")
-                                    })
+                                    if items.iter().all(is_default_codex_memories_root)
                             )
                         {
                             continue;
@@ -2225,6 +2230,32 @@ tryCatch({
                 }
             }),
             "wire snapshots should not retain Codex's default memories writable root"
+        );
+    }
+
+    #[test]
+    fn normalize_wire_snapshot_drops_windows_codex_memories_writable_root() {
+        let workspace = std::env::temp_dir().join("mcp-repl-wire-workspace");
+        let codex_home = std::env::temp_dir().join("mcp-repl-wire-codex-home");
+        let mut value = serde_json::json!({
+            "sandboxPolicy": {
+                "type": "workspace-write",
+                "writable_roots": ["<CODEX_HOME>\\memories"],
+                "network_access": false
+            }
+        });
+
+        normalize_wire_snapshot_value(&mut value, &workspace, &codex_home);
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "sandboxPolicy": {
+                    "type": "workspace-write",
+                    "network_access": false
+                }
+            }),
+            "wire snapshots should not retain Codex's default Windows memories writable root"
         );
     }
 

--- a/tests/codex_integration.rs
+++ b/tests/codex_integration.rs
@@ -2038,6 +2038,18 @@ tryCatch({
                         path.push(normalized_key.clone());
                         normalize_inner(&mut child, path, workspace, codex_home);
                         path.pop();
+                        if path_matches(path, &["sandboxPolicy"])
+                            && normalized_key == "writable_roots"
+                            && matches!(
+                                &child,
+                                Value::Array(items)
+                                    if items.iter().all(|item| {
+                                        item.as_str() == Some("<CODEX_HOME>/memories")
+                                    })
+                            )
+                        {
+                            continue;
+                        }
                         map.insert(normalized_key, child);
                     }
                     if path_matches(path, &["capabilities", "elicitation"]) && map.is_empty() {
@@ -2186,6 +2198,33 @@ tryCatch({
                 }
             }),
             "wire snapshots should normalize Codex elicitation capability shape"
+        );
+    }
+
+    #[test]
+    fn normalize_wire_snapshot_drops_default_codex_memories_writable_root() {
+        let workspace = std::env::temp_dir().join("mcp-repl-wire-workspace");
+        let codex_home = std::env::temp_dir().join("mcp-repl-wire-codex-home");
+        let memories = codex_home.join("memories");
+        let mut value = serde_json::json!({
+            "sandboxPolicy": {
+                "type": "workspace-write",
+                "writable_roots": [memories],
+                "network_access": false
+            }
+        });
+
+        normalize_wire_snapshot_value(&mut value, &workspace, &codex_home);
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "sandboxPolicy": {
+                    "type": "workspace-write",
+                    "network_access": false
+                }
+            }),
+            "wire snapshots should not retain Codex's default memories writable root"
         );
     }
 
@@ -2794,13 +2833,9 @@ tryCatch({
 
     fn split_legacy_tool_name(legacy_tool_name: &str) -> Option<(&str, &str)> {
         let split = legacy_tool_name.rfind("__")?;
-        let namespace_end = split + 2;
-        (namespace_end < legacy_tool_name.len()).then(|| {
-            (
-                &legacy_tool_name[..namespace_end],
-                &legacy_tool_name[namespace_end..],
-            )
-        })
+        let name_start = split + 2;
+        (split > 0 && name_start < legacy_tool_name.len())
+            .then(|| (&legacy_tool_name[..split], &legacy_tool_name[name_start..]))
     }
 
     fn message_item(text: &str) -> Value {
@@ -2930,7 +2965,7 @@ tryCatch({
         let request = serde_json::json!({
             "tools": [{
                 "type": "namespace",
-                "name": "mcp__r__",
+                "name": "mcp__r",
                 "tools": [{
                     "type": "function",
                     "name": "repl",
@@ -2941,7 +2976,7 @@ tryCatch({
             resolve_tool_call_spec(&request, "mcp__r__repl"),
             Some(MockToolCallSpec {
                 name: "repl".to_string(),
-                namespace: Some("mcp__r__".to_string()),
+                namespace: Some("mcp__r".to_string()),
             })
         );
     }

--- a/tests/snapshots/claude_integration__claude_live_install_integration.snap
+++ b/tests/snapshots/claude_integration__claude_live_install_integration.snap
@@ -3,18 +3,17 @@ source: tests/claude_integration.rs
 expression: rendered
 ---
 {
-  "command": "$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json --tools \"\"",
+  "command": "$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json",
   "prompt": "Use the mcp__r__repl tool exactly once. Send this exact R code: cat(\"CLAUDE_MCP_OK\\n\") Then answer with exactly DONE, with no punctuation or extra text.",
   "init": {
     "cwd": "<WORKSPACE>",
     "tools": [
-      "mcp__r__repl",
-      "mcp__r__repl_reset"
+      "ToolSearch"
     ],
     "mcp_servers": [
       {
         "name": "r",
-        "status": "connected"
+        "status": "pending"
       }
     ],
     "model": "haiku",

--- a/tests/snapshots/claude_integration__claude_live_install_integration@transcript.snap
+++ b/tests/snapshots/claude_integration__claude_live_install_integration@transcript.snap
@@ -2,14 +2,14 @@
 source: tests/claude_integration.rs
 expression: transcript
 ---
-$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json --tools ""
+$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json
 stdin:
 Use the mcp__r__repl tool exactly once. Send this exact R code: cat("CLAUDE_MCP_OK\n") Then answer with exactly DONE, with no punctuation or extra text.
 
 init:
 cwd: <WORKSPACE>
-tools: mcp__r__repl, mcp__r__repl_reset
-mcp_server: r (connected)
+tools: ToolSearch
+mcp_server: r (pending)
 model: haiku
 permission_mode: dontAsk
 

--- a/tests/snapshots/claude_integration__claude_live_integration.snap
+++ b/tests/snapshots/claude_integration__claude_live_integration.snap
@@ -3,18 +3,17 @@ source: tests/claude_integration.rs
 expression: rendered
 ---
 {
-  "command": "$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json --tools \"\"",
+  "command": "$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json",
   "prompt": "Use the mcp__r__repl tool exactly once. Send this exact R code: cat(\"CLAUDE_MCP_OK\\n\") Then answer with exactly DONE, with no punctuation or extra text.",
   "init": {
     "cwd": "<WORKSPACE>",
     "tools": [
-      "mcp__r__repl",
-      "mcp__r__repl_reset"
+      "ToolSearch"
     ],
     "mcp_servers": [
       {
         "name": "r",
-        "status": "connected"
+        "status": "pending"
       }
     ],
     "model": "haiku",

--- a/tests/snapshots/claude_integration__claude_live_integration@transcript.snap
+++ b/tests/snapshots/claude_integration__claude_live_integration@transcript.snap
@@ -2,14 +2,14 @@
 source: tests/claude_integration.rs
 expression: transcript
 ---
-$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json --tools ""
+$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json
 stdin:
 Use the mcp__r__repl tool exactly once. Send this exact R code: cat("CLAUDE_MCP_OK\n") Then answer with exactly DONE, with no punctuation or extra text.
 
 init:
 cwd: <WORKSPACE>
-tools: mcp__r__repl, mcp__r__repl_reset
-mcp_server: r (connected)
+tools: ToolSearch
+mcp_server: r (pending)
 model: haiku
 permission_mode: dontAsk
 

--- a/tests/snapshots/codex_integration__linux__codex_exec_wire_sandbox_state_meta.snap
+++ b/tests/snapshots/codex_integration__linux__codex_exec_wire_sandbox_state_meta.snap
@@ -36,9 +36,6 @@ expression: snapshot
           "codex/sandbox-state-meta": {
             "sandboxPolicy": {
               "type": "workspace-write",
-              "writable_roots": [
-                "<CODEX_HOME>/memories"
-              ],
               "network_access": false,
               "exclude_tmpdir_env_var": false,
               "exclude_slash_tmp": false

--- a/tests/snapshots/codex_integration__macos__codex_exec_wire_sandbox_state_meta.snap
+++ b/tests/snapshots/codex_integration__macos__codex_exec_wire_sandbox_state_meta.snap
@@ -35,9 +35,6 @@ expression: snapshot
           "codex/sandbox-state-meta": {
             "sandboxPolicy": {
               "type": "workspace-write",
-              "writable_roots": [
-                "<CODEX_HOME>/memories"
-              ],
               "network_access": false,
               "exclude_tmpdir_env_var": false,
               "exclude_slash_tmp": false


### PR DESCRIPTION
## Summary

Primary issue: kx01

This splits the Claude and Codex integration compatibility drift out of PR #77 into a focused branch that can land independently of the sideband byte-stdin protocol work.

Public-facing changes:
- None. This is test harness and snapshot compatibility work only.

Internal-only changes:
- Let the Claude integration harness use current deferred MCP tool discovery via `ToolSearch`.
- Reject unexpected Claude MCP tool uses while still allowing `ToolSearch`.
- Match Claude tool results by `tool_use` id so `ToolSearch` output cannot be mistaken for `mcp__r__repl` output.
- Update the Codex mock Responses payload to use the current namespace shape, `mcp__r` plus child tool `repl`.
- Normalize Codex's default `<CODEX_HOME>/memories` writable root out of wire snapshots.

Out of scope:
- No sideband byte-frame stdin protocol changes.
- No Windows integration harness stabilization changes.

## Testing

- `cargo test --test claude_integration -- --nocapture`
- `cargo test --test codex_integration -- --nocapture`
- `cargo check`
- `cargo build`
- `python3 tests/run_integration_tests.py --binary target/debug/mcp-repl`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo +nightly fmt`
