### PR TITLE
Add worker-owned turn protocol slice

### DIFF
--- a/docs/worker_sideband_protocol.md
+++ b/docs/worker_sideband_protocol.md
@@ -4,10 +4,25 @@ This document describes the sideband protocol between the server and a worker
 process. The channel is a UTF-8 JSON-lines stream, one JSON object per line,
 carried over an IPC pipe.
 
-User input is not carried on sideband. The server writes decoded MCP `repl()`
-text to worker stdin, appending exactly one trailing `\n` to non-empty input
-that does not already end in `\n`. The worker owns runtime stdin placement and
-reports stdin accounting facts back on sideband.
+The protocol is shaped around one race-free invariant:
+
+> The server does not infer that a worker is idle from stdin writes, PTY state,
+> prompt-looking output, raw stdout/stderr, or timing. A same-worker turn is
+> complete only when the worker emits `idle` for that turn, or when the worker
+> session ends.
+
+## Ownership
+
+The server owns the MCP reply. It captures output, enforces timeouts, detects
+worker exit or IPC loss, creates output bundles, and returns partial replies
+when a turn times out or the worker crashes. A worker crash before `idle` is a
+server-observed terminal condition for the current reply; it is not a protocol
+race.
+
+The worker owns the runtime input boundary. It may drive the runtime through a
+pipe, PTY, callback, embedded queue, or interpreter-specific API, but only the
+worker may assert that the runtime is waiting for more input and that no input
+from the previous turn can satisfy that wait.
 
 ## Sideband Transport
 
@@ -19,33 +34,126 @@ reports stdin accounting facts back on sideband.
   - `MCP_REPL_IPC_PIPE_TO_WORKER`
   - `MCP_REPL_IPC_PIPE_FROM_WORKER`
 - Messages are serialized as UTF-8 JSON, one message per line.
+- Worker-owned output and structural facts are ordered on the sideband stream.
+  Raw stdout/stderr capture remains active only as unowned fallback output.
 
-## Runtime Stdin Transport
+## Turn Model
 
-Runtime stdin transport is a launch-time worker setting, not a sideband
-negotiation. A worker may use ordinary pipes or a PTY for its C stdio, but the
-server still writes accepted request bytes to worker stdin and relies on
-sideband events for prompt, input, discard, output, and session facts.
-For graceful reset and shutdown, the server closes the worker stdin transport
-and then waits for normal worker exit before escalating to OS termination.
-Workers must not advertise interpreter-specific shutdown text, and the server
-does not send shutdown code or a sideband shutdown command. See
-`docs/adr/0001-stdin-close-graceful-shutdown.md`.
+The server allows at most one active turn per worker session. Each non-empty
+`repl()` execution input becomes a sideband `turn_start` message with a fresh
+`turn_id`. The input is a JSON string, so ordinary request payloads remain plain
+UTF-8 text on the inspectable sideband stream. The worker owns newline
+normalization and runtime placement.
 
-Built-in Unix Python uses PTY-backed C stdin/stdout/stderr so CPython calls
-`PyOS_ReadlineFunctionPointer`. The Python callback emits readline accounting
-facts from that CPython path. Sideband IPC stays separate from the PTY.
+Runtime stdin transport is a worker implementation detail. A worker may write
+the turn text into an embedded queue, an ordinary pipe, a PTY master, or an
+interpreter callback. The server must not use transport observations from any
+of those mechanisms to decide request completion.
+
+The worker emits exactly one terminal turn-boundary fact for a successful
+same-session turn:
+
+- `idle(turn_id)`: the runtime is waiting for new input, and no bytes or text
+  from that turn can still satisfy that wait.
+
+`session_end` is also terminal for any active turn because the old runtime can
+no longer consume follow-up input. Worker exit, sideband EOF, or process crash
+without `session_end` is handled by the server as worker failure with captured
+partial output.
+
+Timeouts do not complete a turn. On timeout, the server returns captured partial
+output and keeps the turn active. Later empty polls continue draining output
+until the worker emits `idle`, emits `session_end`, exits, or times out again.
+The server must not send ordinary follow-up input to the same worker while the
+turn remains active. It may send an interrupt for the active turn, reset or
+replace the worker, or report that the worker is still busy.
+
+## PTY And Stdin Workers
+
+PTYs and ordinary stdin are worker-internal runtime transports. They may require
+worker-internal accounting, but they must not expose that accounting as the
+server's completion rule. The server sees only `turn_start`, output,
+`idle`, `session_end`, and failure.
+
+A PTY-backed worker must own the PTY master or an equivalent write endpoint. A
+typical turn works like this:
+
+1. Server sends `{ "type": "turn_start", "turn_id": 7, "input": "x <- 1" }`.
+2. Worker receives `turn_start`.
+3. Worker records active turn `7`.
+4. Worker normalizes input for its runtime. For a line-oriented runtime, this
+   usually means appending a final newline and splitting into worker-owned line
+   items.
+5. Worker enqueues those line items in an active-turn input queue.
+6. Worker writer takes the next queued item and writes it to the PTY master.
+7. PTY/kernel/runtime code may transform or buffer what was written. This is
+   allowed, but it is no longer a server-visible accounting surface.
+8. Runtime consumes input through the PTY.
+9. Runtime reaches a worker-observed input wait, such as a readline callback,
+   prompt hook, or equivalent interpreter event. Raw PTY output that looks like
+   a prompt is not enough.
+10. Worker receives that input-wait event.
+11. Worker checks its active-turn state:
+    - no queued line item remains for turn `7`;
+    - no writer task has unwritten or in-flight input for turn `7`;
+    - observable PTY input is empty, or the transport design gives an
+      equivalent guarantee;
+    - no interrupt or reset cleanup for turn `7` is pending or uncertain.
+12. If all checks pass, worker sends
+    `{ "type": "idle", "turn_id": 7, "prompt": ">" }`.
+13. Server receives `idle(7)` and finalizes the turn reply from captured output.
+
+If any check in step 11 fails, the worker does not emit `idle`. It lets the
+runtime consume the pending input as part of turn `7`, writes the next queued
+line item if needed, and repeats the check at the next worker-observed input
+wait.
+
+This model can use line accounting inside the worker. The worker may track
+"line 1 was written", "line 2 is still queued", or "the current line write is
+in flight." That line accounting remains private because it is only evidence
+for whether the worker can truthfully emit `idle`. The server does not need to
+know whether the worker proved `idle` with lines, bytes, callbacks, or a queue.
+
+Server-visible line accounting is not sufficient for a PTY-backed runtime. A
+line accepted by the PTY master is not necessarily a line consumed by the
+runtime. The PTY may transform newlines, buffer pasted input, split writes,
+merge multiple lines, flush input, or interact with runtime buffering. The
+worker is the only component that can combine the transport facts with the
+runtime input-wait event.
+
+A PTY-backed worker must control buffering well enough for its checks to mean
+what they claim. For example, if the runtime reads through a buffered `FILE*`,
+the worker must either disable read-ahead buffering or place the input-wait
+observation after those buffers are known not to contain active-turn input. If
+the worker cannot make that guarantee, it cannot safely emit same-session
+`idle` for that transport. It should use a queue or callback-backed runtime
+boundary, emit `session_end`, or rely on server-side replacement after
+timeout/reset.
 
 ## Direction: server -> worker
 
+`turn_start`
+- `{ "type": "turn_start", "turn_id": <integer>, "input": <string> }`
+- Starts one runtime turn. The server must not send another `turn_start` for
+  the same worker until the active turn reaches `idle`, reaches `session_end`,
+  or the worker session is replaced.
+- `input` is the decoded MCP `repl()` text. The worker owns appending a final
+  newline when its runtime requires line-oriented input.
+
 `interrupt`
-- `{ "type": "interrupt" }`
-- Sent when the server is about to issue an OS interrupt to an existing worker
-  process or process group.
-- This is for worker-owned bookkeeping only. It does not carry user input and
-  does not replace the OS interrupt.
-- The worker may emit `readline_discard_bytes` for exact active-turn stdin bytes
-  it discarded before delivering them to the runtime.
+- `{ "type": "interrupt", "turn_id": <integer> }`
+- Sent when the server is about to interrupt the active turn. The server may
+  also deliver the platform interrupt to the worker process or process group.
+- This message is for worker-owned cleanup and state transition only. It does
+  not carry user input and does not complete the turn.
+- `turn_id` must match the worker's active turn. It is a stale-control guard,
+  not a general request address. If it does not match, the worker must not apply
+  the interrupt to any newer turn. It should ignore the stale control or end the
+  session with a protocol error.
+- After interrupt, the worker must emit `idle` only if it can prove no input
+  from the interrupted turn can satisfy the next runtime input wait. If it
+  cannot prove that, it must fail closed by staying active, ending the session,
+  or relying on server reset/restart.
 
 ## Direction: worker -> server
 
@@ -60,40 +168,15 @@ invalid base64, and unknown message types are protocol errors.
 - `worker.name` is diagnostic metadata. Server request handling must not branch
   on it.
 
-`readline_start`
-- `{ "type": "readline_start", "prompt": <string> }`
-- Emitted when the runtime enters a line-read operation, before reading bytes
-  for that operation.
+`idle`
+- `{ "type": "idle", "turn_id": <integer>, "prompt": <string> }`
+- Emitted only after the runtime is waiting for more input and no input from
+  `turn_id` can still satisfy that wait.
+- This is the only successful same-worker turn completion signal.
 - The prompt string is required; use an empty string if the runtime supplied no
   prompt.
-- If active-turn stdin bytes remain unaccounted by input or discard events,
-  the prompt is satisfied by already-written stdin and does not complete the
-  request. If no active-turn stdin bytes remain, the prompt is unsatisfied and
-  may complete the request.
 - Prompt rendering is derived from this structured event, not from raw
   stdout/stderr parsing.
-
-`readline_input_bytes`
-- `{ "type": "readline_input_bytes", "data_b64": <base64> }`
-- Emitted after the worker delivers active-turn stdin bytes to the
-  runtime-facing input layer.
-- `data_b64` must encode the exact bytes received from the server over the
-  worker stdin transport before any worker-side normalization or interpreter
-  adaptation. The worker may normalize the bytes it passes to the runtime, but
-  this accounting event reports the pre-normalized wire bytes.
-- The server decodes `data_b64` and removes those bytes from the active stdin
-  queue. Invalid base64 or a byte mismatch is a protocol error.
-
-`readline_discard_bytes`
-- `{ "type": "readline_discard_bytes", "data_b64": <base64> }`
-- Emitted after the worker discards exact active-turn stdin bytes during
-  interrupt/reset cleanup without delivering them to the runtime.
-- `data_b64` must encode the exact bytes received from the server over the
-  worker stdin transport before any worker-side normalization.
-- The server decodes `data_b64` and removes those bytes from the active stdin
-  queue. Invalid base64 or a byte mismatch is a protocol error.
-- Workers must emit this only for exact bytes they can identify. Bytes flushed
-  from terminal state without being observed are not reportable.
 
 `output_text`
 - `{ "type": "output_text", "stream": <"stdout"|"stderr">, "data_b64": <base64>, "is_continuation": <bool, optional> }`
@@ -101,7 +184,7 @@ invalid base64, and unknown message types are protocol errors.
   is base64 so workers can preserve bytes without depending on JSON string
   encoding.
 - Prompt-looking bytes are ordinary output unless the worker reports them in
-  `readline_start.prompt`.
+  `idle.prompt`.
 - `is_continuation` marks bounded transport chunks that continue the same
   worker-owned output write. It defaults to `false`.
 - Workers send output-critical frames synchronously: each JSON line is written,
@@ -118,74 +201,49 @@ invalid base64, and unknown message types are protocol errors.
   owns MCP response image IDs.
 
 `session_end`
-- `{ "type": "session_end", "reason": <string>, "message_b64": <base64, optional> }`
+- `{ "type": "session_end", "reason": <string>, "message_b64": <base64, optional>, "turn_id": <integer, optional> }`
 - Indicates the worker session is terminating.
 - `reason` is required for protocol workers. Recognized values are `shutdown`,
   `reset`, `runtime_exit`, `crash`, and `protocol_error`.
+- If `turn_id` is present and matches the active turn, it is terminal for that
+  turn. If it is absent, it is terminal for the whole session, including any
+  active turn.
 - After this event, the worker must not emit more output.
 
-## Transitional Compatibility Frames
+## Interrupt Recovery
 
-These frames remain for built-in workers that have not fully migrated on every
-platform. New protocol workers should not copy them for steady-state request
-handling. Built-in R no longer uses them. Built-in Unix Python still receives
-the legacy request-boundary frames, but stdin accounting comes from CPython
-readline events rather than a separate stdin bridge.
+Interrupt recovery is worker-owned and fail-closed. The server may send an
+interrupt while a turn is active and may return partial output if recovery times
+out. The server must not send interrupt-tail input to the same worker until the
+active turn reaches `idle` or `session_end`.
 
-`stdin_write`
-- `{ "type": "stdin_write", "byte_len": <usize>, "line_count": <usize>, "final_prompt": <string, optional> }`
-- Legacy server-to-worker request metadata emitted before the server writes raw
-  input payload bytes to stdin.
-- Built-in Unix Python uses these fields only to install active request state
-  before CPython's next readline callback consumes stdin.
-- Non-Unix Python may still use them for the pipe-backed compatibility path
-  until it is migrated to the same readline accounting model.
+An interrupt for a PTY-backed worker works like this:
 
-`stdin_write_complete`
-- `{ "type": "stdin_write_complete" }`
-- Legacy server-to-worker marker emitted after the server has written the raw
-  input payload bytes to stdin.
+1. Server sends `{ "type": "interrupt", "turn_id": 7 }`.
+2. Server may also deliver the platform interrupt to the worker process or
+   process group.
+3. Worker receives `interrupt(7)`.
+4. Worker verifies that `7` is still the active turn. If not, the worker must
+   not apply the interrupt to a newer turn.
+5. Worker stops writing any not-yet-written queued input for turn `7`.
+6. Worker drops any queued line items for turn `7` that have not reached the
+   runtime transport.
+7. Worker attempts runtime-specific cleanup for input that may already be in
+   the transport, such as draining readable PTY input, flushing terminal input,
+   or asking the runtime to unwind.
+8. Runtime either reaches a worker-observed input wait, exits, or remains busy.
+9. If the runtime reaches input wait and the worker can prove no input from
+   turn `7` remains queued, in flight, buffered, or cleanup-uncertain, worker
+   sends `{ "type": "idle", "turn_id": 7, "prompt": <string> }`.
+10. If the runtime exits, worker sends `session_end`.
+11. If cleanup is uncertain, worker sends neither `idle` nor same-worker tail
+    input. The active turn remains active until timeout, later recovery,
+    `session_end`, or server replacement.
 
-`backend_info`
-- `{ "type": "backend_info", "supports_images": <bool> }`
-- Legacy startup metadata accepted from older built-in workers.
-- It may describe narrow worker capabilities, but it must not turn steady-state
-  server request handling into language-specific policy.
-
-`stdin_write_ack`
-- `{ "type": "stdin_write_ack" }`
-- Legacy worker-to-server request-boundary acknowledgement.
-- This only acknowledges request-boundary state. It is not an acknowledgement
-  for stdout/stderr, PTY output, plot images, prompt completion, or request
-  completion.
-
-`python_interrupt_ack`
-- `{ "type": "python_interrupt_ack" }`
-- Transitional worker-to-server acknowledgement used only by built-in Unix
-  Python after it has processed its private `python_interrupt` cleanup message.
-- It means the worker has attempted exact discard accounting and terminal input
-  flushing before the server delivers SIGINT. It is not a generic protocol
-  interrupt acknowledgement.
-
-`readline_result`
-- `{ "type": "readline_result", "prompt": <string>, "line": <string> }`
-- Legacy echo metadata emitted after a line is read.
-- The server may use it for conservative echo suppression of raw pipe output,
-  but completion is driven by `readline_start`, `readline_input_bytes`,
-  `readline_discard_bytes`, and `session_end`.
-
-`plot_image`
-- `{ "type": "plot_image", "mime_type": <string>, "data": <base64>, "is_update": <bool>, "source": <string|null> }`
-- Legacy image payload used by built-in plot emitters.
-- `source` is optional worker-local plot source identity, such as a graphics
-  device or figure slot. It is not a response image ID; the server owns response
-  image IDs and uses `source` only to keep distinct plot sources from
-  collapsing into one response image.
-- There is no plot-image acknowledgement message.
-- Workers must not delay stdout/stderr output waiting for sideband responses.
-- If an update is the first image event for a new server request, the server
-  treats it as a new response image and includes a server notice that it updates
-  the previously sent image.
+The worker may use runtime-specific cleanup mechanisms internally. Those
+details are not protocol facts. If cleanup is only best-effort and old input may
+still be buffered in a PTY, libc, readline, or interpreter state, the worker
+must not emit `idle` for the interrupted turn.
 
 ## Notes
 
@@ -197,10 +255,6 @@ readline events rather than a separate stdin bridge.
   and merged stdout/stderr identity. Worker-owned `output_text` frames preserve
   their declared stream; raw PTY output does not promise pipe-style stream
   fidelity.
-- The server infers request completion when explicit worker sideband facts show
-  that the worker is waiting for the next input or that the session ended.
-- On timeout, a request may remain pending; later empty polls can observe worker
-  events and finish the request.
 - Control-only interrupts are server-owned routing decisions: if a worker
   process already exists, the server forwards the interrupt to it; if no worker
   exists, the server must not spawn one only to interrupt nothing.

--- a/docs/worker_sideband_protocol.md
+++ b/docs/worker_sideband_protocol.md
@@ -4,6 +4,10 @@ This document describes the sideband protocol between the server and a worker
 process. The channel is a UTF-8 JSON-lines stream, one JSON object per line,
 carried over an IPC pipe.
 
+This document defines worker protocol version 3. The server still accepts
+version 2 from built-in and migrating workers, but version 2 request-boundary
+frames are legacy compatibility surfaces rather than the current contract.
+
 The protocol is shaped around one race-free invariant:
 
 > The server does not infer that a worker is idle from stdin writes, PTY state,
@@ -161,7 +165,7 @@ Worker-to-server messages are strict: unknown fields, invalid enum values,
 invalid base64, and unknown message types are protocol errors.
 
 `worker_ready`
-- `{ "type": "worker_ready", "protocol": { "name": "mcp-repl-worker", "version": 2 }, "worker": { "name": <string>, "version": <string> }, "capabilities": { "images": <bool> } }`
+- `{ "type": "worker_ready", "protocol": { "name": "mcp-repl-worker", "version": 3 }, "worker": { "name": <string>, "version": <string> }, "capabilities": { "images": <bool> } }`
 - Must be the first worker-to-server message for protocol workers.
 - The server rejects unsupported protocol names or versions before sending user
   input.
@@ -177,6 +181,15 @@ invalid base64, and unknown message types are protocol errors.
   prompt.
 - Prompt rendering is derived from this structured event, not from raw
   stdout/stderr parsing.
+
+`input_line`
+- `{ "type": "input_line", "turn_id": <integer>, "prompt": <string>, "text": <string> }`
+- Records that the worker delivered a logical input line to the runtime at this
+  point in the ordered sideband stream.
+- `turn_id` must match the active turn.
+- `prompt` and `text` are structural input facts, not runtime output.
+  Submitted input must not be emitted as `output_text`.
+- The final MCP reply elides synthetic input echoes by default. The server may reconstruct `prompt + text` from ordered `input_line` events for transcript finalization, echo trimming, debugging views, or other surfaces that need an interactive transcript.
 
 `output_text`
 - `{ "type": "output_text", "stream": <"stdout"|"stderr">, "data_b64": <base64>, "is_continuation": <bool, optional> }`
@@ -199,6 +212,12 @@ invalid base64, and unknown message types are protocol errors.
 - Carries worker-owned image bytes on the ordered sideband stream.
 - `image_id` is worker-local source identity for update grouping. The server
   owns MCP response image IDs.
+
+`plot_image`
+- `{ "type": "plot_image", "mime_type": <string>, "data": <base64>, "is_update": <bool>, "source": <string|null> }`
+- Legacy v2 image event retained for built-in workers during migration.
+- There is no plot-image acknowledgement message.
+- Workers must not delay stdout/stderr output waiting for sideband responses.
 
 `session_end`
 - `{ "type": "session_end", "reason": <string>, "message_b64": <base64, optional>, "turn_id": <integer, optional> }`

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -84,11 +84,16 @@ static NEXT_SERVER_IMAGE_ID: AtomicU64 = AtomicU64::new(0);
 static WORKER_IPC_ATFORK_REGISTER_RESULT: OnceLock<i32> = OnceLock::new();
 
 pub const WORKER_PROTOCOL_VERSION: u32 = 2;
+pub const WORKER_PROTOCOL_V3_VERSION: u32 = 3;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServerToWorkerIpcMessage {
     RequestStart,
+    TurnStart {
+        turn_id: u64,
+        input: String,
+    },
     PythonRequestStart {
         request_generation: u64,
         stdin_b64: String,
@@ -104,7 +109,10 @@ pub enum ServerToWorkerIpcMessage {
     PythonInterrupt {
         request_generation: u64,
     },
-    Interrupt,
+    Interrupt {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        turn_id: Option<u64>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -140,6 +148,15 @@ pub enum WorkerToServerIpcMessage {
         prompt: String,
         line: String,
     },
+    InputLine {
+        turn_id: u64,
+        prompt: String,
+        text: String,
+    },
+    Idle {
+        turn_id: u64,
+        prompt: String,
+    },
     PlotImage {
         mime_type: String,
         data: String,
@@ -158,6 +175,8 @@ pub enum WorkerToServerIpcMessage {
         reason: Option<String>,
         #[serde(default)]
         message_b64: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        turn_id: Option<u64>,
     },
 }
 
@@ -190,6 +209,9 @@ struct ServerIpcInbox {
     prompt_history: VecDeque<String>,
     echo_events: VecDeque<IpcEchoEvent>,
     active_stdin: Option<VecDeque<u8>>,
+    active_turn_id: Option<u64>,
+    completed_turn_id: Option<u64>,
+    completed_turn_observed_at: Option<Instant>,
     readline_result_count: u64,
     readline_unmatched_starts: usize,
     readline_unmatched_since: Option<Instant>,
@@ -401,16 +423,7 @@ impl ServerIpcConnection {
                                 guard.readline_unmatched_since = Some(Instant::now());
                             }
                         }
-                        if guard
-                            .prompt_history
-                            .back()
-                            .is_none_or(|last| last != &prompt)
-                        {
-                            guard.prompt_history.push_back(prompt.clone());
-                            if guard.prompt_history.len() > MAX_PROMPT_HISTORY {
-                                guard.prompt_history.pop_front();
-                            }
-                        }
+                        push_prompt_history(&mut guard, prompt.clone());
                         guard.last_prompt = Some(prompt);
                         reader_cvar.notify_all();
                         drop(guard);
@@ -481,9 +494,50 @@ impl ServerIpcConnection {
                             handler(echo_event);
                         }
                     }
+                    WorkerToServerIpcMessage::InputLine {
+                        turn_id,
+                        prompt,
+                        text,
+                    } => {
+                        let echo_event = IpcEchoEvent {
+                            prompt: prompt.clone(),
+                            line: text.clone(),
+                            source: OutputTextSource::Ipc,
+                        };
+                        let mut guard = reader_inbox.lock().unwrap();
+                        if let Err(err) =
+                            validate_open_active_turn_id(&guard, turn_id, "input_line")
+                        {
+                            latch_protocol_error(&mut guard, err);
+                            reader_cvar.notify_all();
+                            break;
+                        }
+                        guard.readline_result_count = guard.readline_result_count.saturating_add(1);
+                        push_prompt_history(&mut guard, prompt);
+                        guard.echo_events.push_back(echo_event.clone());
+                        reader_cvar.notify_all();
+                        drop(guard);
+                        if let Some(handler) = readline_result_handler.as_ref() {
+                            handler(echo_event);
+                        }
+                    }
+                    WorkerToServerIpcMessage::Idle { turn_id, prompt } => {
+                        let mut guard = reader_inbox.lock().unwrap();
+                        if let Err(err) = validate_open_active_turn_id(&guard, turn_id, "idle") {
+                            latch_protocol_error(&mut guard, err);
+                            reader_cvar.notify_all();
+                            break;
+                        }
+                        push_prompt_history(&mut guard, prompt.clone());
+                        guard.last_prompt = Some(prompt);
+                        guard.completed_turn_id = Some(turn_id);
+                        guard.completed_turn_observed_at = Some(Instant::now());
+                        reader_cvar.notify_all();
+                    }
                     WorkerToServerIpcMessage::SessionEnd {
                         reason,
                         message_b64,
+                        turn_id,
                     } => {
                         if let Err(err) =
                             validate_session_end(reason.as_deref(), message_b64.as_deref())
@@ -494,11 +548,20 @@ impl ServerIpcConnection {
                             break;
                         }
                         let mut guard = reader_inbox.lock().unwrap();
+                        if let Some(turn_id) = turn_id
+                            && let Err(err) =
+                                validate_active_turn_id(&guard, turn_id, "session_end")
+                        {
+                            latch_protocol_error(&mut guard, err);
+                            reader_cvar.notify_all();
+                            break;
+                        }
                         guard.session_end = true;
                         guard.session_end_final = true;
                         guard.queue.push_back(WorkerToServerIpcMessage::SessionEnd {
                             reason,
                             message_b64,
+                            turn_id,
                         });
                         reader_cvar.notify_all();
                         drop(guard);
@@ -672,6 +735,19 @@ impl ServerIpcConnection {
         drop_stdin_write_acks(&mut guard);
         drop_python_interrupt_acks(&mut guard);
         guard.active_stdin = Some(payload.iter().copied().collect());
+        guard.echo_events.clear();
+        guard.prompt_history.clear();
+        guard.protocol_warnings.clear();
+    }
+
+    pub fn begin_turn(&self, turn_id: u64) {
+        let mut guard = self.inbox.lock().unwrap();
+        reset_after_completed_request(&mut guard);
+        drop_stdin_write_acks(&mut guard);
+        drop_python_interrupt_acks(&mut guard);
+        guard.active_turn_id = Some(turn_id);
+        guard.completed_turn_id = None;
+        guard.completed_turn_observed_at = None;
         guard.echo_events.clear();
         guard.prompt_history.clear();
         guard.protocol_warnings.clear();
@@ -1808,6 +1884,7 @@ pub fn emit_session_end() {
         let _ = ipc.send(WorkerToServerIpcMessage::SessionEnd {
             reason: None,
             message_b64: None,
+            turn_id: None,
         });
     }
 }
@@ -1931,7 +2008,51 @@ fn drop_python_interrupt_acks(guard: &mut ServerIpcInbox) {
         .retain(|msg| !matches!(msg, WorkerToServerIpcMessage::PythonInterruptAck));
 }
 
+fn push_prompt_history(guard: &mut ServerIpcInbox, prompt: String) {
+    if guard
+        .prompt_history
+        .back()
+        .is_none_or(|last| last != &prompt)
+    {
+        guard.prompt_history.push_back(prompt);
+        if guard.prompt_history.len() > MAX_PROMPT_HISTORY {
+            guard.prompt_history.pop_front();
+        }
+    }
+}
+
+fn validate_active_turn_id(
+    guard: &ServerIpcInbox,
+    turn_id: u64,
+    event_type: &str,
+) -> Result<(), String> {
+    match guard.active_turn_id {
+        Some(active) if active == turn_id => Ok(()),
+        Some(active) => Err(format!(
+            "{event_type} turn_id {turn_id} does not match active turn_id {active}"
+        )),
+        None => Err(format!(
+            "{event_type} reported turn_id {turn_id} with no active turn"
+        )),
+    }
+}
+
+fn validate_open_active_turn_id(
+    guard: &ServerIpcInbox,
+    turn_id: u64,
+    event_type: &str,
+) -> Result<(), String> {
+    validate_active_turn_id(guard, turn_id, event_type)?;
+    if guard.completed_turn_id == Some(turn_id) {
+        return Err(format!("{event_type} turn_id {turn_id} arrived after idle"));
+    }
+    Ok(())
+}
+
 fn request_completion_ready(guard: &ServerIpcInbox, stable_wait: Duration) -> bool {
+    if let Some(active_turn_id) = guard.active_turn_id {
+        return guard.completed_turn_id == Some(active_turn_id);
+    }
     let Some(since) = guard.readline_unmatched_since else {
         return false;
     };
@@ -1984,6 +2105,13 @@ fn request_completion_precedes_latched_protocol_error(
     let Some(error) = guard.protocol_error.as_ref() else {
         return false;
     };
+    if let Some(active_turn_id) = guard.active_turn_id
+        && guard.completed_turn_id == Some(active_turn_id)
+    {
+        return guard
+            .completed_turn_observed_at
+            .is_some_and(|observed_at| observed_at <= error.observed_at);
+    }
     let Some(since) = guard.readline_unmatched_since else {
         return false;
     };
@@ -2006,6 +2134,13 @@ fn request_completion_observed_before_deadline(
     deadline: Instant,
     allow_completion_settle_after_deadline: bool,
 ) -> bool {
+    if let Some(active_turn_id) = guard.active_turn_id
+        && guard.completed_turn_id == Some(active_turn_id)
+    {
+        return guard
+            .completed_turn_observed_at
+            .is_some_and(|observed_at| observed_at <= deadline);
+    }
     allow_completion_settle_after_deadline
         && guard.readline_unmatched_starts > 0
         && guard
@@ -2021,6 +2156,9 @@ fn completion_wait_duration(
 ) -> Duration {
     let now = Instant::now();
     let until_deadline = deadline.saturating_duration_since(now);
+    if guard.active_turn_id.is_some() {
+        return until_deadline;
+    }
     let Some(since) = guard.readline_unmatched_since else {
         return until_deadline;
     };
@@ -2084,6 +2222,9 @@ fn assign_plot_image_id(
 
 fn reset_request_progress(guard: &mut ServerIpcInbox) {
     guard.active_stdin = None;
+    guard.active_turn_id = None;
+    guard.completed_turn_id = None;
+    guard.completed_turn_observed_at = None;
     guard.readline_result_count = 0;
     guard.readline_unmatched_starts = 0;
     guard.readline_unmatched_since = None;

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -18,7 +18,6 @@ use std::os::windows::io::{AsRawHandle, FromRawHandle};
 #[cfg(target_family = "unix")]
 use std::sync::atomic::{AtomicBool, AtomicI32};
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
-#[cfg(target_family = "windows")]
 use std::sync::mpsc;
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::thread;
@@ -305,6 +304,39 @@ impl OutputCriticalIpcWriter {
             .lock()
             .map_err(|_| io::Error::other("ipc writer mutex poisoned"))?;
         write_ipc_message(&mut **writer, &message)
+    }
+
+    pub fn send_with_timeout<T>(&self, message: T, timeout: Duration) -> io::Result<()>
+    where
+        T: Serialize + Send + 'static,
+    {
+        if timeout.is_zero() {
+            return Err(ipc_send_timeout_error());
+        }
+
+        let writer = self.writer.clone();
+        let (tx, rx) = mpsc::sync_channel(1);
+        thread::spawn(move || {
+            let result = {
+                let mut writer = match writer.lock() {
+                    Ok(writer) => writer,
+                    Err(_) => {
+                        let _ = tx.send(Err(io::Error::other("ipc writer mutex poisoned")));
+                        return;
+                    }
+                };
+                write_ipc_message(&mut **writer, &message)
+            };
+            let _ = tx.send(result);
+        });
+
+        match rx.recv_timeout(timeout) {
+            Ok(result) => result,
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(ipc_send_timeout_error()),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                Err(io::Error::other("ipc writer thread exited unexpectedly"))
+            }
+        }
     }
 }
 
@@ -705,6 +737,14 @@ impl ServerIpcConnection {
 
     pub fn send(&self, message: ServerToWorkerIpcMessage) -> io::Result<()> {
         self.writer.send(message)
+    }
+
+    pub fn send_with_timeout(
+        &self,
+        message: ServerToWorkerIpcMessage,
+        timeout: Duration,
+    ) -> io::Result<()> {
+        self.writer.send_with_timeout(message, timeout)
     }
 
     pub fn join_reader_thread(&self) -> io::Result<()> {
@@ -1111,6 +1151,13 @@ fn write_ipc_message<T: Serialize>(writer: &mut dyn Write, message: &T) -> io::R
     writer.write_all(payload.as_bytes())?;
     writer.write_all(b"\n")?;
     writer.flush()
+}
+
+fn ipc_send_timeout_error() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::TimedOut,
+        "timed out sending IPC message to worker",
+    )
 }
 
 #[derive(Debug)]

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -2060,8 +2060,15 @@ fn request_completion_ready(guard: &ServerIpcInbox, stable_wait: Duration) -> bo
 }
 
 fn latch_protocol_error(guard: &mut ServerIpcInbox, message: impl Into<String>) {
+    let message = message.into();
+    crate::event_log::log(
+        "worker_protocol_error_latched",
+        serde_json::json!({
+            "message": message.clone(),
+        }),
+    );
     guard.protocol_error = Some(LatchedProtocolError {
-        message: message.into(),
+        message,
         observed_at: Instant::now(),
     });
 }

--- a/src/python_worker.rs
+++ b/src/python_worker.rs
@@ -90,6 +90,7 @@ fn init_ipc(
                         python_session::mark_request_started();
                         emit_stdin_write_ack();
                     }
+                    Some(ServerToWorkerIpcMessage::TurnStart { .. }) => {}
                     Some(ServerToWorkerIpcMessage::PythonRequestStart {
                         request_generation,
                         stdin_b64,
@@ -125,7 +126,7 @@ fn init_ipc(
                     Some(ServerToWorkerIpcMessage::StdinWriteComplete) => {
                         python_session::mark_stdin_write_complete();
                     }
-                    Some(ServerToWorkerIpcMessage::Interrupt) => {
+                    Some(ServerToWorkerIpcMessage::Interrupt { .. }) => {
                         python_session::interrupt();
                     }
                     Some(ServerToWorkerIpcMessage::PythonInterrupt { request_generation }) => {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -91,10 +91,11 @@ fn init_ipc() -> Result<(), Box<dyn std::error::Error>> {
             loop {
                 match conn.recv(None) {
                     Some(ServerToWorkerIpcMessage::RequestStart) => {}
+                    Some(ServerToWorkerIpcMessage::TurnStart { .. }) => {}
                     Some(ServerToWorkerIpcMessage::PythonRequestStart { .. }) => {}
                     Some(ServerToWorkerIpcMessage::StdinWrite { .. }) => {}
                     Some(ServerToWorkerIpcMessage::StdinWriteComplete) => {}
-                    Some(ServerToWorkerIpcMessage::Interrupt) => {
+                    Some(ServerToWorkerIpcMessage::Interrupt { .. }) => {
                         crate::r_session::clear_pending_input();
                     }
                     Some(ServerToWorkerIpcMessage::PythonInterrupt { .. }) => {

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -1009,11 +1009,19 @@ impl BackendDriver for ProtocolBackendDriver {
             }
             let turn_id = self.next_turn_id();
             ipc.begin_turn(turn_id);
-            ipc.send(ServerToWorkerIpcMessage::TurnStart {
-                turn_id,
-                input: text.to_string(),
-            })
-            .map_err(WorkerError::Io)?;
+            match ipc.send_with_timeout(
+                ServerToWorkerIpcMessage::TurnStart {
+                    turn_id,
+                    input: text.to_string(),
+                },
+                timeout,
+            ) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::TimedOut => {
+                    return Err(WorkerError::Timeout(timeout));
+                }
+                Err(err) => return Err(WorkerError::Io(err)),
+            }
             self.active_turn_id = Some(turn_id);
             if let Some(message) = ipc.take_protocol_error() {
                 return Err(WorkerError::Protocol(message));

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -303,6 +303,13 @@ trait BackendDriver: Send {
         oversized_output: OversizedOutputMode,
         pending_input: Option<&str>,
     ) -> bool;
+    fn should_write_stdin_payload(&self) -> bool {
+        true
+    }
+    fn uses_turn_protocol(&self) -> bool {
+        false
+    }
+    fn clear_active_turn(&mut self) {}
     fn wait_for_completion(
         &mut self,
         timeout: Duration,
@@ -410,7 +417,7 @@ fn driver_wait_for_completion(
 
 fn driver_interrupt(process: &mut WorkerProcess) -> Result<(), WorkerError> {
     if let Some(ipc) = process.ipc.get() {
-        let _ = ipc.send(ServerToWorkerIpcMessage::Interrupt);
+        let _ = ipc.send(ServerToWorkerIpcMessage::Interrupt { turn_id: None });
     }
     process.send_interrupt()
 }
@@ -488,6 +495,41 @@ fn driver_refresh_worker_ready(
     }
 }
 
+fn driver_refresh_custom_worker_ready(
+    ipc: ServerIpcConnection,
+    timeout: Duration,
+) -> Result<u32, WorkerError> {
+    match ipc.wait_for_backend_info(timeout) {
+        Ok(WorkerToServerIpcMessage::WorkerReady { protocol, .. }) => {
+            if protocol.name != "mcp-repl-worker"
+                || !matches!(
+                    protocol.version,
+                    crate::ipc::WORKER_PROTOCOL_VERSION | crate::ipc::WORKER_PROTOCOL_V3_VERSION
+                )
+            {
+                return Err(WorkerError::Protocol(format!(
+                    "unsupported worker protocol {} version {}",
+                    protocol.name, protocol.version
+                )));
+            }
+            Ok(protocol.version)
+        }
+        Ok(_) => Err(WorkerError::Protocol(
+            "expected worker_ready before user input".to_string(),
+        )),
+        Err(IpcWaitError::Timeout) => Err(WorkerError::Protocol(
+            "timed out waiting for worker_ready".to_string(),
+        )),
+        Err(IpcWaitError::Disconnected) => Err(WorkerError::Protocol(
+            "ipc disconnected while waiting for worker_ready".to_string(),
+        )),
+        Err(IpcWaitError::SessionEnd) => Err(WorkerError::Protocol(
+            "worker session ended before worker_ready".to_string(),
+        )),
+        Err(IpcWaitError::Protocol(message)) => Err(WorkerError::Protocol(message)),
+    }
+}
+
 impl BackendDriver for RBackendDriver {
     fn prepare_input_text(&self, text: String) -> String {
         normalize_input_newlines(&text)
@@ -530,7 +572,7 @@ impl BackendDriver for RBackendDriver {
 
     fn interrupt(&mut self, process: &mut WorkerProcess) -> Result<(), WorkerError> {
         if let Some(ipc) = process.ipc.get() {
-            let _ = ipc.send(ServerToWorkerIpcMessage::Interrupt);
+            let _ = ipc.send(ServerToWorkerIpcMessage::Interrupt { turn_id: None });
         }
         process.send_r_interrupt()
     }
@@ -912,6 +954,9 @@ impl BackendDriver for PythonBackendDriver {
 struct ProtocolBackendDriver {
     #[cfg(target_family = "unix")]
     python_request_generation: Option<u64>,
+    protocol_version: Option<u32>,
+    next_turn_id: u64,
+    active_turn_id: Option<u64>,
 }
 
 impl ProtocolBackendDriver {
@@ -919,6 +964,9 @@ impl ProtocolBackendDriver {
         Self {
             #[cfg(target_family = "unix")]
             python_request_generation: None,
+            protocol_version: None,
+            next_turn_id: 1,
+            active_turn_id: None,
         }
     }
 
@@ -926,6 +974,9 @@ impl ProtocolBackendDriver {
     fn python() -> Self {
         Self {
             python_request_generation: Some(0),
+            protocol_version: Some(crate::ipc::WORKER_PROTOCOL_VERSION),
+            next_turn_id: 1,
+            active_turn_id: None,
         }
     }
 
@@ -935,16 +986,44 @@ impl ProtocolBackendDriver {
         *generation = generation.wrapping_add(1);
         Some(*generation)
     }
+
+    fn is_v3(&self) -> bool {
+        self.protocol_version == Some(crate::ipc::WORKER_PROTOCOL_V3_VERSION)
+    }
+
+    fn next_turn_id(&mut self) -> u64 {
+        let turn_id = self.next_turn_id;
+        self.next_turn_id = self.next_turn_id.wrapping_add(1).max(1);
+        turn_id
+    }
 }
 
 impl BackendDriver for ProtocolBackendDriver {
     fn on_input_start(
         &mut self,
-        _text: &str,
+        text: &str,
         payload: &[u8],
         ipc: &ServerIpcConnection,
         timeout: Duration,
     ) -> Result<(), WorkerError> {
+        if self.is_v3() {
+            if let Some(message) = ipc.take_protocol_error() {
+                return Err(WorkerError::Protocol(message));
+            }
+            let turn_id = self.next_turn_id();
+            ipc.begin_turn(turn_id);
+            ipc.send(ServerToWorkerIpcMessage::TurnStart {
+                turn_id,
+                input: text.to_string(),
+            })
+            .map_err(WorkerError::Io)?;
+            self.active_turn_id = Some(turn_id);
+            if let Some(message) = ipc.take_protocol_error() {
+                return Err(WorkerError::Protocol(message));
+            }
+            return Ok(());
+        }
+
         ipc.begin_request_with_stdin(payload);
         #[cfg(not(target_family = "unix"))]
         let _ = timeout;
@@ -987,15 +1066,43 @@ impl BackendDriver for ProtocolBackendDriver {
         false
     }
 
+    fn should_write_stdin_payload(&self) -> bool {
+        !self.is_v3()
+    }
+
+    fn uses_turn_protocol(&self) -> bool {
+        self.is_v3()
+    }
+
+    fn clear_active_turn(&mut self) {
+        self.active_turn_id = None;
+    }
+
     fn wait_for_completion(
         &mut self,
         timeout: Duration,
         ipc: ServerIpcConnection,
     ) -> Result<CompletionInfo, WorkerError> {
-        driver_wait_for_completion(timeout, ipc, OutputTextSource::Ipc)
+        let result = driver_wait_for_completion(timeout, ipc, OutputTextSource::Ipc);
+        if matches!(result, Ok(_) | Err(WorkerError::Protocol(_))) {
+            self.active_turn_id = None;
+        }
+        result
     }
 
     fn interrupt(&mut self, process: &mut WorkerProcess) -> Result<(), WorkerError> {
+        if self.is_v3() {
+            if let Some(turn_id) = self.active_turn_id
+                && let Some(ipc) = process.ipc.get()
+            {
+                ipc.send(ServerToWorkerIpcMessage::Interrupt {
+                    turn_id: Some(turn_id),
+                })
+                .map_err(WorkerError::Io)?;
+            }
+            return process.send_interrupt();
+        }
+
         #[cfg(target_family = "unix")]
         if let Some(request_generation) = self.python_request_generation {
             if let Some(ipc) = process.ipc.get() {
@@ -1014,7 +1121,13 @@ impl BackendDriver for ProtocolBackendDriver {
         ipc: ServerIpcConnection,
         timeout: Duration,
     ) -> Result<(), WorkerError> {
-        driver_refresh_worker_ready(ipc, timeout)
+        #[cfg(target_family = "unix")]
+        if self.python_request_generation.is_some() {
+            return driver_refresh_worker_ready(ipc, timeout);
+        }
+
+        self.protocol_version = Some(driver_refresh_custom_worker_ready(ipc, timeout)?);
+        Ok(())
     }
 }
 
@@ -2571,11 +2684,13 @@ impl WorkerManager {
         if remaining.is_zero() {
             return Err(WorkerError::Timeout(server_timeout));
         }
-        self.process
-            .as_mut()
-            .expect("worker process should be available")
-            .write_stdin_payload(payload, remaining)?;
-        self.driver.on_input_written(&ipc)?;
+        if self.driver.should_write_stdin_payload() {
+            self.process
+                .as_mut()
+                .expect("worker process should be available")
+                .write_stdin_payload(payload, remaining)?;
+            self.driver.on_input_written(&ipc)?;
+        }
         Ok(RequestState {
             timeout: worker_timeout,
             started_at,
@@ -3953,6 +4068,7 @@ impl WorkerManager {
         if !preserve_detached_output {
             self.pending_request_input = None;
         }
+        self.driver.clear_active_turn();
         self.session_end_seen = false;
         if !preserve_detached_output {
             self.settled_pending_completion = None;
@@ -4023,6 +4139,7 @@ impl WorkerManager {
         self.pending_request = false;
         self.pending_request_started_at = None;
         self.pending_request_input = None;
+        self.driver.clear_active_turn();
         self.session_end_seen = false;
         if !preserve_detached_output {
             self.settled_pending_completion = None;
@@ -4533,6 +4650,9 @@ impl WorkerManager {
                 self.settle_pending_session_end(&ipc);
             }
             Err(IpcWaitError::Protocol(message)) => {
+                if self.driver.uses_turn_protocol() {
+                    self.clear_pending_request_state();
+                }
                 self.settled_pending_error = Some(WorkerError::Protocol(message));
             }
             Err(IpcWaitError::Timeout | IpcWaitError::Disconnected) => {
@@ -4562,6 +4682,7 @@ impl WorkerManager {
     fn clear_pending_request_state(&mut self) {
         self.pending_request = false;
         self.pending_request_started_at = None;
+        self.driver.clear_active_turn();
         self.settled_pending_completion = None;
         self.settled_pending_error = None;
         self.guardrail.busy.store(false, Ordering::Relaxed);
@@ -7907,6 +8028,7 @@ mod tests {
         let _ = worker.send(WorkerToServerIpcMessage::SessionEnd {
             reason: None,
             message_b64: None,
+            turn_id: None,
         });
 
         let completion =
@@ -7938,6 +8060,7 @@ mod tests {
         let _ = worker.send(WorkerToServerIpcMessage::SessionEnd {
             reason: None,
             message_b64: None,
+            turn_id: None,
         });
         thread::sleep(Duration::from_millis(25));
 
@@ -9093,6 +9216,7 @@ mod tests {
             .send(WorkerToServerIpcMessage::SessionEnd {
                 reason: None,
                 message_b64: None,
+                turn_id: None,
             })
             .expect("send session_end");
 

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -306,9 +306,6 @@ trait BackendDriver: Send {
     fn should_write_stdin_payload(&self) -> bool {
         true
     }
-    fn uses_turn_protocol(&self) -> bool {
-        false
-    }
     fn clear_active_turn(&mut self) {}
     fn wait_for_completion(
         &mut self,
@@ -1068,10 +1065,6 @@ impl BackendDriver for ProtocolBackendDriver {
 
     fn should_write_stdin_payload(&self) -> bool {
         !self.is_v3()
-    }
-
-    fn uses_turn_protocol(&self) -> bool {
-        self.is_v3()
     }
 
     fn clear_active_turn(&mut self) {
@@ -2219,6 +2212,7 @@ impl WorkerManager {
         };
 
         if let Some(err) = self.settled_pending_error.take() {
+            let _ = self.reset_preserving_detached_prefix_item_count();
             return Err(err);
         }
         if self.pending_request {
@@ -2378,6 +2372,8 @@ impl WorkerManager {
         };
 
         if let Some(err) = self.settled_pending_error.take() {
+            let preserve_pager = self.pager.is_active();
+            let _ = self.reset_with_pager_preserving_detached_prefix_item_count(preserve_pager);
             return Err(err);
         }
         if self.pending_request {
@@ -4650,9 +4646,7 @@ impl WorkerManager {
                 self.settle_pending_session_end(&ipc);
             }
             Err(IpcWaitError::Protocol(message)) => {
-                if self.driver.uses_turn_protocol() {
-                    self.clear_pending_request_state();
-                }
+                self.driver.clear_active_turn();
                 self.settled_pending_error = Some(WorkerError::Protocol(message));
             }
             Err(IpcWaitError::Timeout | IpcWaitError::Disconnected) => {

--- a/tests/docs_contracts.rs
+++ b/tests/docs_contracts.rs
@@ -107,8 +107,17 @@ fn worker_sideband_protocol_keeps_plot_images_one_way() {
     for required in [
         r#"{ "type": "output_text", "stream": <"stdout"|"stderr">, "data_b64": <base64>, "is_continuation": <bool, optional> }"#,
         r#"{ "type": "plot_image", "mime_type": <string>, "data": <base64>, "is_update": <bool>, "source": <string|null> }"#,
+        r#"{ "type": "worker_ready", "protocol": { "name": "mcp-repl-worker", "version": 3 }, "worker": { "name": <string>, "version": <string> }, "capabilities": { "images": <bool> } }"#,
+        r#"{ "type": "turn_start", "turn_id": <integer>, "input": <string> }"#,
+        r#"{ "type": "input_line", "turn_id": <integer>, "prompt": <string>, "text": <string> }"#,
+        r#"{ "type": "idle", "turn_id": <integer>, "prompt": <string> }"#,
+        r#"{ "type": "interrupt", "turn_id": <integer> }"#,
+        "This document defines worker protocol version 3.",
+        "version 2 from built-in and migrating workers",
         "There is no plot-image acknowledgement message.",
         "Workers must not delay stdout/stderr output waiting for sideband responses.",
+        "Submitted input must not be emitted as `output_text`.",
+        "The server may reconstruct `prompt + text` from ordered `input_line` events",
     ] {
         assert!(
             protocol.contains(required),

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -309,6 +309,17 @@ fn run_v3_command(
         return Ok(false);
     }
 
+    if let Some(millis) = command.strip_prefix("bad-output-after-sleep ") {
+        sleep_for(parse_millis(millis)?, sideband_interrupted, false);
+        append_control_log(
+            control_log_path.as_deref(),
+            &format!("bad_output_after_sleep turn_id={turn_id}"),
+        )?;
+        writer.send_raw_json(INVALID_OUTPUT_TEXT_BASE64)?;
+        sleep_for(5_000, sideband_interrupted, false);
+        return Ok(false);
+    }
+
     if let Some(millis) = command.strip_prefix("interrupt-report ") {
         let report = observe_interrupts_for(parse_millis(millis)?, sideband_interrupted);
         let text = format!(

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -27,6 +27,7 @@ const STARTUP_PROTOCOL_ERROR_ENV: &str = "MCP_REPL_ZOD_STARTUP_PROTOCOL_ERROR";
 const SHUTDOWN_LOG_ENV: &str = "MCP_REPL_ZOD_SHUTDOWN_LOG";
 const PROTOCOL_VERSION_ENV: &str = "MCP_REPL_ZOD_PROTOCOL_VERSION";
 const CONTROL_LOG_ENV: &str = "MCP_REPL_ZOD_CONTROL_LOG";
+const STALL_CONTROL_READER_ENV: &str = "MCP_REPL_ZOD_STALL_CONTROL_READER";
 const INVALID_OUTPUT_TEXT_BASE64: &str =
     r#"{"type":"output_text","stream":"stdout","data_b64":"***"}"#;
 const INVALID_SESSION_END_REASON: &str =
@@ -157,14 +158,6 @@ fn run_v3_worker(
     let (tx, rx) = mpsc::channel();
 
     start_v3_stdin_observer(control_log_path.clone());
-    start_v3_control_reader(
-        sideband_reader,
-        tx,
-        sideband_interrupted.clone(),
-        control_session_end.clone(),
-        control_log_path.clone(),
-        shutdown_log_path.clone(),
-    );
 
     writer.send(&WorkerToServer::WorkerReady {
         protocol: Protocol {
@@ -180,6 +173,22 @@ fn run_v3_worker(
     if std::env::var_os(STARTUP_PROTOCOL_ERROR_ENV).is_some() {
         writer.send_raw_json(INVALID_OUTPUT_TEXT_BASE64)?;
     }
+    if std::env::var_os(STALL_CONTROL_READER_ENV).is_some() {
+        let _sideband_reader = sideband_reader;
+        let _turn_tx = tx;
+        loop {
+            thread::park();
+        }
+    }
+
+    start_v3_control_reader(
+        sideband_reader,
+        tx,
+        sideband_interrupted.clone(),
+        control_session_end.clone(),
+        control_log_path.clone(),
+        shutdown_log_path.clone(),
+    );
 
     let mut state = V3CommandState {
         next_prompt: "v3> ".to_string(),

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
+    mpsc,
 };
 use std::thread;
 use std::time::{Duration, Instant};
@@ -24,6 +25,8 @@ const IPC_PIPE_TO_WORKER_ENV: &str = "MCP_REPL_IPC_PIPE_TO_WORKER";
 const IPC_PIPE_FROM_WORKER_ENV: &str = "MCP_REPL_IPC_PIPE_FROM_WORKER";
 const STARTUP_PROTOCOL_ERROR_ENV: &str = "MCP_REPL_ZOD_STARTUP_PROTOCOL_ERROR";
 const SHUTDOWN_LOG_ENV: &str = "MCP_REPL_ZOD_SHUTDOWN_LOG";
+const PROTOCOL_VERSION_ENV: &str = "MCP_REPL_ZOD_PROTOCOL_VERSION";
+const CONTROL_LOG_ENV: &str = "MCP_REPL_ZOD_CONTROL_LOG";
 const INVALID_OUTPUT_TEXT_BASE64: &str =
     r#"{"type":"output_text","stream":"stdout","data_b64":"***"}"#;
 const INVALID_SESSION_END_REASON: &str =
@@ -38,6 +41,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let transport = IpcTransport::connect_from_env()?;
     let writer = IpcWriter::new(transport.writer);
+    let protocol_version = std::env::var(PROTOCOL_VERSION_ENV)
+        .ok()
+        .as_deref()
+        .unwrap_or("2")
+        .parse::<u32>()?;
+    if protocol_version == 3 {
+        return run_v3_worker(transport.reader, writer);
+    }
+
     let sideband_interrupted = Arc::new(AtomicBool::new(false));
     let control_session_end = Arc::new(AtomicBool::new(false));
     let shutdown_log_path = std::env::var_os(SHUTDOWN_LOG_ENV).map(PathBuf::from);
@@ -132,6 +144,256 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             std::mem::replace(&mut command_state.next_prompt, "zod> ".to_string()),
         )?;
     }
+}
+
+fn run_v3_worker(
+    sideband_reader: Box<dyn Read + Send>,
+    writer: IpcWriter,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let control_log_path = std::env::var_os(CONTROL_LOG_ENV).map(PathBuf::from);
+    let shutdown_log_path = std::env::var_os(SHUTDOWN_LOG_ENV).map(PathBuf::from);
+    let sideband_interrupted = Arc::new(AtomicBool::new(false));
+    let control_session_end = Arc::new(AtomicBool::new(false));
+    let (tx, rx) = mpsc::channel();
+
+    start_v3_stdin_observer(control_log_path.clone());
+    start_v3_control_reader(
+        sideband_reader,
+        tx,
+        sideband_interrupted.clone(),
+        control_session_end.clone(),
+        control_log_path.clone(),
+        shutdown_log_path.clone(),
+    );
+
+    writer.send(&WorkerToServer::WorkerReady {
+        protocol: Protocol {
+            name: "mcp-repl-worker".to_string(),
+            version: 3,
+        },
+        worker: WorkerIdentity {
+            name: "zod".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+        capabilities: Capabilities { images: true },
+    })?;
+    if std::env::var_os(STARTUP_PROTOCOL_ERROR_ENV).is_some() {
+        writer.send_raw_json(INVALID_OUTPUT_TEXT_BASE64)?;
+    }
+
+    let mut state = V3CommandState {
+        next_prompt: "v3> ".to_string(),
+        previous_line_empty: false,
+        input_line_after_idle: false,
+        bad_output_after_idle: None,
+    };
+    while let Ok(message) = rx.recv() {
+        match message {
+            ServerToWorker::TurnStart { turn_id, input } => {
+                if run_v3_turn(
+                    &writer,
+                    &sideband_interrupted,
+                    &control_log_path,
+                    turn_id,
+                    &input,
+                    &mut state,
+                )? {
+                    return Ok(());
+                }
+            }
+            ServerToWorker::SessionEnd => {
+                let shutdown_event = if control_session_end.load(Ordering::SeqCst) {
+                    "sideband_shutdown"
+                } else {
+                    "sideband_reader_closed"
+                };
+                append_shutdown_log(shutdown_log_path.as_deref(), shutdown_event)?;
+                send_v3_session_end(&writer, None, "shutdown")?;
+                return Ok(());
+            }
+            ServerToWorker::Interrupt { .. } | ServerToWorker::Other => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn run_v3_turn(
+    writer: &IpcWriter,
+    sideband_interrupted: &AtomicBool,
+    control_log_path: &Option<PathBuf>,
+    turn_id: u64,
+    input: &str,
+    state: &mut V3CommandState,
+) -> io::Result<bool> {
+    for raw_line in v3_runtime_lines(input) {
+        let prompt = state.next_prompt.clone();
+        writer.send(&WorkerToServer::InputLine {
+            turn_id,
+            prompt,
+            text: raw_line.clone(),
+        })?;
+        append_control_log(
+            control_log_path.as_deref(),
+            &format!(
+                "input_line turn_id={turn_id} text={}",
+                escape_bytes(raw_line.as_bytes())
+            ),
+        )?;
+        let command = raw_line.trim_end_matches(['\r', '\n']);
+        if run_v3_command(
+            writer,
+            sideband_interrupted,
+            control_log_path,
+            turn_id,
+            command,
+            state,
+        )? {
+            return Ok(true);
+        }
+        state.previous_line_empty = command.is_empty();
+    }
+
+    let prompt = std::mem::replace(&mut state.next_prompt, "v3> ".to_string());
+    writer.send(&WorkerToServer::Idle { turn_id, prompt })?;
+    append_control_log(
+        control_log_path.as_deref(),
+        &format!("idle turn_id={turn_id}"),
+    )?;
+    if state.input_line_after_idle {
+        state.input_line_after_idle = false;
+        append_control_log(
+            control_log_path.as_deref(),
+            &format!("late_input_line turn_id={turn_id}"),
+        )?;
+        writer.send(&WorkerToServer::InputLine {
+            turn_id,
+            prompt: "v3> ".to_string(),
+            text: "late\n".to_string(),
+        })?;
+    }
+    if let Some(delay) = state.bad_output_after_idle.take() {
+        let writer = writer.clone();
+        let control_log_path = control_log_path.clone();
+        thread::spawn(move || {
+            thread::sleep(delay);
+            let _ = append_control_log(
+                control_log_path.as_deref(),
+                &format!("late_bad_output turn_id={turn_id}"),
+            );
+            let _ = writer.send_raw_json(INVALID_OUTPUT_TEXT_BASE64);
+        });
+    }
+    Ok(false)
+}
+
+fn run_v3_command(
+    writer: &IpcWriter,
+    sideband_interrupted: &AtomicBool,
+    control_log_path: &Option<PathBuf>,
+    turn_id: u64,
+    command: &str,
+    state: &mut V3CommandState,
+) -> io::Result<bool> {
+    if command == "idle-only" {
+        return Ok(false);
+    }
+
+    if let Some(prompt) = command.strip_prefix("wait ") {
+        state.next_prompt = prompt.to_string();
+        return Ok(false);
+    }
+
+    if let Some(millis) = command.strip_prefix("sleep ") {
+        sleep_for(parse_millis(millis)?, sideband_interrupted, false);
+        return Ok(false);
+    }
+
+    if let Some(millis) = command.strip_prefix("interrupt-report ") {
+        let report = observe_interrupts_for(parse_millis(millis)?, sideband_interrupted);
+        let text = format!(
+            "sideband interrupt: {}\nos interrupt: {}\n",
+            if report.sideband {
+                "observed"
+            } else {
+                "missing"
+            },
+            if report.os { "observed" } else { "missing" },
+        );
+        v3_output_text(writer, control_log_path, turn_id, text.as_bytes())?;
+        return Ok(false);
+    }
+
+    if command == "emit-output-after-input" {
+        v3_output_text(writer, control_log_path, turn_id, b"after input_line\n")?;
+        return Ok(false);
+    }
+
+    if command == "late-input-line-after-idle" {
+        state.input_line_after_idle = true;
+        return Ok(false);
+    }
+
+    if let Some(millis) = command.strip_prefix("bad-output-after-idle ") {
+        state.bad_output_after_idle = Some(Duration::from_millis(parse_millis(millis)?));
+        return Ok(false);
+    }
+
+    if command == "exit" {
+        send_v3_session_end(writer, Some(turn_id), "runtime_exit")?;
+        return Ok(true);
+    }
+
+    let text = format!("v3-output: {command}\n");
+    v3_output_text(writer, control_log_path, turn_id, text.as_bytes())?;
+    Ok(false)
+}
+
+fn v3_output_text(
+    writer: &IpcWriter,
+    control_log_path: &Option<PathBuf>,
+    turn_id: u64,
+    bytes: &[u8],
+) -> io::Result<()> {
+    append_control_log(
+        control_log_path.as_deref(),
+        &format!("output_text turn_id={turn_id}"),
+    )?;
+    writer.output_text("stdout", bytes)
+}
+
+fn send_v3_session_end(writer: &IpcWriter, turn_id: Option<u64>, reason: &str) -> io::Result<()> {
+    writer.send(&WorkerToServer::SessionEnd {
+        reason: reason.to_string(),
+        message_b64: None,
+        turn_id,
+    })
+}
+
+fn v3_runtime_lines(input: &str) -> Vec<String> {
+    let mut text = input.to_string();
+    if !text.ends_with(['\n', '\r']) {
+        text.push('\n');
+    }
+    let mut lines = Vec::new();
+    let mut start = 0usize;
+    for (idx, ch) in text.char_indices() {
+        if ch == '\n' {
+            lines.push(text[start..=idx].to_string());
+            start = idx + ch.len_utf8();
+        }
+    }
+    if start < text.len() {
+        lines.push(text[start..].to_string());
+    }
+    lines
+}
+
+struct V3CommandState {
+    next_prompt: String,
+    previous_line_empty: bool,
+    input_line_after_idle: bool,
+    bad_output_after_idle: Option<Duration>,
 }
 
 fn run_command(
@@ -428,8 +690,92 @@ fn send_session_end(writer: &IpcWriter, timeline: &mut Timeline, reason: &str) -
     writer.send(&WorkerToServer::SessionEnd {
         reason: reason.to_string(),
         message_b64: None,
+        turn_id: None,
     })?;
     timeline.run(LifecyclePoint::AfterSessionEnd, writer)
+}
+
+fn start_v3_control_reader(
+    reader: Box<dyn Read + Send>,
+    turn_tx: mpsc::Sender<ServerToWorker>,
+    interrupted: Arc<AtomicBool>,
+    control_session_end: Arc<AtomicBool>,
+    control_log_path: Option<PathBuf>,
+    shutdown_log_path: Option<PathBuf>,
+) {
+    thread::spawn(move || {
+        let mut reader = BufReader::new(reader);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) | Err(_) => return,
+                Ok(_) => {}
+            }
+            let message = serde_json::from_str::<ServerToWorker>(line.trim_end());
+            match message {
+                Ok(ServerToWorker::TurnStart { turn_id, input }) => {
+                    let _ = append_control_log(
+                        control_log_path.as_deref(),
+                        &format!(
+                            "turn_start turn_id={turn_id} input={}",
+                            escape_bytes(input.as_bytes())
+                        ),
+                    );
+                    let _ = turn_tx.send(ServerToWorker::TurnStart { turn_id, input });
+                }
+                Ok(ServerToWorker::Interrupt { turn_id }) => {
+                    interrupted.store(true, Ordering::SeqCst);
+                    let rendered_turn = turn_id
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "<none>".to_string());
+                    let _ = append_control_log(
+                        control_log_path.as_deref(),
+                        &format!("interrupt turn_id={rendered_turn}"),
+                    );
+                }
+                Ok(ServerToWorker::SessionEnd) => {
+                    control_session_end.store(true, Ordering::SeqCst);
+                    let _ =
+                        append_shutdown_log(shutdown_log_path.as_deref(), "control_session_end");
+                    let _ = append_control_log(control_log_path.as_deref(), "session_end");
+                    let _ = turn_tx.send(ServerToWorker::SessionEnd);
+                    return;
+                }
+                Ok(ServerToWorker::Other) | Err(_) => {}
+            }
+        }
+    });
+}
+
+fn start_v3_stdin_observer(control_log_path: Option<PathBuf>) {
+    thread::spawn(move || {
+        let stdin = io::stdin();
+        let mut stdin = stdin.lock();
+        let mut buffer = [0u8; 1024];
+        loop {
+            match stdin.read(&mut buffer) {
+                Ok(0) | Err(_) => return,
+                Ok(len) => {
+                    let _ = append_control_log(
+                        control_log_path.as_deref(),
+                        &format!("stdin:{}", escape_bytes(&buffer[..len])),
+                    );
+                }
+            }
+        }
+    });
+}
+
+fn append_control_log(path: Option<&Path>, event: &str) -> io::Result<()> {
+    let Some(path) = path else {
+        return Ok(());
+    };
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    file.write_all(format!("{event}\n").as_bytes())
 }
 
 fn append_shutdown_log(path: Option<&Path>, event: &str) -> io::Result<()> {
@@ -665,7 +1011,14 @@ fn install_signal_handler() {
 #[derive(Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum ServerToWorker {
-    Interrupt,
+    TurnStart {
+        turn_id: u64,
+        input: String,
+    },
+    Interrupt {
+        #[serde(default)]
+        turn_id: Option<u64>,
+    },
     SessionEnd,
     #[serde(other)]
     Other,
@@ -688,6 +1041,15 @@ enum WorkerToServer {
     ReadlineDiscardBytes {
         data_b64: String,
     },
+    InputLine {
+        turn_id: u64,
+        prompt: String,
+        text: String,
+    },
+    Idle {
+        turn_id: u64,
+        prompt: String,
+    },
     OutputText {
         stream: String,
         data_b64: String,
@@ -702,6 +1064,8 @@ enum WorkerToServer {
         reason: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         message_b64: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        turn_id: Option<u64>,
     },
 }
 
@@ -829,7 +1193,7 @@ fn start_control_reader(
             }
             let message = serde_json::from_str::<ServerToWorker>(line.trim_end());
             match message {
-                Ok(ServerToWorker::Interrupt) => {
+                Ok(ServerToWorker::Interrupt { .. }) => {
                     interrupted.store(true, Ordering::SeqCst);
                 }
                 Ok(ServerToWorker::SessionEnd) => {
@@ -838,7 +1202,7 @@ fn start_control_reader(
                         append_shutdown_log(shutdown_log_path.as_deref(), "control_session_end");
                     return;
                 }
-                Ok(ServerToWorker::Other) | Err(_) => {}
+                Ok(ServerToWorker::TurnStart { .. }) | Ok(ServerToWorker::Other) | Err(_) => {}
             }
         }
     });

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -420,7 +420,7 @@ async fn zod_worker_v3_busy_follow_up_does_not_send_second_turn_start() -> TestR
         .call_tool_raw(
             "repl",
             json!({
-                "input": "sleep 150",
+                "input": "interrupt-report 5000",
                 "timeout_ms": 10
             }),
         )
@@ -446,19 +446,19 @@ async fn zod_worker_v3_busy_follow_up_does_not_send_second_turn_start() -> TestR
         "expected busy follow-up response, got: {busy_text:?}"
     );
 
-    let poll = session
+    let interrupted = session
         .call_tool_raw(
             "repl",
             json!({
-                "input": "",
+                "input": "\u{3}",
                 "timeout_ms": 10_000
             }),
         )
         .await?;
-    let poll_text = result_text(&poll);
+    let interrupted_text = result_text(&interrupted);
     assert!(
-        poll_text.contains("v3> "),
-        "expected first turn to settle on poll, got: {poll_text:?}"
+        interrupted_text.contains("sideband interrupt: observed"),
+        "expected active turn to settle after interrupt, got: {interrupted_text:?}"
     );
 
     let log = wait_for_log_contains(&control_log, "idle turn_id=1")?;

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -618,6 +618,53 @@ async fn zod_worker_v3_latched_protocol_error_blocks_next_turn_start() -> TestRe
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_v3_protocol_error_after_timeout_blocks_next_turn_start() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_v3_server(&control_log).await?;
+
+    let first = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "bad-output-after-sleep 80",
+                "timeout_ms": 10
+            }),
+        )
+        .await?;
+    let first_text = result_text(&first);
+    assert!(
+        first_text.contains("<<repl status: busy"),
+        "expected initial timeout busy status, got: {first_text:?}"
+    );
+    wait_for_log_contains(&control_log, "bad_output_after_sleep turn_id=1")?;
+
+    let second = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "must not reach timed-out v3 worker",
+                "timeout_ms": 100
+            }),
+        )
+        .await?;
+    let second_text = result_text(&second);
+    assert!(
+        second_text.contains("invalid output_text base64"),
+        "expected delayed protocol error on follow-up, got: {second_text:?}"
+    );
+
+    let log = read_optional(&control_log);
+    assert!(
+        !log.contains("must not reach timed-out v3 worker"),
+        "delayed protocol error must prevent the next turn_start, got log: {log:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn zod_worker_raw_line_escape_preserves_stdin_bytes() -> TestResult<()> {
     let session = spawn_zod_server().await?;
 

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -41,6 +41,24 @@ fn result_image_count(result: &rmcp::model::CallToolResult) -> usize {
         .count()
 }
 
+fn read_optional(path: &std::path::Path) -> String {
+    fs::read_to_string(path).unwrap_or_default()
+}
+
+fn wait_for_log_contains(path: &std::path::Path, needle: &str) -> TestResult<String> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        let text = read_optional(path);
+        if text.contains(needle) {
+            return Ok(text);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(format!("expected {needle:?} in {}, got {text:?}", path.display()).into());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
+
 fn zod_worker_path() -> TestResult<PathBuf> {
     match ZOD_WORKER_PATH.get_or_init(build_zod_worker) {
         Ok(path) => Ok(path.clone()),
@@ -134,6 +152,15 @@ async fn spawn_zod_server() -> TestResult<common::McpTestSession> {
     spawn_zod_server_with_env(Vec::new()).await
 }
 
+async fn spawn_zod_v3_server(control_log: &std::path::Path) -> TestResult<common::McpTestSession> {
+    let control_log_text = control_log.display().to_string();
+    spawn_zod_server_with_env(vec![
+        ("MCP_REPL_ZOD_PROTOCOL_VERSION", "3"),
+        ("MCP_REPL_ZOD_CONTROL_LOG", control_log_text.as_str()),
+    ])
+    .await
+}
+
 fn latest_debug_events(debug_dir: &std::path::Path) -> TestResult<Vec<Value>> {
     let mut sessions = fs::read_dir(debug_dir)?
         .filter_map(|entry| entry.ok().map(|entry| entry.path()))
@@ -173,6 +200,417 @@ async fn zod_worker_echoes_input_and_returns_worker_prompt() -> TestResult<()> {
     assert!(
         text.contains("zod> "),
         "expected worker-supplied prompt in response, got: {text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_v3_receives_turn_start_without_raw_stdin() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_v3_server(&control_log).await?;
+
+    let result = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "hello v3",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let text = result_text(&result);
+
+    assert!(
+        text.contains("v3-output: hello v3\n"),
+        "expected v3 worker to receive input through turn_start, got: {text:?}"
+    );
+    assert!(
+        !text.contains("v3> hello v3"),
+        "default reply must elide synthetic input_line echo, got: {text:?}"
+    );
+
+    let log = wait_for_log_contains(&control_log, "turn_start turn_id=1 input=hello v3")?;
+    assert!(
+        !log.contains("stdin:"),
+        "v3 server path must not write request text to raw stdin, got log: {log:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_v3_input_line_is_ordered_before_output_text_but_elided() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_v3_server(&control_log).await?;
+
+    let result = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "emit-output-after-input",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let text = result_text(&result);
+
+    assert!(
+        text.contains("after input_line\n"),
+        "expected output_text after input_line, got: {text:?}"
+    );
+    assert!(
+        !text.contains("v3> emit-output-after-input"),
+        "input_line is structural and should not be rendered by default, got: {text:?}"
+    );
+
+    let log = wait_for_log_contains(
+        &control_log,
+        "input_line turn_id=1 text=emit-output-after-input\\n",
+    )?;
+    let input_line = log
+        .find("input_line turn_id=1")
+        .ok_or_else(|| "missing input_line log".to_string())?;
+    let output_text = log
+        .find("output_text turn_id=1")
+        .ok_or_else(|| "missing output_text log".to_string())?;
+    assert!(
+        input_line < output_text,
+        "expected worker to emit input_line before output_text, got log: {log:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_v3_idle_turn_id_completes_without_readline_start() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_v3_server(&control_log).await?;
+
+    let result = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "idle-only",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let text = result_text(&result);
+
+    assert!(
+        !text.contains("<<repl status: busy"),
+        "idle(turn_id) should complete the turn, got: {text:?}"
+    );
+    assert!(
+        text.contains("v3> "),
+        "expected idle prompt from v3 worker, got: {text:?}"
+    );
+    wait_for_log_contains(&control_log, "idle turn_id=1")?;
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_v3_busy_follow_up_does_not_send_second_turn_start() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_v3_server(&control_log).await?;
+
+    let first = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "sleep 150",
+                "timeout_ms": 10
+            }),
+        )
+        .await?;
+    let first_text = result_text(&first);
+    assert!(
+        first_text.contains("<<repl status: busy"),
+        "expected initial timeout, got: {first_text:?}"
+    );
+
+    let busy = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "second v3 input",
+                "timeout_ms": 10
+            }),
+        )
+        .await?;
+    let busy_text = result_text(&busy);
+    assert!(
+        busy_text.contains("busy") || busy_text.contains("discarded"),
+        "expected busy follow-up response, got: {busy_text:?}"
+    );
+
+    let poll = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let poll_text = result_text(&poll);
+    assert!(
+        poll_text.contains("v3> "),
+        "expected first turn to settle on poll, got: {poll_text:?}"
+    );
+
+    let log = wait_for_log_contains(&control_log, "idle turn_id=1")?;
+    assert!(
+        !log.contains("second v3 input"),
+        "busy follow-up must not reach the active v3 worker, got log: {log:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_v3_interrupt_carries_active_turn_id() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_v3_server(&control_log).await?;
+
+    let first = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "interrupt-report 1000",
+                "timeout_ms": 10
+            }),
+        )
+        .await?;
+    let first_text = result_text(&first);
+    assert!(
+        first_text.contains("<<repl status: busy"),
+        "expected initial timeout, got: {first_text:?}"
+    );
+
+    let interrupted = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "\u{3}",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let interrupted_text = result_text(&interrupted);
+    assert!(
+        interrupted_text.contains("sideband interrupt: observed"),
+        "expected v3 worker to observe sideband interrupt, got: {interrupted_text:?}"
+    );
+
+    wait_for_log_contains(&control_log, "interrupt turn_id=1")?;
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_v3_idle_interrupt_does_not_require_active_turn() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_v3_server(&control_log).await?;
+
+    let first = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "idle-only",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let first_text = result_text(&first);
+    assert!(
+        first_text.contains("v3> "),
+        "expected v3 worker to settle before idle interrupt, got: {first_text:?}"
+    );
+
+    let interrupted = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "\u{3}",
+                "timeout_ms": 100
+            }),
+        )
+        .await?;
+    let interrupted_text = result_text(&interrupted);
+    assert_ne!(
+        interrupted.is_error,
+        Some(true),
+        "idle Ctrl-C must remain a non-error control reply, got: {interrupted_text:?}"
+    );
+    assert!(
+        !interrupted_text.contains("cannot interrupt v3 worker without active turn"),
+        "idle Ctrl-C must not require an active v3 turn, got: {interrupted_text:?}"
+    );
+
+    let log = read_optional(&control_log);
+    assert!(
+        !log.contains("interrupt turn_id="),
+        "idle Ctrl-C must not send a turn-bound sideband interrupt, got log: {log:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_v3_interrupt_after_background_settle_has_no_stale_turn_id() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_v3_server(&control_log).await?;
+
+    let first = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "sleep 50",
+                "timeout_ms": 10
+            }),
+        )
+        .await?;
+    let first_text = result_text(&first);
+    assert!(
+        first_text.contains("<<repl status: busy"),
+        "expected initial timeout, got: {first_text:?}"
+    );
+    wait_for_log_contains(&control_log, "idle turn_id=1")?;
+
+    let interrupted = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "\u{3}",
+                "timeout_ms": 100
+            }),
+        )
+        .await?;
+    let interrupted_text = result_text(&interrupted);
+    assert_ne!(
+        interrupted.is_error,
+        Some(true),
+        "Ctrl-C after background settle must not use stale active-turn state, got: {interrupted_text:?}"
+    );
+
+    let log = read_optional(&control_log);
+    assert!(
+        !log.contains("interrupt turn_id=1"),
+        "Ctrl-C after background settle must not send a stale turn-bound interrupt, got log: {log:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_v3_input_line_after_idle_is_protocol_error() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_v3_server(&control_log).await?;
+
+    let first = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "late-input-line-after-idle",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let first_text = result_text(&first);
+    wait_for_log_contains(&control_log, "late_input_line turn_id=1")?;
+    if first_text.contains("input_line") {
+        assert!(
+            first_text.contains("arrived after idle") || first_text.contains("with no active turn"),
+            "expected late input_line to fail closed as protocol error, got: {first_text:?}"
+        );
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert!(
+        first_text.contains("v3> "),
+        "expected first turn to complete before reporting late input_line, got: {first_text:?}"
+    );
+
+    let second = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "after late input line",
+                "timeout_ms": 100
+            }),
+        )
+        .await?;
+    let second_text = result_text(&second);
+    assert!(
+        second_text.contains("input_line turn_id 1 arrived after idle")
+            || second_text.contains("input_line reported turn_id 1 with no active turn"),
+        "expected late input_line to fail closed as protocol error, got: {second_text:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_v3_latched_protocol_error_blocks_next_turn_start() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_v3_server(&control_log).await?;
+
+    let first = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "bad-output-after-idle 500",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let first_text = result_text(&first);
+    assert!(
+        first_text.contains("v3> "),
+        "expected first turn to complete before delayed protocol error, got: {first_text:?}"
+    );
+    wait_for_log_contains(&control_log, "late_bad_output turn_id=1")?;
+
+    let second = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "must not reach v3 worker",
+                "timeout_ms": 100
+            }),
+        )
+        .await?;
+    let second_text = result_text(&second);
+    assert!(
+        second_text.contains("invalid output_text base64"),
+        "expected latched protocol error before next v3 turn, got: {second_text:?}"
+    );
+
+    let log = read_optional(&control_log);
+    assert!(
+        !log.contains("must not reach v3 worker"),
+        "latched protocol error must prevent the next turn_start, got log: {log:?}"
     );
 
     session.cancel().await?;

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -59,6 +59,36 @@ fn wait_for_log_contains(path: &std::path::Path, needle: &str) -> TestResult<Str
     }
 }
 
+fn wait_for_debug_event_message_contains(
+    debug_dir: &std::path::Path,
+    event: &str,
+    needle: &str,
+) -> TestResult<Value> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    let mut latest = Vec::new();
+    loop {
+        if let Ok(events) = latest_debug_events(debug_dir) {
+            latest = events;
+            if let Some(entry) = latest.iter().find(|entry| {
+                entry["event"] == event
+                    && entry["payload"]["message"]
+                        .as_str()
+                        .is_some_and(|message| message.contains(needle))
+            }) {
+                return Ok(entry.clone());
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(format!(
+                "expected {event:?} containing {needle:?} in {}, got {latest:?}",
+                debug_dir.display()
+            )
+            .into());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
+
 fn zod_worker_path() -> TestResult<PathBuf> {
     match ZOD_WORKER_PATH.get_or_init(build_zod_worker) {
         Ok(path) => Ok(path.clone()),
@@ -153,11 +183,21 @@ async fn spawn_zod_server() -> TestResult<common::McpTestSession> {
 }
 
 async fn spawn_zod_v3_server(control_log: &std::path::Path) -> TestResult<common::McpTestSession> {
+    spawn_zod_v3_server_with_extra_args(control_log, Vec::new()).await
+}
+
+async fn spawn_zod_v3_server_with_extra_args(
+    control_log: &std::path::Path,
+    extra_args: Vec<String>,
+) -> TestResult<common::McpTestSession> {
     let control_log_text = control_log.display().to_string();
-    spawn_zod_server_with_env(vec![
-        ("MCP_REPL_ZOD_PROTOCOL_VERSION", "3"),
-        ("MCP_REPL_ZOD_CONTROL_LOG", control_log_text.as_str()),
-    ])
+    spawn_zod_server_with_env_and_extra_args(
+        vec![
+            ("MCP_REPL_ZOD_PROTOCOL_VERSION", "3"),
+            ("MCP_REPL_ZOD_CONTROL_LOG", control_log_text.as_str()),
+        ],
+        extra_args,
+    )
     .await
 }
 
@@ -574,7 +614,12 @@ async fn zod_worker_v3_input_line_after_idle_is_protocol_error() -> TestResult<(
 async fn zod_worker_v3_latched_protocol_error_blocks_next_turn_start() -> TestResult<()> {
     let tempdir = tempfile::tempdir()?;
     let control_log = tempdir.path().join("control.log");
-    let session = spawn_zod_v3_server(&control_log).await?;
+    let debug_dir = tempdir.path().join("debug");
+    let session = spawn_zod_v3_server_with_extra_args(
+        &control_log,
+        vec!["--debug-dir".to_string(), debug_dir.display().to_string()],
+    )
+    .await?;
 
     let first = session
         .call_tool_raw(
@@ -590,7 +635,11 @@ async fn zod_worker_v3_latched_protocol_error_blocks_next_turn_start() -> TestRe
         first_text.contains("v3> "),
         "expected first turn to complete before delayed protocol error, got: {first_text:?}"
     );
-    wait_for_log_contains(&control_log, "late_bad_output turn_id=1")?;
+    wait_for_debug_event_message_contains(
+        &debug_dir,
+        "worker_protocol_error_latched",
+        "invalid output_text base64",
+    )?;
 
     let second = session
         .call_tool_raw(
@@ -621,7 +670,12 @@ async fn zod_worker_v3_latched_protocol_error_blocks_next_turn_start() -> TestRe
 async fn zod_worker_v3_protocol_error_after_timeout_blocks_next_turn_start() -> TestResult<()> {
     let tempdir = tempfile::tempdir()?;
     let control_log = tempdir.path().join("control.log");
-    let session = spawn_zod_v3_server(&control_log).await?;
+    let debug_dir = tempdir.path().join("debug");
+    let session = spawn_zod_v3_server_with_extra_args(
+        &control_log,
+        vec!["--debug-dir".to_string(), debug_dir.display().to_string()],
+    )
+    .await?;
 
     let first = session
         .call_tool_raw(
@@ -637,7 +691,11 @@ async fn zod_worker_v3_protocol_error_after_timeout_blocks_next_turn_start() -> 
         first_text.contains("<<repl status: busy"),
         "expected initial timeout busy status, got: {first_text:?}"
     );
-    wait_for_log_contains(&control_log, "bad_output_after_sleep turn_id=1")?;
+    wait_for_debug_event_message_contains(
+        &debug_dir,
+        "worker_protocol_error_latched",
+        "invalid output_text base64",
+    )?;
 
     let second = session
         .call_tool_raw(

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::OnceLock;
+use std::time::Duration;
 
 static ZOD_WORKER_PATH: OnceLock<Result<PathBuf, String>> = OnceLock::new();
 
@@ -201,6 +202,21 @@ async fn spawn_zod_v3_server_with_extra_args(
     .await
 }
 
+async fn spawn_zod_v3_stalled_control_server(
+    control_log: &std::path::Path,
+) -> TestResult<common::McpTestSession> {
+    let control_log_text = control_log.display().to_string();
+    spawn_zod_server_with_env_and_extra_args(
+        vec![
+            ("MCP_REPL_ZOD_PROTOCOL_VERSION", "3"),
+            ("MCP_REPL_ZOD_CONTROL_LOG", control_log_text.as_str()),
+            ("MCP_REPL_ZOD_STALL_CONTROL_READER", "1"),
+        ],
+        Vec::new(),
+    )
+    .await
+}
+
 fn latest_debug_events(debug_dir: &std::path::Path) -> TestResult<Vec<Value>> {
     let mut sessions = fs::read_dir(debug_dir)?
         .filter_map(|entry| entry.ok().map(|entry| entry.path()))
@@ -276,6 +292,42 @@ async fn zod_worker_v3_receives_turn_start_without_raw_stdin() -> TestResult<()>
     assert!(
         !log.contains("stdin:"),
         "v3 server path must not write request text to raw stdin, got log: {log:?}"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_worker_v3_turn_start_write_respects_timeout_when_control_reader_stalls()
+-> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_v3_stalled_control_server(&control_log).await?;
+    let input = "x".repeat(2 * 1024 * 1024);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(3),
+        session.call_tool_raw(
+            "repl",
+            json!({
+                "input": input,
+                "timeout_ms": 100
+            }),
+        ),
+    )
+    .await;
+    let result = match result {
+        Ok(result) => result?,
+        Err(_) => {
+            session.cancel().await?;
+            panic!("v3 turn_start write did not respect timeout_ms");
+        }
+    };
+    let text = result_text(&result);
+    assert!(
+        text.contains("worker response timed out"),
+        "expected bounded turn_start write timeout, got: {text:?}"
     );
 
     session.cancel().await?;


### PR DESCRIPTION
## Summary

This PR documents and implements the first worker-owned turn protocol slice for custom workers. Protocol v3 sends `turn_start` with a `turn_id` and input over sideband, lets workers emit ordered `input_line`, `output_text`, `idle`, and `session_end` events, and makes `idle(turn_id)` or session termination the same-worker completion boundary.

It preserves the existing built-in R/Python v2 path while adding a v3 path for custom workers that does not write request text to raw stdin. The Zod fixture now exercises both v2 and v3 behavior.

## Public-Facing Changes

- Adds worker sideband protocol v3 documentation for third-party/custom workers.
- Defines structural `input_line` events so default replies can elide input echoes while still allowing synthetic transcript reconstruction from ordered server events.
- Defines `idle(turn_id)` as the successful same-session completion signal and turn-bound `interrupt(turn_id)` as a stale-control guard.
- No intentional change to built-in R/Python user-facing `repl` output; their compatibility path remains protocol v2.

## Internal-Only Changes

- Adds server active-turn tracking for v3 workers and prevents raw stdin writes on the v3 custom-worker path.
- Bounds v3 `turn_start` delivery by `timeout_ms` so a custom worker that stops reading its control pipe returns a timeout instead of hanging the MCP call.
- Latches v3 protocol errors and blocks the next `turn_start` before user input can reach a bad worker.
- Updates the Zod protocol fixture to cover v3 sideband input, structural echo elision, idle completion, busy follow-up blocking, turn-bound interrupts, stale-turn cleanup, and late protocol errors.
- Updates docs contract coverage for the v3 protocol surface.

## Diff composition

Measured against `origin/main`, this PR is `1533` insertions and `149` deletions across `8` files.
- runtime `src/`: `+345/-25` (`22.0%` of churn)
- inline tests inside `src/`: `+3/-0` (`0.2%` of churn)
- tests in `tests/`: `+991/-3` (`59.1%` of churn)
- docs: `+194/-121` (`18.7%` of churn)

Largest files:
- `tests/zod_protocol.rs`: `+595/-0`
- `tests/fixtures/zod-worker.rs`: `+387/-3`
- `docs/worker_sideband_protocol.md`: `+194/-121`
- `src/ipc.rs`: `+208/-13`
- `src/worker_process.rs`: `+136/-10`

## Testing

- `cargo +nightly fmt`
- `cargo check`
- `cargo build`
- `python3 tests/run_integration_tests.py --binary target/debug/mcp-repl`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
