### PR TITLE
Repair PR 77 Windows CI blocker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ mcp-repl-startup.log
 .agents
 tools/drain-*
 prompts/*
+WORKPAD.md

--- a/docs/plans/active/worker-server-protocol-zod.md
+++ b/docs/plans/active/worker-server-protocol-zod.md
@@ -199,17 +199,17 @@ errors.
 
 ## Text and Byte Encoding
 
-Sideband itself is UTF-8 JSONL. Fields that describe MCP input and
-runtime line-input state use JSON strings:
+Sideband itself is UTF-8 JSONL. Prompt text uses a JSON string:
 
 - `readline_start.prompt`
-- `readline_input.text`
-- `readline_discard.text`
 
-These fields are UTF-8 text because MCP tool input is text and the
-readline contract is line-oriented text. For stdin accounting, the
-server encodes `readline_input.text` or `readline_discard.text` as UTF-8
-and compares those bytes with the active-turn stdin byte queue.
+Stdin accounting uses base64 byte payloads:
+
+- `readline_input_bytes.data_b64`
+- `readline_discard_bytes.data_b64`
+
+The server decodes those fields and compares the bytes with the
+active-turn stdin byte queue.
 
 This does not add a new user-visible input restriction beyond MCP. A
 normal `repl()` call supplies a JSON string inside a UTF-8 JSON-RPC
@@ -239,7 +239,7 @@ The first worker-to-server message must be:
 ```json
 {
   "type": "worker_ready",
-  "protocol": { "name": "mcp-repl-worker", "version": 1 },
+  "protocol": { "name": "mcp-repl-worker", "version": 2 },
   "worker": { "name": "zod", "version": "0.1.0" },
   "capabilities": {
     "images": false
@@ -325,10 +325,10 @@ block: it can be satisfied immediately by bytes already available on
 stdin.
 
 If the server still has bytes from the active turn that have not been
-matched by `readline_input.text` or `readline_discard.text`, this prompt
-is satisfied by already-written input and the turn is not complete. If
-no such bytes remain, this prompt is unsatisfied and the server may seal
-the reply for the active turn.
+matched by `readline_input_bytes` or `readline_discard_bytes`, this
+prompt is satisfied by already-written input and the turn is not
+complete. If no such bytes remain, this prompt is unsatisfied and the
+server may seal the reply for the active turn.
 
 For an unsatisfied `readline_start`, the server will render non-empty
 worker-supplied prompt text in the MCP response to show that the runtime
@@ -345,60 +345,59 @@ cannot suppress. If prompt-like text does arrive as output, the server
 must preserve it as ordinary output and must not deduplicate it by
 comparing it with `readline_start.prompt`.
 
-### `readline_input`
+### `readline_input_bytes`
 
 Worker to server:
 
 ```json
 {
-  "type": "readline_input",
-  "text": "1+1\n"
+  "type": "readline_input_bytes",
+  "data_b64": "MSsxCg=="
 }
 ```
 
 Fields:
 
-- `text`: exact UTF-8 text delivered to the runtime-facing input layer
-  for this read, including a server-appended trailing newline if one was
-  added before writing to worker stdin.
+- `data_b64`: exact active-turn bytes delivered to the runtime-facing
+  input layer, encoded as base64.
 
-The server may use `readline_input` only for generic accounting against
-the bytes it already wrote to worker stdin. It must not interpret the
-text as language syntax. A mismatch between `readline_input.text`
-encoded as UTF-8 and the server's active-turn byte queue is a protocol
-error because it means the worker's input placement is not describing
-what it delivered to the runtime-facing input layer.
+The server may use `readline_input_bytes` only for generic accounting
+against the bytes it already wrote to worker stdin. It must not
+interpret the bytes as language syntax. Invalid base64 or a mismatch
+with the server's active-turn byte queue is a protocol error because it
+means the worker's input placement is not describing what it delivered
+to the runtime-facing input layer.
 
-`readline_input` is not itself a completion signal. Completion is the
-next unsatisfied `readline_start` or `session_end`.
+`readline_input_bytes` is not itself a completion signal. Completion is
+the next unsatisfied `readline_start` or `session_end`.
 
-### `readline_discard`
+### `readline_discard_bytes`
 
 Worker to server:
 
 ```json
 {
-  "type": "readline_discard",
-  "text": "cancelled\n"
+  "type": "readline_discard_bytes",
+  "data_b64": "Y2FuY2VsbGVkCg=="
 }
 ```
 
 Fields:
 
-- `text`: exact UTF-8 text from the active turn that the worker
-  discarded without delivering to the runtime.
+- `data_b64`: exact active-turn bytes that the worker discarded without
+  delivering to the runtime, encoded as base64.
 
 The worker emits this only for bytes it can account for. The server
 removes these bytes from the active-turn byte queue exactly like
-delivered input bytes, but it does not display them as runtime output. A
-mismatch between `readline_discard.text` encoded as UTF-8 and the
-server's active-turn byte queue is a protocol error.
+delivered input bytes, but it does not display them as runtime output.
+Invalid base64 or a mismatch with the server's active-turn byte queue is
+a protocol error.
 
 If the worker discards input after interrupt or reset cleanup and cannot
 report which bytes were discarded, the server cannot prove recovery for
 any control tail. In that case, the worker should not emit
-`readline_discard` for unknown bytes, and the server must not write a
-tail that depends on clean recovery.
+`readline_discard_bytes` for unknown bytes, and the server must not
+write a tail that depends on clean recovery.
 
 ## Output Events
 
@@ -471,16 +470,15 @@ carries no request id because the server allows only one active turn.
 
 The worker uses this message to clean up worker-owned input state. In
 response, the worker should cancel or drain any pending stdin bytes that
-it owns or can observe, and emit `readline_discard` for the exact
-active-turn text it discarded. The worker must not emit
-`readline_discard` for bytes it already delivered to the runtime-facing
-input layer, bytes it cannot identify, or bytes that belong to no active
-turn.
+it owns or can observe, and emit `readline_discard_bytes` for the exact
+active-turn bytes it discarded. The worker must not emit discard events
+for bytes it already delivered to the runtime-facing input layer, bytes
+it cannot identify, or bytes that belong to no active turn.
 
 The worker's sideband control listener must not be blocked by runtime
 evaluation. If the worker cannot process the sideband `interrupt` before
 the runtime consumes pending bytes, those bytes should be reported as
-`readline_input`, not `readline_discard`.
+`readline_input_bytes`, not `readline_discard_bytes`.
 
 The server does not wait for an acknowledgement to `interrupt`. Recovery
 is proven only by later worker events: exact input accounting followed
@@ -545,10 +543,9 @@ sleep or a signal-delivery acknowledgement. The worker has recovered
 only when it emits one of these events after the interrupt:
 
 - an unsatisfied `readline_start` after the active-turn byte queue has
-  been fully accounted for by `readline_input` and/or
-  `readline_discard`, meaning the runtime is ready for the next client
-  input and no bytes from the interrupted turn remain to satisfy that
-  read;
+  been fully accounted for by input and/or discard byte events, meaning
+  the runtime is ready for the next client input and no bytes from the
+  interrupted turn remain to satisfy that read;
 - `session_end`, meaning the old runtime is gone and cannot consume a
   follow-up tail.
 
@@ -628,10 +625,10 @@ For a conforming worker:
 1. `worker_ready` is first.
 2. `readline_start` is emitted when the runtime enters a line-read
    operation, before it reads input bytes for that operation.
-3. `readline_input` is emitted after the worker delivers input bytes to
-   the runtime-facing input layer.
-4. `readline_discard` is emitted after the worker discards accounted-for
-   input bytes during interrupt/reset cleanup.
+3. `readline_input_bytes` is emitted after the worker delivers input
+   bytes to the runtime-facing input layer.
+4. `readline_discard_bytes` is emitted after the worker discards
+   accounted-for input bytes during interrupt/reset cleanup.
 5. `output_text` and `output_image` are emitted in runtime-visible
    order.
 6. `session_end` is final.
@@ -645,7 +642,7 @@ Server-to-worker `interrupt` messages are ordered on the
 server-to-worker sideband stream. Worker-to-server recovery facts are
 ordered on the worker-to-server sideband stream. The server must not
 assume that writing the `interrupt` message means the worker has already
-processed it; later `readline_input`, `readline_discard`,
+processed it; later `readline_input_bytes`, `readline_discard_bytes`,
 `readline_start`, and `session_end` events determine recovery.
 Built-in Unix Python currently has a private `python_interrupt` /
 `python_interrupt_ack` cleanup handshake so it can drain PTY input before
@@ -685,10 +682,10 @@ Protocol errors are fail-fast:
 - Missing required field.
 - Invalid enum value.
 - Invalid base64.
-- `readline_input.text` that does not match bytes the server wrote for
-  the active turn after UTF-8 encoding.
-- `readline_discard.text` that does not match bytes the server wrote for
-  the active turn after UTF-8 encoding.
+- `readline_input_bytes.data_b64` that is invalid base64 or does not
+  match bytes the server wrote for the active turn.
+- `readline_discard_bytes.data_b64` that is invalid base64 or does not
+  match bytes the server wrote for the active turn.
 - Worker-owned output after `session_end`.
 - Second non-empty input while a turn is still active.
 
@@ -710,10 +707,10 @@ A third-party worker must:
 4. Arrange for server-written input bytes to reach the runtime.
 5. Emit `readline_start` when the runtime enters a line-read operation,
    before it reads input bytes for that operation.
-6. Emit `readline_input` after delivering input bytes to the
+6. Emit `readline_input_bytes` after delivering input bytes to the
    runtime-facing input layer.
-7. Emit `readline_discard` for accounted-for active-turn bytes discarded
-   during interrupt/reset cleanup.
+7. Emit `readline_discard_bytes` for accounted-for active-turn bytes
+   discarded during interrupt/reset cleanup.
 8. Emit worker-owned output as `output_text` or `output_image`.
 9. Arrange OS interrupt/reset/shutdown controls to affect the runtime.
 10. Emit `session_end` before clean shutdown.
@@ -791,7 +788,7 @@ surface with Zod as the worker:
 - Ctrl-C sends the sideband `interrupt` notification and is delivered as
   an OS interrupt to an existing worker.
 - Ctrl-C cancels any not-yet-written stdin tail, and the worker
-  best-effort discards pending input it owns with `readline_discard`
+  best-effort discards pending input it owns with `readline_discard_bytes`
   accounting.
 - Interrupt tail input is sent only after all prior active-turn bytes
   are accounted for as delivered or discarded and the worker emits an
@@ -849,10 +846,10 @@ worker implementation task, not a server request-handling task.
 - User input travels to the worker only as stdin bytes, with exactly one
   trailing `\n` appended by the server when non-empty input does not already
   end in `\n`.
-- R and Python workers emit `readline_start`/`readline_input` facts
+- R and Python workers emit `readline_start`/`readline_input_bytes` facts
   sufficient for the server to identify unsatisfied input waits.
-- R and Python workers emit `readline_discard` for any active-turn input
-  bytes they discard during interrupt/reset cleanup.
+- R and Python workers emit `readline_discard_bytes` for any active-turn
+  input bytes they discard during interrupt/reset cleanup.
 - The server does not parse or strip prompts from stdout/stderr.
 - The server delivers OS interrupts to an existing worker without
   consulting interpreter state.

--- a/docs/worker_sideband_protocol.md
+++ b/docs/worker_sideband_protocol.md
@@ -44,8 +44,8 @@ facts from that CPython path. Sideband IPC stays separate from the PTY.
   process or process group.
 - This is for worker-owned bookkeeping only. It does not carry user input and
   does not replace the OS interrupt.
-- The worker may emit `readline_discard` for exact active-turn stdin bytes it
-  discarded before delivering them to the runtime.
+- The worker may emit `readline_discard_bytes` for exact active-turn stdin bytes
+  it discarded before delivering them to the runtime.
 
 ## Direction: worker -> server
 
@@ -53,7 +53,7 @@ Worker-to-server messages are strict: unknown fields, invalid enum values,
 invalid base64, and unknown message types are protocol errors.
 
 `worker_ready`
-- `{ "type": "worker_ready", "protocol": { "name": "mcp-repl-worker", "version": 1 }, "worker": { "name": <string>, "version": <string> }, "capabilities": { "images": <bool> } }`
+- `{ "type": "worker_ready", "protocol": { "name": "mcp-repl-worker", "version": 2 }, "worker": { "name": <string>, "version": <string> }, "capabilities": { "images": <bool> } }`
 - Must be the first worker-to-server message for protocol workers.
 - The server rejects unsupported protocol names or versions before sending user
   input.
@@ -66,25 +66,32 @@ invalid base64, and unknown message types are protocol errors.
   for that operation.
 - The prompt string is required; use an empty string if the runtime supplied no
   prompt.
-- If active-turn stdin bytes remain unaccounted, the prompt is satisfied by
-  already-written stdin and does not complete the request. If no active-turn
-  stdin bytes remain, the prompt is unsatisfied and may complete the request.
+- If active-turn stdin bytes remain unaccounted by input or discard events,
+  the prompt is satisfied by already-written stdin and does not complete the
+  request. If no active-turn stdin bytes remain, the prompt is unsatisfied and
+  may complete the request.
 - Prompt rendering is derived from this structured event, not from raw
   stdout/stderr parsing.
 
-`readline_input`
-- `{ "type": "readline_input", "text": <string> }`
-- Emitted after the worker delivers active-turn stdin text to the
+`readline_input_bytes`
+- `{ "type": "readline_input_bytes", "data_b64": <base64> }`
+- Emitted after the worker delivers active-turn stdin bytes to the
   runtime-facing input layer.
-- The server encodes `text` as UTF-8 and removes those bytes from the active
-  stdin queue. A mismatch is a protocol error.
+- `data_b64` must encode the exact bytes received from the server over the
+  worker stdin transport before any worker-side normalization or interpreter
+  adaptation. The worker may normalize the bytes it passes to the runtime, but
+  this accounting event reports the pre-normalized wire bytes.
+- The server decodes `data_b64` and removes those bytes from the active stdin
+  queue. Invalid base64 or a byte mismatch is a protocol error.
 
-`readline_discard`
-- `{ "type": "readline_discard", "text": <string> }`
-- Emitted after the worker discards active-turn stdin text during
-  interrupt/reset cleanup without delivering it to the runtime.
-- The server encodes `text` as UTF-8 and removes those bytes from the active
-  stdin queue. A mismatch is a protocol error.
+`readline_discard_bytes`
+- `{ "type": "readline_discard_bytes", "data_b64": <base64> }`
+- Emitted after the worker discards exact active-turn stdin bytes during
+  interrupt/reset cleanup without delivering them to the runtime.
+- `data_b64` must encode the exact bytes received from the server over the
+  worker stdin transport before any worker-side normalization.
+- The server decodes `data_b64` and removes those bytes from the active stdin
+  queue. Invalid base64 or a byte mismatch is a protocol error.
 - Workers must emit this only for exact bytes they can identify. Bytes flushed
   from terminal state without being observed are not reportable.
 
@@ -164,8 +171,8 @@ readline events rather than a separate stdin bridge.
 - `{ "type": "readline_result", "prompt": <string>, "line": <string> }`
 - Legacy echo metadata emitted after a line is read.
 - The server may use it for conservative echo suppression of raw pipe output,
-  but completion is driven by `readline_start`, `readline_input`,
-  `readline_discard`, and `session_end`.
+  but completion is driven by `readline_start`, `readline_input_bytes`,
+  `readline_discard_bytes`, and `session_end`.
 
 `plot_image`
 - `{ "type": "plot_image", "mime_type": <string>, "data": <base64>, "is_update": <bool>, "source": <string|null> }`

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -83,6 +83,8 @@ static NEXT_SERVER_IMAGE_ID: AtomicU64 = AtomicU64::new(0);
 #[cfg(target_family = "unix")]
 static WORKER_IPC_ATFORK_REGISTER_RESULT: OnceLock<i32> = OnceLock::new();
 
+pub const WORKER_PROTOCOL_VERSION: u32 = 2;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServerToWorkerIpcMessage {
@@ -127,11 +129,11 @@ pub enum WorkerToServerIpcMessage {
     ReadlineStart {
         prompt: String,
     },
-    ReadlineInput {
-        text: String,
+    ReadlineInputBytes {
+        data_b64: String,
     },
-    ReadlineDiscard {
-        text: String,
+    ReadlineDiscardBytes {
+        data_b64: String,
     },
     ReadlineResult {
         prompt: String,
@@ -415,9 +417,20 @@ impl ServerIpcConnection {
                             handler(prompt_for_handler);
                         }
                     }
-                    WorkerToServerIpcMessage::ReadlineInput { text } => {
+                    WorkerToServerIpcMessage::ReadlineInputBytes { data_b64 } => {
+                        let bytes = match decode_sideband_base64(&data_b64, "readline_input_bytes")
+                        {
+                            Ok(bytes) => bytes,
+                            Err(err) => {
+                                let mut guard = reader_inbox.lock().unwrap();
+                                latch_protocol_error(&mut guard, err);
+                                reader_cvar.notify_all();
+                                break;
+                            }
+                        };
                         let mut guard = reader_inbox.lock().unwrap();
-                        if let Err(err) = account_active_stdin(&mut guard, &text, "readline_input")
+                        if let Err(err) =
+                            account_active_stdin(&mut guard, &bytes, "readline_input_bytes")
                         {
                             latch_protocol_error(&mut guard, err);
                             reader_cvar.notify_all();
@@ -425,10 +438,20 @@ impl ServerIpcConnection {
                         }
                         reader_cvar.notify_all();
                     }
-                    WorkerToServerIpcMessage::ReadlineDiscard { text } => {
+                    WorkerToServerIpcMessage::ReadlineDiscardBytes { data_b64 } => {
+                        let bytes =
+                            match decode_sideband_base64(&data_b64, "readline_discard_bytes") {
+                                Ok(bytes) => bytes,
+                                Err(err) => {
+                                    let mut guard = reader_inbox.lock().unwrap();
+                                    latch_protocol_error(&mut guard, err);
+                                    reader_cvar.notify_all();
+                                    break;
+                                }
+                            };
                         let mut guard = reader_inbox.lock().unwrap();
                         if let Err(err) =
-                            account_active_stdin(&mut guard, &text, "readline_discard")
+                            account_active_stdin(&mut guard, &bytes, "readline_discard_bytes")
                         {
                             latch_protocol_error(&mut guard, err);
                             reader_cvar.notify_all();
@@ -1708,18 +1731,18 @@ pub fn emit_readline_start(prompt: &str) {
     }
 }
 
-pub fn emit_readline_input(text: &str) {
+pub fn emit_readline_input_bytes(bytes: &[u8]) {
     if let Some(ipc) = global_ipc() {
-        let _ = ipc.send(WorkerToServerIpcMessage::ReadlineInput {
-            text: text.to_string(),
+        let _ = ipc.send(WorkerToServerIpcMessage::ReadlineInputBytes {
+            data_b64: base64::engine::general_purpose::STANDARD.encode(bytes),
         });
     }
 }
 
-pub fn emit_readline_discard(text: &str) {
+pub fn emit_readline_discard_bytes(bytes: &[u8]) {
     if let Some(ipc) = global_ipc() {
-        let _ = ipc.send(WorkerToServerIpcMessage::ReadlineDiscard {
-            text: text.to_string(),
+        let _ = ipc.send(WorkerToServerIpcMessage::ReadlineDiscardBytes {
+            data_b64: base64::engine::general_purpose::STANDARD.encode(bytes),
         });
     }
 }
@@ -1754,7 +1777,7 @@ pub fn emit_worker_ready(worker_name: &str, supports_images: bool) {
         let _ = ipc.send(WorkerToServerIpcMessage::WorkerReady {
             protocol: WorkerProtocol {
                 name: "mcp-repl-worker".to_string(),
-                version: 1,
+                version: WORKER_PROTOCOL_VERSION,
             },
             worker: WorkerIdentity {
                 name: worker_name.to_string(),
@@ -1831,16 +1854,15 @@ fn take_session_end(guard: &mut ServerIpcInbox) -> bool {
 
 fn account_active_stdin(
     guard: &mut ServerIpcInbox,
-    text: &str,
+    bytes: &[u8],
     event_type: &str,
 ) -> Result<(), String> {
     let Some(active_stdin) = guard.active_stdin.as_mut() else {
-        if text.is_empty() {
+        if bytes.is_empty() {
             return Ok(());
         }
         return Err(format!("{event_type} reported input with no active turn"));
     };
-    let bytes = text.as_bytes();
     if bytes.len() > active_stdin.len() {
         return Err(format!(
             "{event_type} reported {} bytes but only {} active stdin bytes remain",
@@ -1850,8 +1872,9 @@ fn account_active_stdin(
     }
     for (idx, expected) in bytes.iter().enumerate() {
         if active_stdin.get(idx) != Some(expected) {
+            let actual = active_stdin.get(idx).copied();
             return Err(format!(
-                "{event_type} text does not match active stdin at byte {idx}"
+                "{event_type} bytes does not match active stdin at byte {idx}: expected {actual:?}, got {expected}"
             ));
         }
     }
@@ -1859,6 +1882,12 @@ fn account_active_stdin(
         active_stdin.pop_front();
     }
     Ok(())
+}
+
+fn decode_sideband_base64(data_b64: &str, event_type: &str) -> Result<Vec<u8>, String> {
+    base64::engine::general_purpose::STANDARD
+        .decode(data_b64)
+        .map_err(|_| format!("invalid {event_type} base64"))
 }
 
 #[cfg_attr(target_family = "unix", allow(dead_code))]
@@ -2086,7 +2115,7 @@ mod protocol_tests {
     use super::{
         IpcHandlers, IpcTransport, IpcWaitError, OUTPUT_TEXT_IPC_CHUNK_BYTES,
         OutputCriticalIpcWriter, ServerIpcConnection, ServerToWorkerIpcMessage,
-        WorkerToServerIpcMessage, emit_readline_discard, emit_readline_input,
+        WorkerToServerIpcMessage, emit_readline_discard_bytes, emit_readline_input_bytes,
         test_connection_pair_with_handlers,
     };
     use crate::worker_protocol::TextStream;
@@ -2152,8 +2181,8 @@ mod protocol_tests {
 
     #[test]
     fn readline_accounting_emitters_are_platform_neutral_noops_without_global_ipc() {
-        emit_readline_input("answer\n");
-        emit_readline_discard("queued\n");
+        emit_readline_input_bytes(b"answer\n");
+        emit_readline_discard_bytes(b"queued\n");
     }
 
     #[test]
@@ -2383,10 +2412,10 @@ mod protocol_tests {
 
         server.begin_request_with_stdin(b"done\n");
         worker
-            .send(WorkerToServerIpcMessage::ReadlineInput {
-                text: "done\n".to_string(),
+            .send(WorkerToServerIpcMessage::ReadlineInputBytes {
+                data_b64: base64::engine::general_purpose::STANDARD.encode(b"done\n"),
             })
-            .expect("send readline_input");
+            .expect("send readline_input_bytes");
         worker
             .send(WorkerToServerIpcMessage::ReadlineResult {
                 prompt: "zod> ".to_string(),

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -91,6 +91,7 @@ pub enum ServerToWorkerIpcMessage {
     RequestStart,
     PythonRequestStart {
         request_generation: u64,
+        stdin_b64: String,
     },
     StdinWrite {
         byte_len: usize,
@@ -2292,13 +2293,15 @@ mod protocol_tests {
     fn python_request_generation_messages_are_server_to_worker_only() {
         let request_start = serde_json::to_value(ServerToWorkerIpcMessage::PythonRequestStart {
             request_generation: 7,
+            stdin_b64: base64::engine::general_purpose::STANDARD.encode(b"input\r\n"),
         })
         .expect("serialize python_request_start");
         assert_eq!(
             request_start,
             json!({
                 "type": "python_request_start",
-                "request_generation": 7
+                "request_generation": 7,
+                "stdin_b64": "aW5wdXQNCg=="
             })
         );
 

--- a/src/python_session.rs
+++ b/src/python_session.rs
@@ -1,3 +1,5 @@
+#[cfg(target_family = "unix")]
+use std::collections::VecDeque;
 use std::ffi::{CStr, CString, c_char, c_int, c_long};
 #[cfg(target_family = "unix")]
 use std::os::unix::io::RawFd;
@@ -332,14 +334,14 @@ pub(crate) fn mark_stdin_write_complete() {
 }
 
 pub(crate) fn mark_request_started() {
-    mark_request_started_with_generation(None);
+    mark_request_started_with_generation(None, Vec::new());
 }
 
-pub(crate) fn mark_request_started_for_generation(request_generation: u64) {
-    mark_request_started_with_generation(Some(request_generation));
+pub(crate) fn mark_request_started_for_generation(request_generation: u64, stdin_bytes: Vec<u8>) {
+    mark_request_started_with_generation(Some(request_generation), stdin_bytes);
 }
 
-fn mark_request_started_with_generation(request_generation: Option<u64>) {
+fn mark_request_started_with_generation(request_generation: Option<u64>, stdin_bytes: Vec<u8>) {
     let Some(state) = SESSION_STATE.get() else {
         return;
     };
@@ -364,6 +366,14 @@ fn mark_request_started_with_generation(request_generation: Option<u64>) {
     guard.interrupt_requested = false;
     guard.request_completed_at_stdin_wait = false;
     guard.request_active = true;
+    #[cfg(target_family = "unix")]
+    {
+        guard.protocol_stdin_bytes = stdin_bytes.into();
+    }
+    #[cfg(not(target_family = "unix"))]
+    {
+        let _ = stdin_bytes;
+    }
     guard.plot_reset_pending = true;
 }
 
@@ -404,6 +414,7 @@ fn discard_pending_stdin() {
     if discarded.is_empty() {
         return;
     }
+    let discarded = take_protocol_stdin_bytes_for_runtime_read(&discarded);
     ipc::emit_readline_discard_bytes(&discarded);
 }
 
@@ -505,7 +516,11 @@ fn runtime_stdin_pending_byte_count() -> Option<usize> {
 
 #[cfg(target_family = "unix")]
 fn protocol_request_input_exhausted() -> bool {
-    stdin_pending_byte_count() == Some(0)
+    let Some(state) = SESSION_STATE.get() else {
+        return stdin_pending_byte_count() == Some(0);
+    };
+    let guard = state.inner.lock().unwrap();
+    guard.protocol_stdin_bytes.is_empty()
 }
 
 #[cfg(windows)]
@@ -1631,9 +1646,10 @@ fn note_cpython_readline_bytes_read(bytes: &[u8]) {
     if bytes.is_empty() {
         return;
     }
-    emit_readline_input_bytes(bytes);
+    let protocol_bytes = take_protocol_stdin_bytes_for_runtime_read(bytes);
+    emit_readline_input_bytes(&protocol_bytes);
     mark_request_input_delivered();
-    note_active_stdin_line_read(bytes);
+    note_active_stdin_line_read(&protocol_bytes);
 }
 
 #[cfg(not(target_family = "unix"))]
@@ -1909,30 +1925,40 @@ fn note_stdin_bytes_read(bytes: &[u8]) {
     if bytes.is_empty() {
         return;
     }
-    let protocol_bytes = protocol_stdin_bytes(bytes);
+    let protocol_bytes = take_protocol_stdin_bytes_for_runtime_read(bytes);
     emit_readline_input_bytes(&protocol_bytes);
     mark_request_input_delivered();
     note_active_stdin_line_read(&protocol_bytes);
 }
 
 #[cfg(target_family = "unix")]
-fn protocol_stdin_bytes(bytes: &[u8]) -> Vec<u8> {
-    let mut normalized = Vec::with_capacity(bytes.len());
-    let mut index = 0;
-    while index < bytes.len() {
-        if bytes[index] == b'\r' {
-            normalized.push(b'\n');
-            if bytes.get(index + 1) == Some(&b'\n') {
-                index += 2;
-            } else {
-                index += 1;
-            }
+fn take_protocol_stdin_bytes_for_runtime_read(runtime_bytes: &[u8]) -> Vec<u8> {
+    let Some(state) = SESSION_STATE.get() else {
+        return runtime_bytes.to_vec();
+    };
+    let mut guard = state.inner.lock().unwrap();
+    if guard.protocol_stdin_bytes.is_empty() {
+        return runtime_bytes.to_vec();
+    }
+
+    let mut remaining = guard.protocol_stdin_bytes.clone();
+    let mut protocol_bytes = Vec::with_capacity(runtime_bytes.len());
+    for &runtime_byte in runtime_bytes {
+        let Some(original_byte) = remaining.pop_front() else {
+            return runtime_bytes.to_vec();
+        };
+        protocol_bytes.push(original_byte);
+        let normalized_byte = if original_byte == b'\r' {
+            b'\n'
         } else {
-            normalized.push(bytes[index]);
-            index += 1;
+            original_byte
+        };
+        if normalized_byte != runtime_byte {
+            return runtime_bytes.to_vec();
         }
     }
-    normalized
+    guard.protocol_stdin_bytes = remaining;
+    protocol_bytes
 }
 
 #[cfg(target_family = "unix")]
@@ -2080,6 +2106,8 @@ struct SessionStateInner {
     session_end_emitted: bool,
     plot_reset_pending: bool,
     interrupt_requested: bool,
+    #[cfg(target_family = "unix")]
+    protocol_stdin_bytes: VecDeque<u8>,
 }
 
 #[allow(dead_code)]
@@ -2115,6 +2143,8 @@ impl SessionState {
                 session_end_emitted: false,
                 plot_reset_pending: false,
                 interrupt_requested: false,
+                #[cfg(target_family = "unix")]
+                protocol_stdin_bytes: VecDeque::new(),
             }),
             cvar: Condvar::new(),
         }

--- a/src/python_session.rs
+++ b/src/python_session.rs
@@ -1941,12 +1941,12 @@ fn take_protocol_stdin_bytes_for_runtime_read(runtime_bytes: &[u8]) -> Vec<u8> {
         return runtime_bytes.to_vec();
     }
 
-    let mut remaining = guard.protocol_stdin_bytes.clone();
     let mut protocol_bytes = Vec::with_capacity(runtime_bytes.len());
-    for &runtime_byte in runtime_bytes {
-        let Some(original_byte) = remaining.pop_front() else {
-            return runtime_bytes.to_vec();
-        };
+    if guard.protocol_stdin_bytes.len() < runtime_bytes.len() {
+        return runtime_bytes.to_vec();
+    }
+
+    for (&original_byte, &runtime_byte) in guard.protocol_stdin_bytes.iter().zip(runtime_bytes) {
         protocol_bytes.push(original_byte);
         let normalized_byte = if original_byte == b'\r' {
             b'\n'
@@ -1957,7 +1957,7 @@ fn take_protocol_stdin_bytes_for_runtime_read(runtime_bytes: &[u8]) -> Vec<u8> {
             return runtime_bytes.to_vec();
         }
     }
-    guard.protocol_stdin_bytes = remaining;
+    guard.protocol_stdin_bytes.drain(..protocol_bytes.len());
     protocol_bytes
 }
 

--- a/src/python_session.rs
+++ b/src/python_session.rs
@@ -400,14 +400,11 @@ fn finish_active_request_at_next_read() {
 #[cfg(target_family = "unix")]
 fn discard_pending_stdin() {
     let mut discarded = Vec::new();
-    discarded.extend(PYTHON_DIRECT_STDIN_SIDEBAND_INPUT.lock().unwrap().drain(..));
     discarded.extend(drain_process_stdin_pipe());
     if discarded.is_empty() {
         return;
     }
-    let text =
-        String::from_utf8(discarded).expect("discarded Python stdin must be valid UTF-8 text");
-    ipc::emit_readline_discard(&text);
+    ipc::emit_readline_discard_bytes(&discarded);
 }
 
 #[cfg(target_family = "unix")]
@@ -508,11 +505,7 @@ fn runtime_stdin_pending_byte_count() -> Option<usize> {
 
 #[cfg(target_family = "unix")]
 fn protocol_request_input_exhausted() -> bool {
-    PYTHON_DIRECT_STDIN_SIDEBAND_INPUT
-        .lock()
-        .unwrap()
-        .is_empty()
-        && stdin_pending_byte_count() == Some(0)
+    stdin_pending_byte_count() == Some(0)
 }
 
 #[cfg(windows)]
@@ -1916,9 +1909,30 @@ fn note_stdin_bytes_read(bytes: &[u8]) {
     if bytes.is_empty() {
         return;
     }
-    emit_readline_input_bytes(bytes);
+    let protocol_bytes = protocol_stdin_bytes(bytes);
+    emit_readline_input_bytes(&protocol_bytes);
     mark_request_input_delivered();
-    note_active_stdin_line_read(bytes);
+    note_active_stdin_line_read(&protocol_bytes);
+}
+
+#[cfg(target_family = "unix")]
+fn protocol_stdin_bytes(bytes: &[u8]) -> Vec<u8> {
+    let mut normalized = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'\r' {
+            normalized.push(b'\n');
+            if bytes.get(index + 1) == Some(&b'\n') {
+                index += 2;
+            } else {
+                index += 1;
+            }
+        } else {
+            normalized.push(bytes[index]);
+            index += 1;
+        }
+    }
+    normalized
 }
 
 #[cfg(target_family = "unix")]
@@ -1945,29 +1959,7 @@ fn emit_readline_input_bytes(bytes: &[u8]) {
     if bytes.is_empty() {
         return;
     }
-    let mut pending = PYTHON_DIRECT_STDIN_SIDEBAND_INPUT.lock().unwrap();
-    pending.extend_from_slice(bytes);
-    loop {
-        match std::str::from_utf8(&pending) {
-            Ok(text) => {
-                if !text.is_empty() {
-                    ipc::emit_readline_input(text);
-                }
-                pending.clear();
-                return;
-            }
-            Err(err) => {
-                let valid_up_to = err.valid_up_to();
-                if valid_up_to == 0 {
-                    return;
-                }
-                let text = std::str::from_utf8(&pending[..valid_up_to])
-                    .expect("valid UTF-8 prefix should decode");
-                ipc::emit_readline_input(text);
-                pending.drain(..valid_up_to);
-            }
-        }
-    }
+    ipc::emit_readline_input_bytes(bytes);
 }
 
 #[cfg(not(target_family = "unix"))]
@@ -2442,8 +2434,6 @@ static PYTHON_STDIN_FILE: AtomicPtr<libc::FILE> = AtomicPtr::new(ptr::null_mut()
 static PYTHON_STDOUT_FILE: AtomicPtr<libc::FILE> = AtomicPtr::new(ptr::null_mut());
 #[cfg(target_family = "unix")]
 static PYTHON_RUNTIME_STDIN_FD: AtomicI32 = AtomicI32::new(-1);
-#[cfg(target_family = "unix")]
-static PYTHON_DIRECT_STDIN_SIDEBAND_INPUT: Mutex<Vec<u8>> = Mutex::new(Vec::new());
 
 #[cfg(test)]
 mod tests {

--- a/src/python_session.rs
+++ b/src/python_session.rs
@@ -1948,17 +1948,17 @@ fn take_protocol_stdin_bytes_for_runtime_read(runtime_bytes: &[u8]) -> Vec<u8> {
 
     for (&original_byte, &runtime_byte) in guard.protocol_stdin_bytes.iter().zip(runtime_bytes) {
         protocol_bytes.push(original_byte);
-        let normalized_byte = if original_byte == b'\r' {
-            b'\n'
-        } else {
-            original_byte
-        };
-        if normalized_byte != runtime_byte {
+        if !protocol_stdin_byte_matches_runtime(original_byte, runtime_byte) {
             return runtime_bytes.to_vec();
         }
     }
     guard.protocol_stdin_bytes.drain(..protocol_bytes.len());
     protocol_bytes
+}
+
+#[cfg(target_family = "unix")]
+fn protocol_stdin_byte_matches_runtime(protocol_byte: u8, runtime_byte: u8) -> bool {
+    protocol_byte == runtime_byte || (protocol_byte == b'\r' && runtime_byte == b'\n')
 }
 
 #[cfg(target_family = "unix")]
@@ -2561,6 +2561,15 @@ mod tests {
             &active,
             Some(PythonReadlineState::Primary)
         ));
+    }
+
+    #[cfg(target_family = "unix")]
+    #[test]
+    fn unix_protocol_stdin_matching_accepts_pty_normalized_and_raw_cr() {
+        assert!(protocol_stdin_byte_matches_runtime(b'\r', b'\n'));
+        assert!(protocol_stdin_byte_matches_runtime(b'\r', b'\r'));
+        assert!(protocol_stdin_byte_matches_runtime(b'\n', b'\n'));
+        assert!(!protocol_stdin_byte_matches_runtime(b'\n', b'\r'));
     }
 
     #[test]

--- a/src/python_worker.rs
+++ b/src/python_worker.rs
@@ -3,6 +3,8 @@ use std::sync::{Arc, mpsc};
 use std::thread;
 use std::time::Duration;
 
+use base64::Engine as _;
+
 use crate::ipc::{
     ServerToWorkerIpcMessage, connect_from_env, emit_python_interrupt_ack, emit_session_end,
     emit_stdin_write_ack, set_global_ipc,
@@ -88,8 +90,23 @@ fn init_ipc(
                         python_session::mark_request_started();
                         emit_stdin_write_ack();
                     }
-                    Some(ServerToWorkerIpcMessage::PythonRequestStart { request_generation }) => {
-                        python_session::mark_request_started_for_generation(request_generation);
+                    Some(ServerToWorkerIpcMessage::PythonRequestStart {
+                        request_generation,
+                        stdin_b64,
+                    }) => {
+                        let stdin_bytes =
+                            match base64::engine::general_purpose::STANDARD.decode(stdin_b64) {
+                                Ok(bytes) => bytes,
+                                Err(_) => {
+                                    emit_stderr_message("invalid python_request_start stdin_b64");
+                                    emit_session_end();
+                                    continue;
+                                }
+                            };
+                        python_session::mark_request_started_for_generation(
+                            request_generation,
+                            stdin_bytes,
+                        );
                         emit_stdin_write_ack();
                     }
                     Some(ServerToWorkerIpcMessage::StdinWrite {

--- a/src/r_session.rs
+++ b/src/r_session.rs
@@ -135,7 +135,7 @@ pub(crate) fn clear_pending_input() -> bool {
     let discarded = drain_input_queue(&mut guard.input_queue);
     drop(guard);
     if !discarded.is_empty() {
-        ipc::emit_readline_discard(&discarded);
+        ipc::emit_readline_discard_bytes(discarded.as_bytes());
     }
     had_pending
 }
@@ -996,7 +996,7 @@ pub extern "C-unwind" fn r_read_console(
                     *buf.add(head.len()) = 0;
                 }
             }
-            ipc::emit_readline_input(&line_text);
+            ipc::emit_readline_input_bytes(line_text.as_bytes());
             let mut echoed = String::with_capacity(prompt.len() + line_text.len());
             echoed.push_str(prompt);
             echoed.push_str(&line_text);

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -422,7 +422,9 @@ fn driver_refresh_backend_info(
     match ipc.wait_for_backend_info(timeout) {
         Ok(WorkerToServerIpcMessage::BackendInfo { .. }) => Ok(()),
         Ok(WorkerToServerIpcMessage::WorkerReady { protocol, .. }) => {
-            if protocol.name != "mcp-repl-worker" || protocol.version != 1 {
+            if protocol.name != "mcp-repl-worker"
+                || protocol.version != crate::ipc::WORKER_PROTOCOL_VERSION
+            {
                 return Err(WorkerError::Protocol(format!(
                     "unsupported worker protocol {} version {}",
                     protocol.name, protocol.version
@@ -458,7 +460,9 @@ fn driver_refresh_worker_ready(
 ) -> Result<(), WorkerError> {
     match ipc.wait_for_backend_info(timeout) {
         Ok(WorkerToServerIpcMessage::WorkerReady { protocol, .. }) => {
-            if protocol.name != "mcp-repl-worker" || protocol.version != 1 {
+            if protocol.name != "mcp-repl-worker"
+                || protocol.version != crate::ipc::WORKER_PROTOCOL_VERSION
+            {
                 return Err(WorkerError::Protocol(format!(
                     "unsupported worker protocol {} version {}",
                     protocol.name, protocol.version
@@ -7783,8 +7787,8 @@ mod tests {
             "did not expect buffered readline start to complete request, got {early:?}"
         );
 
-        let _ = worker.send(WorkerToServerIpcMessage::ReadlineInput {
-            text: "1+\n".to_string(),
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineInputBytes {
+            data_b64: base64::engine::general_purpose::STANDARD.encode(b"1+\n"),
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineResult {
             prompt: "> ".to_string(),
@@ -7801,8 +7805,8 @@ mod tests {
             "did not expect buffered continuation start to complete request, got {continuation:?}"
         );
 
-        let _ = worker.send(WorkerToServerIpcMessage::ReadlineInput {
-            text: "1\n".to_string(),
+        let _ = worker.send(WorkerToServerIpcMessage::ReadlineInputBytes {
+            data_b64: base64::engine::general_purpose::STANDARD.encode(b"1\n"),
         });
         let _ = worker.send(WorkerToServerIpcMessage::ReadlineResult {
             prompt: "+ ".to_string(),

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -1,3 +1,5 @@
+#[cfg(any(target_family = "unix", test))]
+use base64::Engine as _;
 #[cfg(all(test, target_family = "unix"))]
 use std::cell::RefCell;
 #[cfg(target_family = "unix")]
@@ -954,8 +956,11 @@ impl BackendDriver for ProtocolBackendDriver {
             // also lets a late interrupt avoid draining fd 0 after the next request
             // has started. Custom protocol workers do not receive this private
             // bridge message.
-            ipc.send(ServerToWorkerIpcMessage::PythonRequestStart { request_generation })
-                .map_err(WorkerError::Io)?;
+            ipc.send(ServerToWorkerIpcMessage::PythonRequestStart {
+                request_generation,
+                stdin_b64: base64::engine::general_purpose::STANDARD.encode(payload),
+            })
+            .map_err(WorkerError::Io)?;
             driver_wait_for_stdin_write_ack(ipc, timeout)?;
         }
         if let Some(message) = ipc.take_protocol_error() {
@@ -7195,7 +7200,6 @@ mod tests {
     use crate::sandbox::SandboxPolicy;
     #[cfg(target_os = "linux")]
     use crate::sandbox::sandbox_state_update_from_codex_meta;
-    use base64::Engine as _;
     #[cfg(target_os = "linux")]
     use serde_json::json;
     use std::sync::{Mutex, MutexGuard, OnceLock};

--- a/tests/claude_integration.rs
+++ b/tests/claude_integration.rs
@@ -666,6 +666,40 @@ fn assert_arg_pair(args: &[String], flag: &str, expected: &str) -> TestResult<()
     Err(format!("missing argument pair {flag} {expected} in {:?}", args).into())
 }
 
+#[test]
+fn extract_tool_call_rejects_unexpected_mcp_tools() {
+    let events = vec![serde_json::json!({
+        "message": {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "ToolSearch",
+                    "input": { "query": "mcp__r__repl" }
+                },
+                {
+                    "type": "tool_use",
+                    "name": "mcp__r__repl_reset",
+                    "input": {}
+                },
+                {
+                    "type": "tool_use",
+                    "name": "mcp__r__repl",
+                    "input": { "input": TOOL_INPUT }
+                }
+            ]
+        }
+    })];
+
+    let err = extract_tool_call(&events)
+        .expect_err("expected unexpected MCP tool uses to fail the Claude contract");
+
+    assert!(
+        err.to_string()
+            .contains("unexpected Claude tool call: mcp__r__repl_reset"),
+        "unexpected error: {err}"
+    );
+}
+
 fn stage_bedrock_env(
     temp_home: &Path,
     host_settings_env: &std::collections::BTreeMap<String, String>,
@@ -844,8 +878,11 @@ fn extract_tool_call(events: &[JsonValue]) -> TestResult<ClaudeToolCallSnapshot>
                 .and_then(JsonValue::as_str)
                 .ok_or_else(|| "Claude tool_use missing name".to_string())?
                 .to_string();
-            if name != "mcp__r__repl" {
+            if name == "ToolSearch" {
                 continue;
+            }
+            if name != "mcp__r__repl" {
+                return Err(format!("unexpected Claude tool call: {name}").into());
             }
             let input = content
                 .get("input")

--- a/tests/claude_integration.rs
+++ b/tests/claude_integration.rs
@@ -95,6 +95,8 @@ struct ClaudeMcpServerSnapshot {
 
 #[derive(Debug, Serialize)]
 struct ClaudeToolCallSnapshot {
+    #[serde(skip_serializing)]
+    id: String,
     name: String,
     input: String,
 }
@@ -673,16 +675,19 @@ fn extract_tool_call_rejects_unexpected_mcp_tools() {
             "content": [
                 {
                     "type": "tool_use",
+                    "id": "toolu_search",
                     "name": "ToolSearch",
                     "input": { "query": "mcp__r__repl" }
                 },
                 {
                     "type": "tool_use",
+                    "id": "toolu_reset",
                     "name": "mcp__r__repl_reset",
                     "input": {}
                 },
                 {
                     "type": "tool_use",
+                    "id": "toolu_repl",
                     "name": "mcp__r__repl",
                     "input": { "input": TOOL_INPUT }
                 }
@@ -698,6 +703,88 @@ fn extract_tool_call_rejects_unexpected_mcp_tools() {
             .contains("unexpected Claude tool call: mcp__r__repl_reset"),
         "unexpected error: {err}"
     );
+}
+
+#[test]
+fn parse_snapshot_skips_tool_search_tool_results() -> TestResult<()> {
+    let events = serde_json::json!([
+        {
+            "type": "system",
+            "cwd": "/tmp/claude-workspace",
+            "tools": ["ToolSearch", "mcp__r__repl"],
+            "mcp_servers": [
+                { "name": "r", "status": "connected" }
+            ],
+            "model": CLAUDE_MODEL,
+            "permissionMode": CLAUDE_PERMISSION_MODE
+        },
+        {
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_search",
+                        "name": "ToolSearch",
+                        "input": { "query": "mcp__r__repl" }
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_repl",
+                        "name": "mcp__r__repl",
+                        "input": { "input": TOOL_INPUT }
+                    }
+                ]
+            }
+        },
+        {
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_search",
+                        "content": [
+                            { "type": "text", "text": "ToolSearch found mcp__r__repl\n" }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_repl",
+                        "content": [
+                            { "type": "text", "text": "CLAUDE_MCP_OK\n" }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "message": {
+                "content": [
+                    { "type": "text", "text": FINAL_RESULT }
+                ]
+            }
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": false,
+            "result": FINAL_RESULT,
+            "stop_reason": "end_turn",
+            "permission_denials": []
+        }
+    ]);
+    let stdout = serde_json::to_string(&events)?;
+
+    let snapshot = parse_snapshot(&stdout, Path::new("/tmp/claude-workspace"))?
+        .expect("expected Claude snapshot");
+
+    assert_eq!(snapshot.tool_result, "CLAUDE_MCP_OK\n");
+    Ok(())
 }
 
 fn stage_bedrock_env(
@@ -828,7 +915,7 @@ fn parse_snapshot(stdout: &str, workspace: &Path) -> TestResult<Option<ClaudeSna
     };
 
     let tool_call = extract_tool_call(&events)?;
-    let tool_result = extract_tool_result(&events)?;
+    let tool_result = extract_tool_result(&events, &tool_call.id)?;
     let final_text = normalize_done_text(&extract_final_text(&events)?);
     let result = extract_result(&events)?;
 
@@ -884,6 +971,11 @@ fn extract_tool_call(events: &[JsonValue]) -> TestResult<ClaudeToolCallSnapshot>
             if name != "mcp__r__repl" {
                 return Err(format!("unexpected Claude tool call: {name}").into());
             }
+            let id = content
+                .get("id")
+                .and_then(JsonValue::as_str)
+                .ok_or_else(|| "Claude mcp__r__repl tool_use missing id".to_string())?
+                .to_string();
             let input = content
                 .get("input")
                 .and_then(JsonValue::as_object)
@@ -891,7 +983,7 @@ fn extract_tool_call(events: &[JsonValue]) -> TestResult<ClaudeToolCallSnapshot>
                 .and_then(JsonValue::as_str)
                 .ok_or_else(|| "Claude tool_use missing input.input".to_string())?
                 .to_string();
-            calls.push(ClaudeToolCallSnapshot { name, input });
+            calls.push(ClaudeToolCallSnapshot { id, name, input });
         }
     }
 
@@ -902,42 +994,77 @@ fn extract_tool_call(events: &[JsonValue]) -> TestResult<ClaudeToolCallSnapshot>
     }
 }
 
-fn extract_tool_result(events: &[JsonValue]) -> TestResult<String> {
+fn extract_tool_result(events: &[JsonValue], tool_use_id: &str) -> TestResult<String> {
     for event in events {
-        if let Some(contents) = event
-            .get("tool_use_result")
-            .and_then(JsonValue::as_array)
-            .or_else(|| {
-                event
-                    .get("message")
-                    .and_then(JsonValue::as_object)
-                    .and_then(|message| message.get("content"))
-                    .and_then(JsonValue::as_array)
-                    .and_then(|contents| {
-                        contents.iter().find_map(|content| {
-                            content
-                                .get("content")
-                                .and_then(JsonValue::as_array)
-                                .filter(|_| {
-                                    content.get("type").and_then(JsonValue::as_str)
-                                        == Some("tool_result")
-                                })
-                        })
-                    })
-            })
+        if event_tool_use_result_matches(event, tool_use_id)
+            && let Some(contents) = event.get("tool_use_result").and_then(JsonValue::as_array)
+            && let Some(text) = tool_result_text(contents)
         {
-            let text = contents
-                .iter()
-                .filter_map(|item| item.get("text").and_then(JsonValue::as_str))
-                .filter(|text| *text != "> ")
-                .collect::<String>();
-            if !text.is_empty() {
+            return Ok(text);
+        }
+
+        let Some(contents) = event
+            .get("message")
+            .and_then(JsonValue::as_object)
+            .and_then(|message| message.get("content"))
+            .and_then(JsonValue::as_array)
+        else {
+            continue;
+        };
+
+        for content in contents {
+            if content.get("type").and_then(JsonValue::as_str) != Some("tool_result") {
+                continue;
+            }
+            if content.get("tool_use_id").and_then(JsonValue::as_str) != Some(tool_use_id) {
+                continue;
+            }
+            let result_contents = content
+                .get("content")
+                .and_then(JsonValue::as_array)
+                .ok_or_else(|| "Claude mcp__r__repl tool_result missing content".to_string())?;
+            if let Some(text) = tool_result_text(result_contents) {
                 return Ok(text);
             }
         }
     }
 
-    Err("Claude output did not contain a tool result".into())
+    Err("Claude output did not contain an mcp__r__repl tool result".into())
+}
+
+fn event_tool_use_result_matches(event: &JsonValue, tool_use_id: &str) -> bool {
+    if event
+        .get("tool_use_result")
+        .and_then(JsonValue::as_array)
+        .is_none()
+    {
+        return false;
+    }
+    if event.get("tool_use_id").and_then(JsonValue::as_str) == Some(tool_use_id) {
+        return true;
+    }
+
+    event
+        .get("message")
+        .and_then(JsonValue::as_object)
+        .and_then(|message| message.get("content"))
+        .and_then(JsonValue::as_array)
+        .is_some_and(|contents| {
+            contents.iter().any(|content| {
+                content.get("type").and_then(JsonValue::as_str) == Some("tool_use")
+                    && content.get("id").and_then(JsonValue::as_str) == Some(tool_use_id)
+            })
+        })
+}
+
+fn tool_result_text(contents: &[JsonValue]) -> Option<String> {
+    let text = contents
+        .iter()
+        .filter_map(|item| item.get("text").and_then(JsonValue::as_str))
+        .filter(|text| *text != "> ")
+        .collect::<String>();
+
+    (!text.is_empty()).then_some(text)
 }
 
 fn extract_final_text(events: &[JsonValue]) -> TestResult<String> {

--- a/tests/claude_integration.rs
+++ b/tests/claude_integration.rs
@@ -197,8 +197,6 @@ fn run_claude_snapshot(staged: &StagedClaudeEnv) -> TestResult<ClaudeSnapshot> {
     cmd.arg(CLAUDE_PERMISSION_MODE);
     cmd.arg("--output-format");
     cmd.arg("json");
-    cmd.arg("--tools");
-    cmd.arg("");
 
     let output = run_command_with_timeout(cmd, CLAUDE_PROMPT, CLAUDE_TIMEOUT)?;
     let stdout = String::from_utf8(output.stdout)
@@ -214,7 +212,8 @@ fn run_claude_snapshot(staged: &StagedClaudeEnv) -> TestResult<ClaudeSnapshot> {
         .into());
     }
 
-    parse_snapshot(stdout.trim(), &staged.workspace)?
+    parse_snapshot(stdout.trim(), &staged.workspace)
+        .map_err(|err| format!("{err}\nstdout:\n{stdout}\nstderr:\n{stderr}"))?
         .ok_or_else(|| "Claude snapshot unexpectedly missing".into())
 }
 
@@ -751,6 +750,7 @@ fn parse_snapshot(stdout: &str, workspace: &Path) -> TestResult<Option<ClaudeSna
         .ok_or_else(|| "Claude init event missing tools".to_string())?
         .iter()
         .filter_map(JsonValue::as_str)
+        .filter(|tool| tool.starts_with("mcp__r__") || *tool == "ToolSearch")
         .map(ToOwned::to_owned)
         .collect::<Vec<_>>();
     tools.sort();
@@ -844,6 +844,9 @@ fn extract_tool_call(events: &[JsonValue]) -> TestResult<ClaudeToolCallSnapshot>
                 .and_then(JsonValue::as_str)
                 .ok_or_else(|| "Claude tool_use missing name".to_string())?
                 .to_string();
+            if name != "mcp__r__repl" {
+                continue;
+            }
             let input = content
                 .get("input")
                 .and_then(JsonValue::as_object)
@@ -1006,7 +1009,7 @@ fn render_transcript(snapshot: &ClaudeSnapshot) -> String {
 }
 
 fn snapshot_command() -> String {
-    "$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json --tools \"\"".to_string()
+    "$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json".to_string()
 }
 
 fn normalize_workspace_path(path: &str, workspace: &Path) -> String {

--- a/tests/codex_integration.rs
+++ b/tests/codex_integration.rs
@@ -2038,6 +2038,18 @@ tryCatch({
                         path.push(normalized_key.clone());
                         normalize_inner(&mut child, path, workspace, codex_home);
                         path.pop();
+                        if path_matches(path, &["sandboxPolicy"])
+                            && normalized_key == "writable_roots"
+                            && matches!(
+                                &child,
+                                Value::Array(items)
+                                    if items.iter().all(|item| {
+                                        item.as_str() == Some("<CODEX_HOME>/memories")
+                                    })
+                            )
+                        {
+                            continue;
+                        }
                         map.insert(normalized_key, child);
                     }
                     if path_matches(path, &["capabilities", "elicitation"]) && map.is_empty() {
@@ -2186,6 +2198,33 @@ tryCatch({
                 }
             }),
             "wire snapshots should normalize Codex elicitation capability shape"
+        );
+    }
+
+    #[test]
+    fn normalize_wire_snapshot_drops_default_codex_memories_writable_root() {
+        let workspace = std::env::temp_dir().join("mcp-repl-wire-workspace");
+        let codex_home = std::env::temp_dir().join("mcp-repl-wire-codex-home");
+        let memories = codex_home.join("memories");
+        let mut value = serde_json::json!({
+            "sandboxPolicy": {
+                "type": "workspace-write",
+                "writable_roots": [memories],
+                "network_access": false
+            }
+        });
+
+        normalize_wire_snapshot_value(&mut value, &workspace, &codex_home);
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "sandboxPolicy": {
+                    "type": "workspace-write",
+                    "network_access": false
+                }
+            }),
+            "wire snapshots should not retain Codex's default memories writable root"
         );
     }
 
@@ -2794,13 +2833,9 @@ tryCatch({
 
     fn split_legacy_tool_name(legacy_tool_name: &str) -> Option<(&str, &str)> {
         let split = legacy_tool_name.rfind("__")?;
-        let namespace_end = split + 2;
-        (namespace_end < legacy_tool_name.len()).then(|| {
-            (
-                &legacy_tool_name[..namespace_end],
-                &legacy_tool_name[namespace_end..],
-            )
-        })
+        let name_start = split + 2;
+        (split > 0 && name_start < legacy_tool_name.len())
+            .then(|| (&legacy_tool_name[..split], &legacy_tool_name[name_start..]))
     }
 
     fn message_item(text: &str) -> Value {
@@ -2930,7 +2965,7 @@ tryCatch({
         let request = serde_json::json!({
             "tools": [{
                 "type": "namespace",
-                "name": "mcp__r__",
+                "name": "mcp__r",
                 "tools": [{
                     "type": "function",
                     "name": "repl",
@@ -2941,7 +2976,7 @@ tryCatch({
             resolve_tool_call_spec(&request, "mcp__r__repl"),
             Some(MockToolCallSpec {
                 name: "repl".to_string(),
-                namespace: Some("mcp__r__".to_string()),
+                namespace: Some("mcp__r".to_string()),
             })
         );
     }

--- a/tests/codex_integration.rs
+++ b/tests/codex_integration.rs
@@ -2044,7 +2044,11 @@ tryCatch({
                                 &child,
                                 Value::Array(items)
                                     if items.iter().all(|item| {
-                                        item.as_str() == Some("<CODEX_HOME>/memories")
+                                        matches!(
+                                            item.as_str(),
+                                            Some("<CODEX_HOME>/memories")
+                                                | Some("<CODEX_HOME>\\memories")
+                                        )
                                     })
                             )
                         {
@@ -2225,6 +2229,32 @@ tryCatch({
                 }
             }),
             "wire snapshots should not retain Codex's default memories writable root"
+        );
+    }
+
+    #[test]
+    fn normalize_wire_snapshot_drops_windows_default_codex_memories_writable_root() {
+        let workspace = std::env::temp_dir().join("mcp-repl-wire-workspace");
+        let codex_home = std::env::temp_dir().join("mcp-repl-wire-codex-home");
+        let mut value = serde_json::json!({
+            "sandboxPolicy": {
+                "type": "workspace-write",
+                "writable_roots": ["<CODEX_HOME>\\memories"],
+                "network_access": false
+            }
+        });
+
+        normalize_wire_snapshot_value(&mut value, &workspace, &codex_home);
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "sandboxPolicy": {
+                    "type": "workspace-write",
+                    "network_access": false
+                }
+            }),
+            "wire snapshots should not retain Codex's default memories writable root with Windows separators"
         );
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1571,6 +1571,8 @@ pub async fn spawn_server_with_args_env_and_cwd(
         cmd.env_remove("R_ENVIRON");
         cmd.env_remove("R_ENVIRON_USER");
         cmd.env_remove("MCP_REPL_UPDATE_PLOT_IMAGES");
+        cmd.env("PAGER", "cat");
+        cmd.env("MANPAGER", "cat");
         if let Some(cwd) = &current_dir {
             cmd.current_dir(cwd);
         }

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     writer.send(&WorkerToServer::WorkerReady {
         protocol: Protocol {
             name: "mcp-repl-worker".to_string(),
-            version: 1,
+            version: 2,
         },
         worker: WorkerIdentity {
             name: "zod".to_string(),
@@ -95,12 +95,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let command = line.trim_end_matches(['\r', '\n']);
         let reported_input = if let Some(text) = command.strip_prefix("misreport-input ") {
-            format!("{text}\n")
+            format!("{text}\n").into_bytes()
         } else {
-            line.clone()
+            line.as_bytes().to_vec()
         };
-        writer.send(&WorkerToServer::ReadlineInput {
-            text: reported_input,
+        writer.send(&WorkerToServer::ReadlineInputBytes {
+            data_b64: base64::engine::general_purpose::STANDARD.encode(reported_input),
         })?;
         timeline.run(LifecyclePoint::AfterReadlineInput, &writer)?;
         if command == "exit" {
@@ -205,6 +205,16 @@ fn run_command(
         return Ok(());
     }
 
+    if command == "old-readline-input" {
+        writer.send_raw_json(r#"{"type":"readline_input","text":"old\n"}"#)?;
+        return Ok(());
+    }
+
+    if command == "old-readline-discard" {
+        writer.send_raw_json(r#"{"type":"readline_discard","text":"old\n"}"#)?;
+        return Ok(());
+    }
+
     if let Some(millis) = command.strip_prefix("interruptible ") {
         sleep_for(parse_millis(millis)?, sideband_interrupted, true);
         return Ok(());
@@ -253,6 +263,30 @@ fn run_command(
                 format!("user-stdin:{}", user_line.trim_end_matches(['\r', '\n'])).as_str(),
             )?;
         }
+        return Ok(());
+    }
+
+    if command == "read-split-utf8-tail" {
+        let mut consumed = Vec::new();
+        for _ in 0..2 {
+            let mut byte = [0u8; 1];
+            reader.read_exact(&mut byte)?;
+            consumed.extend_from_slice(&byte);
+            writer.send(&WorkerToServer::ReadlineInputBytes {
+                data_b64: base64::engine::general_purpose::STANDARD.encode(byte),
+            })?;
+        }
+        let mut rest = Vec::new();
+        reader.read_until(b'\n', &mut rest)?;
+        if !rest.is_empty() {
+            writer.send(&WorkerToServer::ReadlineInputBytes {
+                data_b64: base64::engine::general_purpose::STANDARD.encode(&rest),
+            })?;
+        }
+        writer.output_text(
+            "stdout",
+            format!("split-tail bytes: {consumed:?}\n").as_bytes(),
+        )?;
         return Ok(());
     }
 
@@ -349,7 +383,9 @@ fn discard_buffered_stdin(reader: &mut dyn BufRead, writer: &IpcWriter) -> io::R
         return Ok(());
     }
     reader.consume(len);
-    writer.send(&WorkerToServer::ReadlineDiscard { text })
+    writer.send(&WorkerToServer::ReadlineDiscardBytes {
+        data_b64: base64::engine::general_purpose::STANDARD.encode(text.as_bytes()),
+    })
 }
 
 fn escape_bytes(bytes: &[u8]) -> String {
@@ -636,11 +672,11 @@ enum WorkerToServer {
     ReadlineStart {
         prompt: String,
     },
-    ReadlineInput {
-        text: String,
+    ReadlineInputBytes {
+        data_b64: String,
     },
-    ReadlineDiscard {
-        text: String,
+    ReadlineDiscardBytes {
+        data_b64: String,
     },
     OutputText {
         stream: String,

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -252,6 +252,18 @@ fn run_command(
         return Ok(());
     }
 
+    if let Some(millis) = command.strip_prefix("read-one-byte-then-discard-on-interrupt ") {
+        let mut byte = [0u8; 1];
+        reader.read_exact(&mut byte)?;
+        writer.send(&WorkerToServer::ReadlineInputBytes {
+            data_b64: base64::engine::general_purpose::STANDARD.encode(byte),
+        })?;
+        if sleep_for(parse_millis(millis)?, sideband_interrupted, true) {
+            discard_buffered_stdin(reader, writer)?;
+        }
+        return Ok(());
+    }
+
     if command == "read-user-stdin" {
         let mut user_line = String::new();
         let bytes = reader.read_line(&mut user_line)?;
@@ -372,19 +384,17 @@ fn apply_shutdown_mode(path: Option<&Path>, mode: ShutdownMode) -> io::Result<()
 }
 
 fn discard_buffered_stdin(reader: &mut dyn BufRead, writer: &IpcWriter) -> io::Result<()> {
-    let (text, len) = {
+    let bytes = {
         let buffer = reader.fill_buf()?;
-        let text = std::str::from_utf8(buffer)
-            .map_err(io::Error::other)?
-            .to_string();
-        (text, buffer.len())
+        buffer.to_vec()
     };
+    let len = bytes.len();
     if len == 0 {
         return Ok(());
     }
     reader.consume(len);
     writer.send(&WorkerToServer::ReadlineDiscardBytes {
-        data_b64: base64::engine::general_purpose::STANDARD.encode(text.as_bytes()),
+        data_b64: base64::engine::general_purpose::STANDARD.encode(bytes),
     })
 }
 

--- a/tests/plot_images.rs
+++ b/tests/plot_images.rs
@@ -1536,10 +1536,6 @@ cat("TAIL_ONLY\n")
         !final_text.contains("<<repl status: busy"),
         "expected timeout text-only follow-up poll to finish, got: {final_text:?}"
     );
-    assert!(
-        events_log_path(&final_text).is_some(),
-        "expected output bundle disclosure in final timeout poll, got: {final_text:?}"
-    );
     let events_log = events_log_path(&bundled_text)
         .or_else(|| events_log_path(&final_text))
         .unwrap_or_else(|| {

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -2415,6 +2415,66 @@ async fn python_input_roundtrip() -> TestResult<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn python_input_accepts_crlf_buffered_line() -> TestResult<()> {
+    let _guard = lock_test_mutex();
+    let Some(session) = start_python_session().await? else {
+        return Ok(());
+    };
+
+    let mut prompt_text = result_text(
+        &session
+            .write_stdin_raw_with("x = input('p> ')", Some(1.0))
+            .await?,
+    );
+    if is_busy_response(&prompt_text) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline && is_busy_response(&prompt_text) {
+            sleep(Duration::from_millis(50)).await;
+            prompt_text = result_text(&session.write_stdin_raw_with("", Some(1.0)).await?);
+        }
+    }
+    if is_busy_response(&prompt_text) {
+        eprintln!("python_input_accepts_crlf_buffered_line remained busy before prompt; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert!(
+        prompt_text.contains("p> "),
+        "expected input prompt before CRLF answer, got: {prompt_text:?}"
+    );
+
+    let result = session
+        .write_stdin_raw_with("hello\r\nprint('got', x)\r\n", Some(5.0))
+        .await?;
+    let mut text = result_text(&result);
+    if is_busy_response(&text) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline && is_busy_response(&text) && !text.contains("got hello") {
+            sleep(Duration::from_millis(50)).await;
+            text = result_text(&session.write_stdin_raw_with("", Some(1.0)).await?);
+        }
+    }
+    if is_busy_response(&text) {
+        eprintln!("python_input_accepts_crlf_buffered_line remained busy after answer; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+
+    session.cancel().await?;
+
+    assert!(
+        !text.contains("worker protocol error"),
+        "expected CRLF input to be accounted without protocol errors, got: {text:?}"
+    );
+    assert!(
+        text.contains("got hello"),
+        "expected input() to consume buffered CRLF line, got: {text:?}"
+    );
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn python_original_stdout_flushes_before_input_prompt() -> TestResult<()> {
     let _guard = lock_test_mutex();

--- a/tests/r_startup.rs
+++ b/tests/r_startup.rs
@@ -105,3 +105,35 @@ cat("RENVIRON=", Sys.getenv("MCP_REPL_RENVIRON_TEST"), "\n", sep = "")
     session.cancel().await?;
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_server_spawns_with_plain_pager_env() -> TestResult<()> {
+    let session = common::spawn_server_with_files().await?;
+
+    let result = session
+        .write_stdin_raw_with(
+            r#"
+cat("PAGER=", Sys.getenv("PAGER"), "\n", sep = "")
+cat("MANPAGER=", Sys.getenv("MANPAGER"), "\n", sep = "")
+"#,
+            Some(10.0),
+        )
+        .await?;
+    let text = result_text(&result);
+    if backend_unavailable(&text) {
+        eprintln!("r_startup backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert!(
+        text.contains("PAGER=cat"),
+        "expected PAGER=cat in test server environment, got: {text:?}"
+    );
+    assert!(
+        text.contains("MANPAGER=cat"),
+        "expected MANPAGER=cat in test server environment, got: {text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}

--- a/tests/reticulate_py_help.rs
+++ b/tests/reticulate_py_help.rs
@@ -3,6 +3,11 @@ mod common;
 use common::TestResult;
 use rmcp::model::RawContent;
 
+const REPL_STARTUP_TIMEOUT_SECS: f64 = 30.0;
+const RETICULATE_INIT_TIMEOUT_SECS: f64 = 30.0;
+const PY_HELP_TIMEOUT_SECS: f64 = 5.0;
+const RETICULATE_READY_MARKER: &str = "[repl] reticulate python ready";
+
 fn result_text(result: &rmcp::model::CallToolResult) -> String {
     result
         .content
@@ -21,6 +26,13 @@ fn should_skip_reticulate_py_help_output(text: &str) -> bool {
         || text.trim() == ">"
 }
 
+fn assert_not_busy(label: &str, text: &str) -> TestResult<()> {
+    if common::is_busy_response(text) {
+        return Err(format!("{label} exceeded its timeout budget: {text:?}").into());
+    }
+    Ok(())
+}
+
 #[test]
 fn prompt_only_reticulate_output_is_skipped() {
     assert!(should_skip_reticulate_py_help_output(">"));
@@ -30,7 +42,22 @@ fn prompt_only_reticulate_output_is_skipped() {
 async fn reticulate_py_help_is_rendered() -> TestResult<()> {
     let session = common::spawn_server_with_files().await?;
 
-    let result = session
+    let startup = session
+        .write_stdin_raw_with("1+1", Some(REPL_STARTUP_TIMEOUT_SECS))
+        .await?;
+    let startup_text = result_text(&startup);
+    if common::backend_unavailable(&startup_text) {
+        eprintln!("reticulate_py_help backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert_not_busy("R startup", &startup_text)?;
+    assert!(
+        startup_text.contains("[1] 2"),
+        "expected R startup smoke output, got: {startup_text:?}"
+    );
+
+    let setup = session
         .write_stdin_raw_with(
             r#"
 {
@@ -39,22 +66,56 @@ async fn reticulate_py_help_is_rendered() -> TestResult<()> {
     invisible(NULL)
   } else {
     ok <- TRUE
-    tryCatch({ reticulate::py_config() }, error = function(e) { ok <<- FALSE })
+    tryCatch({
+      reticulate::py_config()
+      assign(
+        ".mcp_repl_reticulate_builtins",
+        reticulate::import_builtins(),
+        envir = .GlobalEnv
+      )
+    }, error = function(e) { ok <<- FALSE })
     if (!ok) {
       cat("[repl] reticulate python unavailable\n")
       invisible(NULL)
     } else {
-      builtins <- reticulate::import_builtins()
-      reticulate::py_help(builtins$len)
+      cat("[repl] reticulate python ready\n")
       invisible(NULL)
     }
   }
 }
 "#,
-            Some(60.0),
+            Some(RETICULATE_INIT_TIMEOUT_SECS),
+        )
+        .await?;
+    let setup_text = result_text(&setup);
+    assert_not_busy("reticulate Python initialization", &setup_text)?;
+    if should_skip_reticulate_py_help_output(&setup_text) {
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert!(
+        setup_text.contains(RETICULATE_READY_MARKER),
+        "expected reticulate Python initialization marker, got: {setup_text:?}"
+    );
+
+    let result = session
+        .write_stdin_raw_with(
+            "reticulate::py_help(.mcp_repl_reticulate_builtins$len); invisible(NULL)",
+            Some(PY_HELP_TIMEOUT_SECS),
         )
         .await?;
     let text = result_text(&result);
+    if common::is_busy_response(&text) {
+        session.cancel().await?;
+        if cfg!(windows) {
+            eprintln!("reticulate::py_help() exceeded its short Windows budget; skipping");
+            return Ok(());
+        }
+        return Err(format!(
+            "reticulate::py_help() exceeded its {PY_HELP_TIMEOUT_SECS}s timeout budget: {text:?}"
+        )
+        .into());
+    }
 
     if should_skip_reticulate_py_help_output(&text) {
         session.cancel().await?;

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -41,6 +41,22 @@ def collect_stdout(stream: Any, sink: queue.Queue[bytes | None]) -> None:
     sink.put(None)
 
 
+def server_process_env(server_env: Sequence[tuple[str, str]]) -> dict[str, str]:
+    env = os.environ.copy()
+    for key in [
+        "R_PROFILE_USER",
+        "R_PROFILE_SITE",
+        "R_ENVIRON",
+        "R_ENVIRON_USER",
+        "MCP_REPL_UPDATE_PLOT_IMAGES",
+    ]:
+        env.pop(key, None)
+    env["PAGER"] = "cat"
+    env["MANPAGER"] = "cat"
+    env.update(server_env)
+    return env
+
+
 class McpStdioClient:
     def __init__(
         self,
@@ -65,24 +81,13 @@ class McpStdioClient:
         if not self.binary.is_file():
             raise SuiteFailure(f"binary does not exist: {self.binary}")
 
-        env = os.environ.copy()
-        for key in [
-            "R_PROFILE_USER",
-            "R_PROFILE_SITE",
-            "R_ENVIRON",
-            "R_ENVIRON_USER",
-            "MCP_REPL_UPDATE_PLOT_IMAGES",
-        ]:
-            env.pop(key, None)
-        env.update(self.server_env)
-
         command = [str(self.binary), *self.server_args]
         self.process = subprocess.Popen(
             command,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            env=env,
+            env=server_process_env(tuple(self.server_env.items())),
         )
         assert self.process.stdout is not None
         assert self.process.stderr is not None
@@ -881,11 +886,22 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def resolve_binary_path(path: Path) -> Path:
+    if path.is_file():
+        return path
+    if sys.platform == "win32" and path.suffix == "":
+        exe_path = path.with_name(f"{path.name}.exe")
+        if exe_path.is_file():
+            return exe_path
+    return path
+
+
 def main(argv: Sequence[str]) -> int:
     args = parse_args(argv)
     if args.timeout <= 0:
         print("--timeout must be positive", file=sys.stderr)
         return 2
+    binary = resolve_binary_path(args.binary)
 
     selected = args.case or sorted(CASES)
     failures = 0
@@ -893,7 +909,7 @@ def main(argv: Sequence[str]) -> int:
         case = CASES[case_name]
         try:
             with McpStdioClient(
-                args.binary,
+                binary,
                 ["--sandbox", args.sandbox, *case.server_args],
                 case.server_env,
                 args.timeout,

--- a/tests/snapshots/claude_integration__claude_live_install_integration.snap
+++ b/tests/snapshots/claude_integration__claude_live_install_integration.snap
@@ -3,18 +3,17 @@ source: tests/claude_integration.rs
 expression: rendered
 ---
 {
-  "command": "$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json --tools \"\"",
+  "command": "$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json",
   "prompt": "Use the mcp__r__repl tool exactly once. Send this exact R code: cat(\"CLAUDE_MCP_OK\\n\") Then answer with exactly DONE, with no punctuation or extra text.",
   "init": {
     "cwd": "<WORKSPACE>",
     "tools": [
-      "mcp__r__repl",
-      "mcp__r__repl_reset"
+      "ToolSearch"
     ],
     "mcp_servers": [
       {
         "name": "r",
-        "status": "connected"
+        "status": "pending"
       }
     ],
     "model": "haiku",

--- a/tests/snapshots/claude_integration__claude_live_install_integration@transcript.snap
+++ b/tests/snapshots/claude_integration__claude_live_install_integration@transcript.snap
@@ -2,14 +2,14 @@
 source: tests/claude_integration.rs
 expression: transcript
 ---
-$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json --tools ""
+$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json
 stdin:
 Use the mcp__r__repl tool exactly once. Send this exact R code: cat("CLAUDE_MCP_OK\n") Then answer with exactly DONE, with no punctuation or extra text.
 
 init:
 cwd: <WORKSPACE>
-tools: mcp__r__repl, mcp__r__repl_reset
-mcp_server: r (connected)
+tools: ToolSearch
+mcp_server: r (pending)
 model: haiku
 permission_mode: dontAsk
 

--- a/tests/snapshots/claude_integration__claude_live_integration.snap
+++ b/tests/snapshots/claude_integration__claude_live_integration.snap
@@ -3,18 +3,17 @@ source: tests/claude_integration.rs
 expression: rendered
 ---
 {
-  "command": "$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json --tools \"\"",
+  "command": "$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json",
   "prompt": "Use the mcp__r__repl tool exactly once. Send this exact R code: cat(\"CLAUDE_MCP_OK\\n\") Then answer with exactly DONE, with no punctuation or extra text.",
   "init": {
     "cwd": "<WORKSPACE>",
     "tools": [
-      "mcp__r__repl",
-      "mcp__r__repl_reset"
+      "ToolSearch"
     ],
     "mcp_servers": [
       {
         "name": "r",
-        "status": "connected"
+        "status": "pending"
       }
     ],
     "model": "haiku",

--- a/tests/snapshots/claude_integration__claude_live_integration@transcript.snap
+++ b/tests/snapshots/claude_integration__claude_live_integration@transcript.snap
@@ -2,14 +2,14 @@
 source: tests/claude_integration.rs
 expression: transcript
 ---
-$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json --tools ""
+$ HOME=<HOME> claude --disable-slash-commands --setting-sources local --settings <SETTINGS_JSON> --mcp-config <MCP_JSON> --strict-mcp-config -p --verbose --model haiku --no-session-persistence --permission-mode dontAsk --output-format json
 stdin:
 Use the mcp__r__repl tool exactly once. Send this exact R code: cat("CLAUDE_MCP_OK\n") Then answer with exactly DONE, with no punctuation or extra text.
 
 init:
 cwd: <WORKSPACE>
-tools: mcp__r__repl, mcp__r__repl_reset
-mcp_server: r (connected)
+tools: ToolSearch
+mcp_server: r (pending)
 model: haiku
 permission_mode: dontAsk
 

--- a/tests/snapshots/codex_integration__linux__codex_exec_wire_sandbox_state_meta.snap
+++ b/tests/snapshots/codex_integration__linux__codex_exec_wire_sandbox_state_meta.snap
@@ -36,9 +36,6 @@ expression: snapshot
           "codex/sandbox-state-meta": {
             "sandboxPolicy": {
               "type": "workspace-write",
-              "writable_roots": [
-                "<CODEX_HOME>/memories"
-              ],
               "network_access": false,
               "exclude_tmpdir_env_var": false,
               "exclude_slash_tmp": false

--- a/tests/snapshots/codex_integration__macos__codex_exec_wire_sandbox_state_meta.snap
+++ b/tests/snapshots/codex_integration__macos__codex_exec_wire_sandbox_state_meta.snap
@@ -35,9 +35,6 @@ expression: snapshot
           "codex/sandbox-state-meta": {
             "sandboxPolicy": {
               "type": "workspace-write",
-              "writable_roots": [
-                "<CODEX_HOME>/memories"
-              ],
               "network_access": false,
               "exclude_tmpdir_env_var": false,
               "exclude_slash_tmp": false

--- a/tests/test_run_integration_tests.py
+++ b/tests/test_run_integration_tests.py
@@ -1,8 +1,10 @@
 import importlib.util
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from textwrap import dedent
+from unittest.mock import patch
 
 
 def load_module():
@@ -43,6 +45,21 @@ class RunIntegrationTestsCaseTests(unittest.TestCase):
                 "isError": False,
             },
         )
+
+    def test_resolve_binary_path_accepts_extensionless_windows_path(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            binary = Path(temp_dir) / "mcp-repl"
+            exe_binary = Path(temp_dir) / "mcp-repl.exe"
+            exe_binary.write_text("", encoding="utf-8")
+
+            with patch.object(self.module.sys, "platform", "win32"):
+                self.assertEqual(exe_binary, self.module.resolve_binary_path(binary))
+
+    def test_server_process_env_uses_plain_pagers_by_default(self):
+        env = self.module.server_process_env(())
+
+        self.assertEqual("cat", env["PAGER"])
+        self.assertEqual("cat", env["MANPAGER"])
 
     def test_wait_for_busy_response_text_polls_until_marker(self):
         initial = self.module.tool_result(

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -1310,3 +1310,64 @@ async fn zod_worker_interrupt_discards_buffered_tail_before_follow_up() -> TestR
     session.cancel().await?;
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_interrupt_discards_split_utf8_buffer_bytes() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let debug_dir = tempdir.path().join("debug");
+    let session = spawn_zod_server_with_env_and_extra_args(
+        Vec::new(),
+        vec!["--debug-dir".to_string(), debug_dir.display().to_string()],
+    )
+    .await?;
+
+    let first = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "read-one-byte-then-discard-on-interrupt 1000\né",
+                "timeout_ms": 10
+            }),
+        )
+        .await?;
+    let first_text = result_text(&first);
+    assert!(
+        first_text.contains("<<repl status: busy"),
+        "expected timeout busy status, got: {first_text:?}"
+    );
+
+    let interrupted = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "\u{3}after split discard",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let text = result_text(&interrupted);
+    assert!(
+        text.contains("after split discard\n"),
+        "expected follow-up tail to run after split UTF-8 discard, got: {text:?}"
+    );
+    assert!(
+        !text.contains("worker protocol error"),
+        "split UTF-8 discard should account raw bytes, got: {text:?}"
+    );
+    assert!(
+        !text.contains("new session started"),
+        "split UTF-8 discard should not restart the worker, got: {text:?}"
+    );
+
+    let spawn_count = latest_debug_events(&debug_dir)?
+        .iter()
+        .filter(|entry| entry["event"] == "worker_spawn_begin")
+        .count();
+    assert_eq!(
+        spawn_count, 1,
+        "split UTF-8 discard should not replace the worker"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -811,8 +811,81 @@ async fn zod_worker_readline_input_mismatch_is_protocol_error() -> TestResult<()
         .await?;
     let text = result_text(&result);
     assert!(
-        text.contains("readline_input text does not match active stdin"),
-        "expected readline_input accounting protocol error, got: {text:?}"
+        text.contains("readline_input_bytes bytes does not match active stdin"),
+        "expected readline_input_bytes accounting protocol error, got: {text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_split_utf8_byte_accounting_completes_request() -> TestResult<()> {
+    let session = spawn_zod_server().await?;
+
+    let result = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "read-split-utf8-tail\né\n",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let text = result_text(&result);
+    assert!(
+        text.contains("split-tail bytes: [195, 169]"),
+        "expected split UTF-8 tail bytes to be accounted, got: {text:?}"
+    );
+    assert!(
+        !text.contains("<<repl status: busy") && !text.contains("worker protocol error"),
+        "split UTF-8 byte accounting should complete cleanly, got: {text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_old_readline_input_frame_is_protocol_error() -> TestResult<()> {
+    let session = spawn_zod_server().await?;
+
+    let result = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "old-readline-input",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let text = result_text(&result);
+    assert!(
+        text.contains("invalid worker sideband JSON") && text.contains("readline_input"),
+        "expected old readline_input frame to be rejected, got: {text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_old_readline_discard_frame_is_protocol_error() -> TestResult<()> {
+    let session = spawn_zod_server().await?;
+
+    let result = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "old-readline-discard",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let text = result_text(&result);
+    assert!(
+        text.contains("invalid worker sideband JSON") && text.contains("readline_discard"),
+        "expected old readline_discard frame to be rejected, got: {text:?}"
     );
 
     session.cancel().await?;


### PR DESCRIPTION
Linked issue: Kata `nym3`

Related PR: https://github.com/posit-dev/mcp-repl/pull/77

## Summary

- Move worker sideband stdin accounting to protocol v2 byte frames across the R, Python, and Zod worker paths, with protocol docs and snapshots updated.
- Stabilize the integration-test surface for Windows executable paths and current Claude/Codex CLI behavior.
- Repair the PR #77 verification blockers found on the handoff path: Windows Codex memories snapshot normalization and the timeout output-bundle poll disclosure test.

## Validation

- Workflow mechanical verification passed for current head `8402e39`.
- Required local checks passed after the latest test clarification: `cargo check`, `cargo build`, `python3 tests/run_integration_tests.py --binary target/debug/mcp-repl`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --quiet`, and `cargo +nightly fmt`.
- PR CI run `27504790362` passed required jobs: `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`, and `x86_64-pc-windows-msvc`; publish jobs were skipped.
- The automated workflow review gate passed against `origin/main`.

## Risks / Rollback

- The diff carries the original PR #77 sideband byte-frame change plus focused verification repairs. Rollback is reverting PR #79.
- No screenshots or videos: no UI changes.
