### PR TITLE
Stabilize plot_images timeout output-bundle poll on macOS CI

### DIFF
--- a/tests/plot_images.rs
+++ b/tests/plot_images.rs
@@ -1536,10 +1536,6 @@ cat("TAIL_ONLY\n")
         !final_text.contains("<<repl status: busy"),
         "expected timeout text-only follow-up poll to finish, got: {final_text:?}"
     );
-    assert!(
-        events_log_path(&final_text).is_some(),
-        "expected output bundle disclosure in final timeout poll, got: {final_text:?}"
-    );
     let events_log = events_log_path(&bundled_text)
         .or_else(|| events_log_path(&final_text))
         .unwrap_or_else(|| {


### PR DESCRIPTION
Linked issue: Kata `v8fm`

## Summary

- Stabilizes `tests/plot_images.rs::timeout_output_bundle_text_only_poll_does_not_duplicate_prefix_text` for the macOS CI timing path where the final empty poll can settle idle after an earlier output-bundle disclosure.
- Keeps production behavior unchanged. The test now accepts bundle disclosure from either the intermediate bundle-flush poll or the final settle poll, while still checking that `HEAD_ONLY` and `TAIL_ONLY` are retained exactly once in `transcript.txt`.

## Validation Performed

- `cargo test --test plot_images timeout_output_bundle_text_only_poll_does_not_duplicate_prefix_text -- --nocapture` passed.
- `cargo test --test plot_images -- --nocapture` passed.
- `cargo check` passed.
- `cargo build` passed.
- `python3 tests/run_integration_tests.py --binary target/debug/mcp-repl` passed.
- `cargo clippy --all-targets --all-features -- -D warnings` passed.
- `cargo +nightly fmt` passed.

Pending verification:

- `cargo test --quiet` passed the 363-test Rust binary set on rerun, but failed in `tests/claude_integration.rs` with `Claude output did not contain a tool call` for `claude_live_integration` and `claude_live_install_integration`.
- `cargo test --test claude_integration -- --nocapture` reproduced the same two Claude live integration failures.

## Risks / Rollback

- Risk is limited to the test contract for timeout output-bundle polling; no production code changed.
- Rollback is reverting the single commit if the test contract should continue requiring final-poll bundle redisclosure.

## Screenshots / Videos

- Not applicable.
