### PR TITLE
Extract legacy request completion state

### DIFF
--- a/docs/plans/active/worker-server-protocol-zod.md
+++ b/docs/plans/active/worker-server-protocol-zod.md
@@ -841,9 +841,12 @@ worker implementation task, not a server request-handling task.
   latching, and session-end latching moved out of `src/ipc.rs` into
   `src/turn_state.rs`. IPC still owns legacy active-stdin accounting and
   readline stable-wait completion.
-- Next safe slice: separate legacy stdin/readline completion state from
-  `ServerIpcInbox`, then delete any compatibility branches once R,
-  Python, and Zod exercise the same public protocol path.
+- 2026-06-15: Legacy stdin/readline completion state moved out of
+  `ServerIpcInbox` into `src/legacy_request_state.rs`. IPC still owns
+  legacy acknowledgement queues and protocol-version branching.
+- Next safe slice: isolate the legacy acknowledgement queues
+  (`stdin_write_ack` and Python interrupt ack), then delete compatibility
+  branches once R, Python, and Zod exercise the same public protocol path.
 
 ## Acceptance Criteria Before Unblocking Embedded Python
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -26,6 +26,7 @@ use std::time::{Duration, Instant};
 use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 
+use crate::legacy_request_state::LegacyRequestState;
 use crate::output_capture::OutputTextSource;
 use crate::turn_state::TurnState;
 use crate::worker_protocol::TextStream;
@@ -208,11 +209,8 @@ struct ServerIpcInbox {
     last_prompt: Option<String>,
     prompt_history: VecDeque<String>,
     echo_events: VecDeque<IpcEchoEvent>,
-    active_stdin: Option<VecDeque<u8>>,
     turn_state: TurnState,
-    readline_result_count: u64,
-    readline_unmatched_starts: usize,
-    readline_unmatched_since: Option<Instant>,
+    legacy_request_state: LegacyRequestState,
     current_image_id: Option<String>,
     request_image_id: Option<String>,
     plot_source_image_ids: HashMap<String, String>,
@@ -432,17 +430,9 @@ impl ServerIpcConnection {
                     WorkerToServerIpcMessage::ReadlineStart { prompt } => {
                         let prompt_for_handler = prompt.clone();
                         let mut guard = reader_inbox.lock().unwrap();
-                        let waiting_for_new_input = guard
-                            .active_stdin
-                            .as_ref()
-                            .is_none_or(|active_stdin| active_stdin.is_empty());
-                        if waiting_for_new_input {
-                            guard.readline_unmatched_starts =
-                                guard.readline_unmatched_starts.saturating_add(1);
-                            if guard.readline_unmatched_starts == 1 {
-                                guard.readline_unmatched_since = Some(Instant::now());
-                            }
-                        }
+                        guard
+                            .legacy_request_state
+                            .record_readline_start(Instant::now());
                         push_prompt_history(&mut guard, prompt.clone());
                         guard.last_prompt = Some(prompt);
                         reader_cvar.notify_all();
@@ -463,8 +453,9 @@ impl ServerIpcConnection {
                             }
                         };
                         let mut guard = reader_inbox.lock().unwrap();
-                        if let Err(err) =
-                            account_active_stdin(&mut guard, &bytes, "readline_input_bytes")
+                        if let Err(err) = guard
+                            .legacy_request_state
+                            .account_stdin(&bytes, "readline_input_bytes")
                         {
                             guard.turn_state.latch_protocol_error(err);
                             reader_cvar.notify_all();
@@ -484,8 +475,9 @@ impl ServerIpcConnection {
                                 }
                             };
                         let mut guard = reader_inbox.lock().unwrap();
-                        if let Err(err) =
-                            account_active_stdin(&mut guard, &bytes, "readline_discard_bytes")
+                        if let Err(err) = guard
+                            .legacy_request_state
+                            .account_stdin(&bytes, "readline_discard_bytes")
                         {
                             guard.turn_state.latch_protocol_error(err);
                             reader_cvar.notify_all();
@@ -500,13 +492,7 @@ impl ServerIpcConnection {
                             source: OutputTextSource::Ipc,
                         };
                         let mut guard = reader_inbox.lock().unwrap();
-                        guard.readline_result_count = guard.readline_result_count.saturating_add(1);
-                        if guard.readline_unmatched_starts > 0 {
-                            guard.readline_unmatched_starts -= 1;
-                            if guard.readline_unmatched_starts == 0 {
-                                guard.readline_unmatched_since = None;
-                            }
-                        }
+                        guard.legacy_request_state.record_readline_result();
                         guard.echo_events.push_back(echo_event.clone());
                         reader_cvar.notify_all();
                         drop(guard);
@@ -533,7 +519,7 @@ impl ServerIpcConnection {
                             reader_cvar.notify_all();
                             break;
                         }
-                        guard.readline_result_count = guard.readline_result_count.saturating_add(1);
+                        guard.legacy_request_state.record_readline_result();
                         push_prompt_history(&mut guard, prompt);
                         guard.echo_events.push_back(echo_event.clone());
                         reader_cvar.notify_all();
@@ -635,7 +621,7 @@ impl ServerIpcConnection {
                                 id,
                                 is_new,
                                 updates_previous_image,
-                                guard.readline_result_count as usize,
+                                guard.legacy_request_state.readline_result_count(),
                             )
                         };
                         if let Some(handler) = plot_handler.as_ref() {
@@ -683,7 +669,7 @@ impl ServerIpcConnection {
                                 id,
                                 is_new,
                                 updates_previous_image,
-                                guard.readline_result_count as usize,
+                                guard.legacy_request_state.readline_result_count(),
                             )
                         };
                         if let Some(handler) = plot_handler.as_ref() {
@@ -765,7 +751,7 @@ impl ServerIpcConnection {
         reset_after_completed_request(&mut guard);
         drop_stdin_write_acks(&mut guard);
         drop_python_interrupt_acks(&mut guard);
-        guard.active_stdin = Some(payload.iter().copied().collect());
+        guard.legacy_request_state.begin_with_stdin(payload);
         guard.echo_events.clear();
         guard.prompt_history.clear();
         guard.protocol_warnings.clear();
@@ -1965,38 +1951,6 @@ fn take_session_end(guard: &mut ServerIpcInbox) -> bool {
     true
 }
 
-fn account_active_stdin(
-    guard: &mut ServerIpcInbox,
-    bytes: &[u8],
-    event_type: &str,
-) -> Result<(), String> {
-    let Some(active_stdin) = guard.active_stdin.as_mut() else {
-        if bytes.is_empty() {
-            return Ok(());
-        }
-        return Err(format!("{event_type} reported input with no active turn"));
-    };
-    if bytes.len() > active_stdin.len() {
-        return Err(format!(
-            "{event_type} reported {} bytes but only {} active stdin bytes remain",
-            bytes.len(),
-            active_stdin.len()
-        ));
-    }
-    for (idx, expected) in bytes.iter().enumerate() {
-        if active_stdin.get(idx) != Some(expected) {
-            let actual = active_stdin.get(idx).copied();
-            return Err(format!(
-                "{event_type} bytes does not match active stdin at byte {idx}: expected {actual:?}, got {expected}"
-            ));
-        }
-    }
-    for _ in bytes {
-        active_stdin.pop_front();
-    }
-    Ok(())
-}
-
 fn decode_sideband_base64(data_b64: &str, event_type: &str) -> Result<Vec<u8>, String> {
     base64::engine::general_purpose::STANDARD
         .decode(data_b64)
@@ -2060,10 +2014,9 @@ fn request_completion_ready(guard: &ServerIpcInbox, stable_wait: Duration) -> bo
     if guard.turn_state.has_active_turn() {
         return guard.turn_state.request_completion_ready();
     }
-    let Some(since) = guard.readline_unmatched_since else {
-        return false;
-    };
-    guard.readline_unmatched_starts > 0 && since.elapsed() >= stable_wait
+    guard
+        .legacy_request_state
+        .request_completion_ready(stable_wait)
 }
 
 fn validate_session_end(reason: Option<&str>, message_b64: Option<&str>) -> Result<(), String> {
@@ -2106,13 +2059,9 @@ fn request_completion_precedes_latched_protocol_error(
     let Some(error_observed_at) = guard.turn_state.protocol_error_observed_at() else {
         return false;
     };
-    let Some(since) = guard.readline_unmatched_since else {
-        return false;
-    };
-    let Some(stable_at) = since.checked_add(stable_wait) else {
-        return false;
-    };
-    guard.readline_unmatched_starts > 0 && stable_at <= error_observed_at
+    guard
+        .legacy_request_state
+        .request_completion_precedes_protocol_error(error_observed_at, stable_wait)
 }
 
 fn take_request_completion(guard: &mut ServerIpcInbox, stable_wait: Duration) -> bool {
@@ -2133,11 +2082,9 @@ fn request_completion_observed_before_deadline(
             .turn_state
             .request_completion_observed_before(deadline);
     }
-    allow_completion_settle_after_deadline
-        && guard.readline_unmatched_starts > 0
-        && guard
-            .readline_unmatched_since
-            .is_some_and(|since| since <= deadline)
+    guard
+        .legacy_request_state
+        .request_completion_observed_before(deadline, allow_completion_settle_after_deadline)
 }
 
 fn completion_wait_duration(
@@ -2151,17 +2098,11 @@ fn completion_wait_duration(
     if guard.turn_state.has_active_turn() {
         return until_deadline;
     }
-    let Some(since) = guard.readline_unmatched_since else {
-        return until_deadline;
-    };
-    let elapsed = since.elapsed();
-    if elapsed >= stable_wait {
-        Duration::from_millis(0)
-    } else if allow_completion_settle_after_deadline && since <= deadline {
-        stable_wait.saturating_sub(elapsed)
-    } else {
-        until_deadline.min(stable_wait.saturating_sub(elapsed))
-    }
+    guard.legacy_request_state.completion_wait_duration(
+        deadline,
+        stable_wait,
+        allow_completion_settle_after_deadline,
+    )
 }
 
 fn allocate_plot_image_id() -> String {
@@ -2213,11 +2154,8 @@ fn assign_plot_image_id(
 }
 
 fn reset_request_progress(guard: &mut ServerIpcInbox) {
-    guard.active_stdin = None;
     guard.turn_state.clear_request_progress();
-    guard.readline_result_count = 0;
-    guard.readline_unmatched_starts = 0;
-    guard.readline_unmatched_since = None;
+    guard.legacy_request_state.reset_request_progress();
 }
 
 fn reset_after_completed_request(guard: &mut ServerIpcInbox) {

--- a/src/legacy_request_state.rs
+++ b/src/legacy_request_state.rs
@@ -1,0 +1,135 @@
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+#[derive(Default)]
+pub(crate) struct LegacyRequestState {
+    active_stdin: Option<VecDeque<u8>>,
+    readline_result_count: u64,
+    readline_unmatched_starts: usize,
+    readline_unmatched_since: Option<Instant>,
+}
+
+impl LegacyRequestState {
+    pub(crate) fn begin_with_stdin(&mut self, payload: &[u8]) {
+        self.active_stdin = Some(payload.iter().copied().collect());
+    }
+
+    pub(crate) fn record_readline_start(&mut self, observed_at: Instant) {
+        if !self.waiting_for_new_input() {
+            return;
+        }
+        self.readline_unmatched_starts = self.readline_unmatched_starts.saturating_add(1);
+        if self.readline_unmatched_starts == 1 {
+            self.readline_unmatched_since = Some(observed_at);
+        }
+    }
+
+    pub(crate) fn account_stdin(&mut self, bytes: &[u8], event_type: &str) -> Result<(), String> {
+        let Some(active_stdin) = self.active_stdin.as_mut() else {
+            if bytes.is_empty() {
+                return Ok(());
+            }
+            return Err(format!("{event_type} reported input with no active turn"));
+        };
+        if bytes.len() > active_stdin.len() {
+            return Err(format!(
+                "{event_type} reported {} bytes but only {} active stdin bytes remain",
+                bytes.len(),
+                active_stdin.len()
+            ));
+        }
+        for (idx, expected) in bytes.iter().enumerate() {
+            if active_stdin.get(idx) != Some(expected) {
+                let actual = active_stdin.get(idx).copied();
+                return Err(format!(
+                    "{event_type} bytes does not match active stdin at byte {idx}: expected {actual:?}, got {expected}"
+                ));
+            }
+        }
+        for _ in bytes {
+            active_stdin.pop_front();
+        }
+        Ok(())
+    }
+
+    pub(crate) fn record_readline_result(&mut self) {
+        self.readline_result_count = self.readline_result_count.saturating_add(1);
+        if self.readline_unmatched_starts > 0 {
+            self.readline_unmatched_starts -= 1;
+            if self.readline_unmatched_starts == 0 {
+                self.readline_unmatched_since = None;
+            }
+        }
+    }
+
+    pub(crate) fn readline_result_count(&self) -> usize {
+        self.readline_result_count as usize
+    }
+
+    pub(crate) fn request_completion_ready(&self, stable_wait: Duration) -> bool {
+        let Some(since) = self.readline_unmatched_since else {
+            return false;
+        };
+        self.readline_unmatched_starts > 0 && since.elapsed() >= stable_wait
+    }
+
+    pub(crate) fn request_completion_precedes_protocol_error(
+        &self,
+        error_observed_at: Instant,
+        stable_wait: Duration,
+    ) -> bool {
+        let Some(since) = self.readline_unmatched_since else {
+            return false;
+        };
+        let Some(stable_at) = since.checked_add(stable_wait) else {
+            return false;
+        };
+        self.readline_unmatched_starts > 0 && stable_at <= error_observed_at
+    }
+
+    pub(crate) fn request_completion_observed_before(
+        &self,
+        deadline: Instant,
+        allow_completion_settle_after_deadline: bool,
+    ) -> bool {
+        allow_completion_settle_after_deadline
+            && self.readline_unmatched_starts > 0
+            && self
+                .readline_unmatched_since
+                .is_some_and(|since| since <= deadline)
+    }
+
+    pub(crate) fn completion_wait_duration(
+        &self,
+        deadline: Instant,
+        stable_wait: Duration,
+        allow_completion_settle_after_deadline: bool,
+    ) -> Duration {
+        let now = Instant::now();
+        let until_deadline = deadline.saturating_duration_since(now);
+        let Some(since) = self.readline_unmatched_since else {
+            return until_deadline;
+        };
+        let elapsed = since.elapsed();
+        if elapsed >= stable_wait {
+            Duration::from_millis(0)
+        } else if allow_completion_settle_after_deadline && since <= deadline {
+            stable_wait.saturating_sub(elapsed)
+        } else {
+            until_deadline.min(stable_wait.saturating_sub(elapsed))
+        }
+    }
+
+    pub(crate) fn reset_request_progress(&mut self) {
+        self.active_stdin = None;
+        self.readline_result_count = 0;
+        self.readline_unmatched_starts = 0;
+        self.readline_unmatched_since = None;
+    }
+
+    fn waiting_for_new_input(&self) -> bool {
+        self.active_stdin
+            .as_ref()
+            .is_none_or(|active_stdin| active_stdin.is_empty())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod event_log;
 mod html_to_markdown;
 mod install;
 mod ipc;
+mod legacy_request_state;
 mod managed_network;
 mod output_capture;
 mod output_stream;


### PR DESCRIPTION
## Summary

Extracts legacy stdin/readline request bookkeeping from the IPC inbox into a dedicated `LegacyRequestState` module.

## User-facing changes

None. This is an internal refactor with no intended behavior changes.

## Internal changes

- Moves active stdin byte accounting into `src/legacy_request_state.rs`.
- Moves legacy readline stable-wait completion tracking into the same module.
- Keeps `ServerIpcInbox` focused on IPC queues, prompt history, turn state, images, and connection status.
- Updates the active protocol refactor plan to record this slice and point the next slice at legacy acknowledgement queues.

## Benefits

This narrows the request-completion state that reviewers need to inspect inside `ipc.rs` and creates a clearer boundary between legacy readline/stdin handling and the newer turn-state protocol path.
