### PR TITLE
Add Windows Python ConPTY turn support

### DIFF
--- a/docs/plans/active/windows-python-conpty-turn-protocol.md
+++ b/docs/plans/active/windows-python-conpty-turn-protocol.md
@@ -1,0 +1,63 @@
+# Windows Python ConPTY Turn Protocol
+
+## Summary
+
+- Add Windows Python PTY support around worker-owned turns.
+- Keep server completion independent of stdin writes, prompt-looking output, PTY byte counts, and timing.
+- Keep the existing Unix Python path unchanged for this slice unless shared protocol code needs small helpers.
+
+## Status
+
+- State: active
+- Last updated: 2026-06-15
+- Current phase: implementation
+
+## Current Direction
+
+- Route built-in Windows Python through worker protocol v3.
+- Let `turn_start` carry accepted input to the Python worker.
+- Let the Python worker own input queuing, logical `input_line` events, and `idle(turn_id)` emission.
+- Use Windows ConPTY for the worker launch envelope and terminal-mode signaling, with sideband IPC remaining on named pipes.
+- Feed CPython top-level input, `input()`, `sys.stdin`, and raw stdin bridges from the worker-owned turn queue at real input wait boundaries.
+
+## Long-Term Direction
+
+- Built-in Python should eventually use one worker-owned turn model on all platforms.
+- Unix still has a legacy built-in adapter in this bounded slice; that is a compatibility tactic, not the target architecture.
+- The Windows sandbox wrapper must create ConPTY for the restricted child when Python is launched through the wrapper. Placing only the wrapper process in a PTY is insufficient because the restricted child would still inherit wrapper-created pipes.
+
+## Phase Status
+
+- Phase 0: completed - read worker protocol, Python worker/session, launch, sandbox, and tests.
+- Phase 1: completed - switch Windows built-in Python to v3 turn ownership.
+- Phase 2: completed - add Windows ConPTY launch support for unsandboxed and sandboxed Python.
+- Phase 3: active - expand Windows Python PTY/turn tests.
+- Phase 4: pending - run required validation.
+
+## Locked Decisions
+
+- The server must not infer turn completion from stdin write success, prompt text, PTY output, byte counts, or timing.
+- The Python worker may emit `idle(turn_id)` only after it observes a safe input wait and knows its active-turn input queue is empty.
+- Interrupt cleanup fails closed: stale interrupts are ignored, and uncertain cleanup must not emit `idle`.
+- Sideband IPC remains separate from ConPTY traffic.
+
+## Open Questions
+
+- Whether additional Windows-specific interrupt tests are needed beyond queued-tail cleanup coverage before marking the plan complete.
+- Whether future work should replace the Python-level Windows ConPTY terminal identity shim with true CRT-visible ConPTY std handles if a stable launch recipe is found.
+
+## Next Safe Slice
+
+- Add or tighten interrupt and sandbox tests, then run the repository-required validation suite.
+
+## Stop Conditions
+
+- Stop and ask if proving input cleanup after Windows interrupt requires changing the user-visible interrupt contract.
+- Stop and ask if sandboxed ConPTY launch requires broad restructuring of the Windows sandbox wrapper beyond a focused child stdio mode.
+
+## Decision Log
+
+- 2026-06-15: Use a checked-in living plan because the work crosses protocol, Python runtime, Windows process launch, sandbox wrapper behavior, and tests.
+- 2026-06-15: Keep Unix Python behavior stable in the first slice to avoid mixing the Windows ConPTY rebuild with a cross-platform protocol migration.
+- 2026-06-15: CPython on this Windows launch path did not invoke `PyOS_ReadlineFunctionPointer` because CRT `isatty()` stayed false, matching `Parser/myreadline.c`; Windows now uses a worker-owned queue REPL loop and Python stdin bridge instead of relying on ConPTY self-feed.
+- 2026-06-15: The ConPTY wrapper keeps sideband IPC separate and tags the child with `MCP_REPL_WINDOWS_CONPTY=1`; embedded Python uses that tag to report terminal identity for managed fd 0/1/2 surfaces while reads still flow through turn state.

--- a/docs/plans/completed/windows-python-conpty-turn-protocol.md
+++ b/docs/plans/completed/windows-python-conpty-turn-protocol.md
@@ -8,17 +8,18 @@
 
 ## Status
 
-- State: active
+- State: completed
 - Last updated: 2026-06-15
-- Current phase: implementation
+- Current phase: validation complete
 
-## Current Direction
+## Final Direction
 
 - Route built-in Windows Python through worker protocol v3.
 - Let `turn_start` carry accepted input to the Python worker.
 - Let the Python worker own input queuing, logical `input_line` events, and `idle(turn_id)` emission.
 - Use Windows ConPTY for the worker launch envelope and terminal-mode signaling, with sideband IPC remaining on named pipes.
 - Feed CPython top-level input, `input()`, `sys.stdin`, and raw stdin bridges from the worker-owned turn queue at real input wait boundaries.
+- Rebind the embedded worker CRT fd `0/1/2` to `CONIN$` / `CONOUT$` before Python initializes so CPython's own TTY checks can invoke `PyOS_ReadlineFunctionPointer`.
 
 ## Long-Term Direction
 
@@ -31,8 +32,8 @@
 - Phase 0: completed - read worker protocol, Python worker/session, launch, sandbox, and tests.
 - Phase 1: completed - switch Windows built-in Python to v3 turn ownership.
 - Phase 2: completed - add Windows ConPTY launch support for unsandboxed and sandboxed Python.
-- Phase 3: active - expand Windows Python PTY/turn tests.
-- Phase 4: pending - run required validation.
+- Phase 3: completed - expanded Windows Python PTY/turn tests.
+- Phase 4: completed - ran required validation and CI.
 
 ## Locked Decisions
 
@@ -40,15 +41,6 @@
 - The Python worker may emit `idle(turn_id)` only after it observes a safe input wait and knows its active-turn input queue is empty.
 - Interrupt cleanup fails closed: stale interrupts are ignored, and uncertain cleanup must not emit `idle`.
 - Sideband IPC remains separate from ConPTY traffic.
-
-## Open Questions
-
-- Whether additional Windows-specific interrupt tests are needed beyond queued-tail cleanup coverage before marking the plan complete.
-- Whether future work should replace the Python-level Windows ConPTY terminal identity shim with true CRT-visible ConPTY std handles if a stable launch recipe is found.
-
-## Next Safe Slice
-
-- Add or tighten interrupt and sandbox tests, then run the repository-required validation suite.
 
 ## Stop Conditions
 
@@ -59,5 +51,6 @@
 
 - 2026-06-15: Use a checked-in living plan because the work crosses protocol, Python runtime, Windows process launch, sandbox wrapper behavior, and tests.
 - 2026-06-15: Keep Unix Python behavior stable in the first slice to avoid mixing the Windows ConPTY rebuild with a cross-platform protocol migration.
-- 2026-06-15: CPython on this Windows launch path did not invoke `PyOS_ReadlineFunctionPointer` because CRT `isatty()` stayed false, matching `Parser/myreadline.c`; Windows now uses a worker-owned queue REPL loop and Python stdin bridge instead of relying on ConPTY self-feed.
-- 2026-06-15: The ConPTY wrapper keeps sideband IPC separate and tags the child with `MCP_REPL_WINDOWS_CONPTY=1`; embedded Python uses that tag to report terminal identity for managed fd 0/1/2 surfaces while reads still flow through turn state.
+- 2026-06-15: CPython on the initial Windows launch path did not invoke `PyOS_ReadlineFunctionPointer` because CRT `isatty()` stayed false, matching `Parser/myreadline.c`; the final design rebinds the embedded worker CRT fds to ConPTY console devices before Python initializes.
+- 2026-06-15: The ConPTY wrapper keeps sideband IPC separate and tags the child with `MCP_REPL_WINDOWS_CONPTY=1`; embedded Python no longer fakes `os.isatty()` and uses the tag only to track managed raw stdin fds.
+- 2026-06-15: Windows now uses CPython's native `PyRun_InteractiveOneFlags` loop and the worker-owned turn queue feeds `PyOS_ReadlineFunctionPointer`, `input()`, `sys.stdin`, and raw fd reads.

--- a/python/embedded.py
+++ b/python/embedded.py
@@ -1,5 +1,6 @@
 import base64
 import builtins
+import code
 import codecs
 import errno
 import hashlib
@@ -38,9 +39,14 @@ _plot_emit_in_progress = False
 _plot_axes_plot = None
 _plot_show = None
 _plot_emitted_this_request = {}
+_mcp_repl_windows_conpty = (
+    os.name == "nt" and os.environ.get("MCP_REPL_WINDOWS_CONPTY") == "1"
+)
 _mcp_repl_ps1 = ">>> "
 _mcp_repl_ps2 = "... "
-_mcp_repl_c_stdio_tty = os.isatty(0) and os.isatty(1)
+_mcp_repl_c_stdio_tty = (os.isatty(0) and os.isatty(1)) or _mcp_repl_windows_conpty
+_mcp_repl_interpreter = code.InteractiveInterpreter(globals())
+_mcp_repl_last_incomplete = False
 
 
 def _mcp_repl_readinto_type_name(target):
@@ -98,6 +104,11 @@ def _mcp_repl_capture_prompts():
     if not _mcp_repl_c_stdio_tty:
         sys.ps1 = _mcp_repl_suppressed_ps1
         sys.ps2 = _mcp_repl_suppressed_ps2
+
+
+def _mcp_repl_runsource_b64(source_b64):
+    source = base64.b64decode(source_b64).decode("utf-8", "replace")
+    return _mcp_repl_interpreter.runsource(source, "<stdin>", "single")
 
 
 def _input(prompt=""):
@@ -313,7 +324,7 @@ class McpInputStream:
         return False
 
     def isatty(self):
-        return False
+        return bool(_mcp_repl_c_stdio_tty)
 
     def fileno(self):
         return self._fileno
@@ -404,7 +415,7 @@ class McpInputBuffer:
         return False
 
     def isatty(self):
-        return False
+        return bool(_mcp_repl_c_stdio_tty)
 
     def fileno(self):
         return self._text_stream.fileno()
@@ -493,7 +504,7 @@ class McpRawInputBuffer(io.RawIOBase):
         return False
 
     def isatty(self):
-        return False
+        return bool(_mcp_repl_c_stdio_tty)
 
     def fileno(self):
         return self._fileno
@@ -755,8 +766,9 @@ _original_builtins_open = builtins.open
 _original_io_FileIO = io.FileIO
 _original_os_fdopen = os.fdopen
 _original_os_read = os.read
+_original_os_isatty = os.isatty
 _original_os_readv = getattr(os, "readv", None)
-_mcp_repl_raw_stdin_read_supported = os.name == "posix"
+_mcp_repl_raw_stdin_read_supported = os.name in ("posix", "nt")
 # Keep the original fd 0 identity so duplicated stdin fds still use the bridge.
 _mcp_repl_raw_stdin_stat = None
 if _mcp_repl_raw_stdin_read_supported:
@@ -1010,6 +1022,13 @@ def _mcp_repl_os_read(fd, n):
     return _original_os_read(fd, n)
 
 
+def _mcp_repl_os_isatty(fd):
+    fd = operator.index(fd)
+    if _mcp_repl_windows_conpty and fd in (0, 1, 2):
+        return True
+    return _original_os_isatty(fd)
+
+
 def _mcp_repl_os_readv(fd, buffers):
     fd = operator.index(fd)
     if not _mcp_repl_is_raw_stdin_fd(fd):
@@ -1037,6 +1056,20 @@ _mcp_repl.set_python_prompts(_mcp_repl_ps1, _mcp_repl_ps2)
 if _mcp_repl_c_stdio_tty:
     sys.ps1 = _mcp_repl_ps1
     sys.ps2 = _mcp_repl_ps2
+    if os.name == "nt":
+        builtins.open = _mcp_repl_open
+        io.open = _mcp_repl_open
+        io.FileIO = _McpReplFileIO
+        _io.open = _mcp_repl_open
+        _io.FileIO = _McpReplFileIO
+        os.fdopen = _mcp_repl_os_fdopen
+        os.isatty = _mcp_repl_os_isatty
+        os.read = _mcp_repl_os_read
+        if _original_os_readv is not None:
+            os.readv = _mcp_repl_os_readv
+        _mcp_repl_stdin = McpInputStream()
+        sys.stdin = _mcp_repl_stdin
+        sys.__stdin__ = _mcp_repl_stdin
 else:
     builtins.input = _input
     builtins.open = _mcp_repl_open

--- a/python/embedded.py
+++ b/python/embedded.py
@@ -765,6 +765,9 @@ _original_builtins_import = builtins.__import__
 _original_builtins_open = builtins.open
 _original_io_FileIO = io.FileIO
 _original_os_fdopen = os.fdopen
+_original_os_dup = os.dup
+_original_os_dup2 = os.dup2
+_original_os_close = os.close
 _original_os_read = os.read
 _original_os_isatty = os.isatty
 _original_os_readv = getattr(os, "readv", None)
@@ -776,6 +779,17 @@ if _mcp_repl_raw_stdin_read_supported:
         _mcp_repl_raw_stdin_stat = os.fstat(0)
     except OSError:
         pass
+_mcp_repl_windows_stdio_fds = set()
+_mcp_repl_windows_raw_stdin_fds = set()
+if _mcp_repl_windows_conpty:
+    for _mcp_repl_fd in (0, 1, 2):
+        try:
+            os.fstat(_mcp_repl_fd)
+        except OSError:
+            continue
+        _mcp_repl_windows_stdio_fds.add(_mcp_repl_fd)
+        if _mcp_repl_fd == 0:
+            _mcp_repl_windows_raw_stdin_fds.add(_mcp_repl_fd)
 _mcp_repl_stdin_path_aliases = frozenset(("/dev/stdin", "/dev/fd/0", "/proc/self/fd/0"))
 
 
@@ -796,6 +810,8 @@ def _mcp_repl_import(name, globals=None, locals=None, fromlist=(), level=0):
 def _mcp_repl_is_raw_stdin_fd(fd):
     if not _mcp_repl_raw_stdin_read_supported:
         return False
+    if _mcp_repl_windows_conpty:
+        return fd in _mcp_repl_windows_raw_stdin_fds
     if _mcp_repl_raw_stdin_stat is None:
         return fd == 0
     try:
@@ -806,6 +822,30 @@ def _mcp_repl_is_raw_stdin_fd(fd):
         stat.st_dev == _mcp_repl_raw_stdin_stat.st_dev
         and stat.st_ino == _mcp_repl_raw_stdin_stat.st_ino
     )
+
+
+def _mcp_repl_is_managed_windows_stdio_fd(fd):
+    return _mcp_repl_windows_conpty and fd in _mcp_repl_windows_stdio_fds
+
+
+def _mcp_repl_note_windows_dup(source_fd, target_fd):
+    if not _mcp_repl_windows_conpty:
+        return
+    if source_fd in _mcp_repl_windows_stdio_fds:
+        _mcp_repl_windows_stdio_fds.add(target_fd)
+    else:
+        _mcp_repl_windows_stdio_fds.discard(target_fd)
+    if source_fd in _mcp_repl_windows_raw_stdin_fds:
+        _mcp_repl_windows_raw_stdin_fds.add(target_fd)
+    else:
+        _mcp_repl_windows_raw_stdin_fds.discard(target_fd)
+
+
+def _mcp_repl_note_windows_close(fd):
+    if not _mcp_repl_windows_conpty:
+        return
+    _mcp_repl_windows_stdio_fds.discard(fd)
+    _mcp_repl_windows_raw_stdin_fds.discard(fd)
 
 
 def _mcp_repl_is_raw_stdin_path(file):
@@ -1010,6 +1050,27 @@ def _mcp_repl_fill_readv_buffers(buffers, data):
     return offset
 
 
+def _mcp_repl_os_dup(fd):
+    fd = operator.index(fd)
+    duplicated = _original_os_dup(fd)
+    _mcp_repl_note_windows_dup(fd, duplicated)
+    return duplicated
+
+
+def _mcp_repl_os_dup2(fd, fd2, inheritable=True):
+    fd = operator.index(fd)
+    fd2 = operator.index(fd2)
+    result = _original_os_dup2(fd, fd2, inheritable)
+    _mcp_repl_note_windows_dup(fd, fd2)
+    return result
+
+
+def _mcp_repl_os_close(fd):
+    fd = operator.index(fd)
+    _original_os_close(fd)
+    _mcp_repl_note_windows_close(fd)
+
+
 def _mcp_repl_os_read(fd, n):
     fd = operator.index(fd)
     if _mcp_repl_is_raw_stdin_fd(fd):
@@ -1024,7 +1085,7 @@ def _mcp_repl_os_read(fd, n):
 
 def _mcp_repl_os_isatty(fd):
     fd = operator.index(fd)
-    if _mcp_repl_windows_conpty and fd in (0, 1, 2):
+    if _mcp_repl_is_managed_windows_stdio_fd(fd):
         return True
     return _original_os_isatty(fd)
 
@@ -1063,6 +1124,9 @@ if _mcp_repl_c_stdio_tty:
         _io.open = _mcp_repl_open
         _io.FileIO = _McpReplFileIO
         os.fdopen = _mcp_repl_os_fdopen
+        os.dup = _mcp_repl_os_dup
+        os.dup2 = _mcp_repl_os_dup2
+        os.close = _mcp_repl_os_close
         os.isatty = _mcp_repl_os_isatty
         os.read = _mcp_repl_os_read
         if _original_os_readv is not None:

--- a/python/embedded.py
+++ b/python/embedded.py
@@ -44,7 +44,7 @@ _mcp_repl_windows_conpty = (
 )
 _mcp_repl_ps1 = ">>> "
 _mcp_repl_ps2 = "... "
-_mcp_repl_c_stdio_tty = (os.isatty(0) and os.isatty(1)) or _mcp_repl_windows_conpty
+_mcp_repl_c_stdio_tty = os.isatty(0) and os.isatty(1)
 _mcp_repl_interpreter = code.InteractiveInterpreter(globals())
 _mcp_repl_last_incomplete = False
 
@@ -769,7 +769,6 @@ _original_os_dup = os.dup
 _original_os_dup2 = os.dup2
 _original_os_close = os.close
 _original_os_read = os.read
-_original_os_isatty = os.isatty
 _original_os_readv = getattr(os, "readv", None)
 _mcp_repl_raw_stdin_read_supported = os.name in ("posix", "nt")
 # Keep the original fd 0 identity so duplicated stdin fds still use the bridge.
@@ -779,17 +778,14 @@ if _mcp_repl_raw_stdin_read_supported:
         _mcp_repl_raw_stdin_stat = os.fstat(0)
     except OSError:
         pass
-_mcp_repl_windows_stdio_fds = set()
 _mcp_repl_windows_raw_stdin_fds = set()
 if _mcp_repl_windows_conpty:
-    for _mcp_repl_fd in (0, 1, 2):
-        try:
-            os.fstat(_mcp_repl_fd)
-        except OSError:
-            continue
-        _mcp_repl_windows_stdio_fds.add(_mcp_repl_fd)
-        if _mcp_repl_fd == 0:
-            _mcp_repl_windows_raw_stdin_fds.add(_mcp_repl_fd)
+    try:
+        os.fstat(0)
+    except OSError:
+        pass
+    else:
+        _mcp_repl_windows_raw_stdin_fds.add(0)
 _mcp_repl_stdin_path_aliases = frozenset(("/dev/stdin", "/dev/fd/0", "/proc/self/fd/0"))
 
 
@@ -824,17 +820,9 @@ def _mcp_repl_is_raw_stdin_fd(fd):
     )
 
 
-def _mcp_repl_is_managed_windows_stdio_fd(fd):
-    return _mcp_repl_windows_conpty and fd in _mcp_repl_windows_stdio_fds
-
-
 def _mcp_repl_note_windows_dup(source_fd, target_fd):
     if not _mcp_repl_windows_conpty:
         return
-    if source_fd in _mcp_repl_windows_stdio_fds:
-        _mcp_repl_windows_stdio_fds.add(target_fd)
-    else:
-        _mcp_repl_windows_stdio_fds.discard(target_fd)
     if source_fd in _mcp_repl_windows_raw_stdin_fds:
         _mcp_repl_windows_raw_stdin_fds.add(target_fd)
     else:
@@ -844,7 +832,6 @@ def _mcp_repl_note_windows_dup(source_fd, target_fd):
 def _mcp_repl_note_windows_close(fd):
     if not _mcp_repl_windows_conpty:
         return
-    _mcp_repl_windows_stdio_fds.discard(fd)
     _mcp_repl_windows_raw_stdin_fds.discard(fd)
 
 
@@ -1083,13 +1070,6 @@ def _mcp_repl_os_read(fd, n):
     return _original_os_read(fd, n)
 
 
-def _mcp_repl_os_isatty(fd):
-    fd = operator.index(fd)
-    if _mcp_repl_is_managed_windows_stdio_fd(fd):
-        return True
-    return _original_os_isatty(fd)
-
-
 def _mcp_repl_os_readv(fd, buffers):
     fd = operator.index(fd)
     if not _mcp_repl_is_raw_stdin_fd(fd):
@@ -1127,7 +1107,6 @@ if _mcp_repl_c_stdio_tty:
         os.dup = _mcp_repl_os_dup
         os.dup2 = _mcp_repl_os_dup2
         os.close = _mcp_repl_os_close
-        os.isatty = _mcp_repl_os_isatty
         os.read = _mcp_repl_os_read
         if _original_os_readv is not None:
             os.readv = _mcp_repl_os_readv

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -39,7 +39,9 @@ impl WorkerLaunch {
 
     pub fn stdin_transport(&self) -> WorkerStdinTransport {
         match self {
-            Self::Builtin(Backend::Python) if cfg!(target_family = "unix") => {
+            Self::Builtin(Backend::Python)
+                if cfg!(target_family = "unix") || cfg!(target_family = "windows") =>
+            {
                 WorkerStdinTransport::Pty
             }
             Self::Builtin(_) => WorkerStdinTransport::Pipe,
@@ -199,10 +201,18 @@ mod tests {
             WorkerStdinTransport::Pipe
         );
         #[cfg(not(target_family = "unix"))]
-        assert_eq!(
-            WorkerLaunch::Builtin(Backend::Python).stdin_transport(),
-            WorkerStdinTransport::Pipe
-        );
+        {
+            #[cfg(target_family = "windows")]
+            assert_eq!(
+                WorkerLaunch::Builtin(Backend::Python).stdin_transport(),
+                WorkerStdinTransport::Pty
+            );
+            #[cfg(not(target_family = "windows"))]
+            assert_eq!(
+                WorkerLaunch::Builtin(Backend::Python).stdin_transport(),
+                WorkerStdinTransport::Pipe
+            );
+        }
         #[cfg(target_family = "unix")]
         assert_eq!(
             WorkerLaunch::Builtin(Backend::Python).stdin_transport(),

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -747,7 +747,10 @@ impl ServerIpcConnection {
         Ok(())
     }
 
-    #[cfg_attr(target_family = "unix", allow(dead_code))]
+    #[cfg_attr(
+        any(target_family = "unix", target_family = "windows"),
+        allow(dead_code)
+    )]
     pub fn begin_request(&self) {
         let mut guard = self.inbox.lock().unwrap();
         reset_after_completed_request(&mut guard);
@@ -940,7 +943,10 @@ impl ServerIpcConnection {
         }
     }
 
-    #[cfg_attr(target_family = "unix", allow(dead_code))]
+    #[cfg_attr(
+        any(target_family = "unix", target_family = "windows"),
+        allow(dead_code)
+    )]
     pub fn wait_for_stdin_write_ack(&self, timeout: Duration) -> Result<(), IpcWaitError> {
         let deadline = Instant::now() + timeout;
         let mut guard = self.inbox.lock().unwrap();
@@ -1881,11 +1887,23 @@ pub fn emit_plot_image(mime_type: &str, data: &str, is_update: bool, source: Opt
 }
 
 pub fn emit_worker_ready(worker_name: &str, supports_images: bool) {
+    emit_worker_ready_with_protocol(
+        worker_name,
+        supports_images,
+        BUILTIN_WORKER_PROTOCOL_VERSION,
+    );
+}
+
+pub fn emit_worker_ready_v3(worker_name: &str, supports_images: bool) {
+    emit_worker_ready_with_protocol(worker_name, supports_images, WORKER_PROTOCOL_VERSION);
+}
+
+fn emit_worker_ready_with_protocol(worker_name: &str, supports_images: bool, version: u32) {
     if let Some(ipc) = global_ipc() {
         let _ = ipc.send(WorkerToServerIpcMessage::WorkerReady {
             protocol: WorkerProtocol {
                 name: "mcp-repl-worker".to_string(),
-                version: BUILTIN_WORKER_PROTOCOL_VERSION,
+                version,
             },
             worker: WorkerIdentity {
                 name: worker_name.to_string(),
@@ -1894,6 +1912,25 @@ pub fn emit_worker_ready(worker_name: &str, supports_images: bool) {
             capabilities: WorkerCapabilities {
                 images: supports_images,
             },
+        });
+    }
+}
+
+pub fn emit_input_line(turn_id: u64, prompt: &str, text: &str) {
+    if let Some(ipc) = global_ipc() {
+        let _ = ipc.send(WorkerToServerIpcMessage::InputLine {
+            turn_id,
+            prompt: prompt.to_string(),
+            text: text.to_string(),
+        });
+    }
+}
+
+pub fn emit_idle(turn_id: u64, prompt: &str) {
+    if let Some(ipc) = global_ipc() {
+        let _ = ipc.send(WorkerToServerIpcMessage::Idle {
+            turn_id,
+            prompt: prompt.to_string(),
         });
     }
 }
@@ -1916,6 +1953,16 @@ pub fn emit_session_end() {
             reason: None,
             message_b64: None,
             turn_id: None,
+        });
+    }
+}
+
+pub fn emit_session_end_with_reason(reason: &str, turn_id: Option<u64>) {
+    if let Some(ipc) = global_ipc() {
+        let _ = ipc.send(WorkerToServerIpcMessage::SessionEnd {
+            reason: Some(reason.to_string()),
+            message_b64: None,
+            turn_id,
         });
     }
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1894,6 +1894,7 @@ pub fn emit_worker_ready(worker_name: &str, supports_images: bool) {
     );
 }
 
+#[cfg_attr(not(windows), allow(dead_code))]
 pub fn emit_worker_ready_v3(worker_name: &str, supports_images: bool) {
     emit_worker_ready_with_protocol(worker_name, supports_images, WORKER_PROTOCOL_VERSION);
 }
@@ -1916,6 +1917,7 @@ fn emit_worker_ready_with_protocol(worker_name: &str, supports_images: bool, ver
     }
 }
 
+#[cfg_attr(not(windows), allow(dead_code))]
 pub fn emit_input_line(turn_id: u64, prompt: &str, text: &str) {
     if let Some(ipc) = global_ipc() {
         let _ = ipc.send(WorkerToServerIpcMessage::InputLine {
@@ -1926,6 +1928,7 @@ pub fn emit_input_line(turn_id: u64, prompt: &str, text: &str) {
     }
 }
 
+#[cfg_attr(not(windows), allow(dead_code))]
 pub fn emit_idle(turn_id: u64, prompt: &str) {
     if let Some(ipc) = global_ipc() {
         let _ = ipc.send(WorkerToServerIpcMessage::Idle {

--- a/src/legacy_ack_state.rs
+++ b/src/legacy_ack_state.rs
@@ -9,6 +9,7 @@ impl LegacyAckState {
         self.stdin_write_acks += 1;
     }
 
+    #[cfg_attr(target_family = "windows", allow(dead_code))]
     pub(crate) fn take_stdin_write_ack(&mut self) -> bool {
         if self.stdin_write_acks == 0 {
             return false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,8 @@ mod server;
 mod stdin_payload;
 mod turn_state;
 #[cfg(target_os = "windows")]
+mod windows_conpty;
+#[cfg(target_os = "windows")]
 mod windows_sandbox;
 mod worker;
 mod worker_process;
@@ -72,6 +74,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_os = "linux")]
     if sandbox::invoked_as_codex_linux_sandbox() {
         sandbox::run_linux_sandbox_main();
+    }
+    #[cfg(target_os = "windows")]
+    if windows_conpty::invoked_as_windows_conpty() {
+        windows_conpty::run_windows_conpty_main();
     }
     #[cfg(target_os = "windows")]
     if sandbox::invoked_as_codex_windows_sandbox() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // crashing.
     ignore_sigpipe();
     crate::diagnostics::startup_log("main: entry");
+    #[cfg(target_os = "windows")]
+    windows_conpty::attach_stdio_to_conpty_if_attached()?;
+    #[cfg(target_os = "windows")]
+    windows_conpty::emit_stdio_diagnostics_if_requested("main-entry");
     #[cfg(target_os = "linux")]
     if sandbox::invoked_as_codex_linux_sandbox() {
         sandbox::run_linux_sandbox_main();

--- a/src/python_ffi.rs
+++ b/src/python_ffi.rs
@@ -88,6 +88,7 @@ pub struct PythonApi {
         *mut PyObject,
         *mut std::ffi::c_void,
     ) -> *mut PyObject,
+    #[cfg_attr(windows, allow(dead_code))]
     pub py_run_interactive_one_flags:
         unsafe extern "C" fn(*mut libc::FILE, *const c_char, *mut c_void) -> c_int,
     pub py_object_get_attr_string:

--- a/src/python_session.rs
+++ b/src/python_session.rs
@@ -1358,6 +1358,7 @@ fn input_hook_prompt(guard: &SessionStateInner, fallback_prompt: Option<&str>) -
     )
 }
 
+#[cfg_attr(not(windows), allow(dead_code))]
 fn emit_turn_input_line(turn_id: u64, prompt: &str, line: &mut TurnInputLine) {
     if line.input_line_emitted {
         return;
@@ -2526,9 +2527,11 @@ struct ActiveRequest {
 }
 
 struct TurnInputLine {
+    #[cfg_attr(not(windows), allow(dead_code))]
     text: String,
     bytes: Vec<u8>,
     offset: usize,
+    #[cfg_attr(not(windows), allow(dead_code))]
     input_line_emitted: bool,
 }
 

--- a/src/python_session.rs
+++ b/src/python_session.rs
@@ -1,4 +1,3 @@
-#[cfg(target_family = "unix")]
 use std::collections::VecDeque;
 use std::ffi::{CStr, CString, c_char, c_int, c_long};
 #[cfg(target_family = "unix")]
@@ -11,6 +10,8 @@ use std::sync::atomic::AtomicI32;
 use std::sync::atomic::{AtomicPtr, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc};
 
+#[cfg(windows)]
+use base64::Engine as _;
 use serde::Deserialize;
 
 use crate::ipc;
@@ -27,6 +28,7 @@ use windows_sys::Win32::System::Pipes::PeekNamedPipe;
 
 pub const PYTHON_EXECUTABLE_ENV: &str = "MCP_REPL_PYTHON_EXECUTABLE";
 const MCP_REPL_PYTHON: &str = include_str!("../python/embedded.py");
+#[cfg(not(windows))]
 const PYTHON_EOF: c_int = 11;
 const PYTHON_PROGRAM: &str = "python3";
 const PYTHON_PROGRAM_FALLBACK: &str = "python";
@@ -120,6 +122,11 @@ impl PythonSession {
         begin_tracked_request(byte_len, line_count, fallback_prompt, reply_tx)?;
         Ok(reply_rx)
     }
+
+    pub fn begin_turn(&self, turn_id: u64, input: String) -> Result<(), String> {
+        self.wait_until_ready()?;
+        begin_tracked_turn(turn_id, input)
+    }
 }
 
 #[derive(Debug)]
@@ -170,6 +177,7 @@ impl SessionInit {
 }
 
 struct PythonRuntime {
+    #[cfg_attr(windows, allow(dead_code))]
     stdin: *mut libc::FILE,
 }
 
@@ -198,6 +206,30 @@ pub(crate) fn interrupt() {
 
 pub(crate) fn interrupt_request_generation(request_generation: u64) {
     interrupt_for_request_generation(Some(request_generation));
+}
+
+pub(crate) fn interrupt_turn(turn_id: u64) {
+    let Some(state) = SESSION_STATE.get() else {
+        return;
+    };
+    {
+        let mut guard = state.inner.lock().unwrap();
+        let write_in_flight = guard.turn_write_in_flight;
+        let Some(active) = guard.active_request.as_mut() else {
+            return;
+        };
+        if active.turn_id != Some(turn_id) {
+            return;
+        }
+        active.queued_lines.clear();
+        if write_in_flight {
+            guard.turn_cleanup_uncertain = true;
+        }
+        guard.interrupt_requested = true;
+        guard.waiting_for_input = false;
+        state.cvar.notify_all();
+    }
+    request_platform_interrupt();
 }
 
 fn interrupt_for_request_generation(request_generation: Option<u64>) {
@@ -629,6 +661,9 @@ fn run_session_on_current_thread(init: Arc<SessionInit>) -> Result<(), String> {
     }
 
     init.mark_ready();
+    #[cfg(windows)]
+    ipc::emit_worker_ready_v3("python", plot_capable());
+    #[cfg(not(windows))]
     ipc::emit_worker_ready("python", plot_capable());
 
     let result = run_repl(&runtime);
@@ -1107,30 +1142,39 @@ fn configure_python(api: &'static PythonApi) -> Result<(), String> {
 }
 
 fn run_repl(runtime: &PythonRuntime) -> Result<(), String> {
-    let api = PythonApi::global();
-    loop {
-        let status = {
-            let _gil = GilGuard::acquire();
-            begin_repl_turn();
-            let status = unsafe {
-                (api.py_run_interactive_one_flags)(
-                    runtime.stdin,
-                    c"<stdin>".as_ptr(),
-                    ptr::null_mut(),
-                )
+    #[cfg(windows)]
+    {
+        let _ = runtime;
+        run_windows_turn_repl()
+    }
+
+    #[cfg(not(windows))]
+    {
+        let api = PythonApi::global();
+        loop {
+            let status = {
+                let _gil = GilGuard::acquire();
+                begin_repl_turn();
+                let status = unsafe {
+                    (api.py_run_interactive_one_flags)(
+                        runtime.stdin,
+                        c"<stdin>".as_ptr(),
+                        ptr::null_mut(),
+                    )
+                };
+                capture_python_prompts(api)?;
+                status
             };
-            capture_python_prompts(api)?;
-            status
-        };
-        if take_exit_requested() {
-            flush_original_stdio();
-            return Ok(());
-        }
-        emit_plots();
-        finish_repl_turn_request();
-        if status == PYTHON_EOF {
-            flush_original_stdio();
-            return Ok(());
+            if take_exit_requested() {
+                flush_original_stdio();
+                return Ok(());
+            }
+            emit_plots();
+            finish_repl_turn_request();
+            if status == PYTHON_EOF {
+                flush_original_stdio();
+                return Ok(());
+            }
         }
     }
 }
@@ -1183,10 +1227,12 @@ fn begin_tracked_request(
     guard.request_generation = guard.request_generation.wrapping_add(1);
     guard.request_completed_at_stdin_wait = false;
     guard.active_request = Some(ActiveRequest {
-        reply,
+        reply: Some(reply),
+        turn_id: None,
         byte_len,
         line_count,
         fallback_prompt,
+        queued_lines: VecDeque::new(),
         consumed_lines: 0,
         skip_next_hook,
         stdin_write_complete: false,
@@ -1200,6 +1246,65 @@ fn begin_tracked_request(
     guard.plot_reset_pending = true;
     state.cvar.notify_all();
     Ok(())
+}
+
+fn begin_tracked_turn(turn_id: u64, input: String) -> Result<(), String> {
+    let state = session_state();
+    let queued_lines = prepare_turn_input_lines(&input);
+    let byte_len = queued_lines
+        .iter()
+        .map(|line| line.bytes.len().saturating_sub(line.offset))
+        .sum();
+    let line_count = queued_lines.len();
+    let mut guard = state.inner.lock().unwrap();
+    if guard.shutdown {
+        return Err("Python session is shutting down".to_string());
+    }
+    if guard.active_request.is_some() {
+        return Err("Python session already has an active turn".to_string());
+    }
+    guard.request_generation = turn_id;
+    guard.interrupt_requested = false;
+    guard.request_completed_at_stdin_wait = false;
+    guard.request_active = true;
+    guard.plot_reset_pending = true;
+    guard.turn_write_in_flight = false;
+    guard.turn_cleanup_uncertain = false;
+    let started_after_continuation_prompt = guard.last_prompt_was_continuation;
+    guard.active_request = Some(ActiveRequest {
+        reply: None,
+        turn_id: Some(turn_id),
+        byte_len,
+        line_count,
+        fallback_prompt: None,
+        queued_lines,
+        consumed_lines: 0,
+        skip_next_hook: false,
+        stdin_write_complete: true,
+        repl_turn_finished: false,
+        started_after_continuation_prompt,
+    });
+    state.cvar.notify_all();
+    Ok(())
+}
+
+fn prepare_turn_input_lines(input: &str) -> VecDeque<TurnInputLine> {
+    if input.is_empty() {
+        return VecDeque::new();
+    }
+    let mut input = input.to_string();
+    if !input.ends_with('\n') {
+        input.push('\n');
+    }
+    input
+        .split_inclusive('\n')
+        .map(|line| TurnInputLine {
+            text: line.to_string(),
+            bytes: line.as_bytes().to_vec(),
+            offset: 0,
+            input_line_emitted: false,
+        })
+        .collect()
 }
 
 #[cfg(target_family = "unix")]
@@ -1253,13 +1358,211 @@ fn input_hook_prompt(guard: &SessionStateInner, fallback_prompt: Option<&str>) -
     )
 }
 
+fn emit_turn_input_line(turn_id: u64, prompt: &str, line: &mut TurnInputLine) {
+    if line.input_line_emitted {
+        return;
+    }
+    ipc::emit_input_line(turn_id, prompt, &line.text);
+    line.input_line_emitted = true;
+}
+
+#[cfg(windows)]
+fn read_windows_turn_line(
+    prompt: &str,
+    emit_prompt_to_stdout: bool,
+    release_gil_while_waiting: bool,
+) -> Result<StdioLineRead, String> {
+    let state = SESSION_STATE
+        .get()
+        .ok_or_else(|| "Python session state is not initialized".to_string())?;
+
+    loop {
+        let action = {
+            let mut guard = state.inner.lock().unwrap();
+            guard.waiting_for_input = true;
+            state.cvar.notify_all();
+
+            if guard.shutdown || guard.exit_requested {
+                return Ok(StdioLineRead {
+                    bytes: Vec::new(),
+                    interrupted: false,
+                });
+            }
+
+            if guard.interrupt_requested {
+                guard.interrupt_requested = false;
+                return Ok(StdioLineRead {
+                    bytes: Vec::new(),
+                    interrupted: true,
+                });
+            }
+
+            if guard.turn_cleanup_uncertain {
+                if release_gil_while_waiting {
+                    let allow_threads = PythonThreadsAllowed::new();
+                    guard = state.cvar.wait(guard).unwrap();
+                    drop(guard);
+                    drop(allow_threads);
+                } else {
+                    guard = state.cvar.wait(guard).unwrap();
+                    drop(guard);
+                }
+                continue;
+            }
+
+            match guard
+                .active_request
+                .as_mut()
+                .and_then(|active| active.turn_id)
+            {
+                Some(turn_id) => {
+                    let line = {
+                        let active = guard.active_request.as_mut().expect("active turn exists");
+                        let line = active.queued_lines.pop_front();
+                        if line.is_some() {
+                            active.consumed_lines = active.consumed_lines.saturating_add(1);
+                        }
+                        line
+                    };
+                    if let Some(line) = line {
+                        guard.waiting_for_input = false;
+                        guard.request_active = true;
+                        Some((turn_id, Some(line)))
+                    } else {
+                        guard.active_request.take();
+                        Some((turn_id, None))
+                    }
+                }
+                None => {
+                    if release_gil_while_waiting {
+                        let allow_threads = PythonThreadsAllowed::new();
+                        guard = state.cvar.wait(guard).unwrap();
+                        drop(guard);
+                        drop(allow_threads);
+                    } else {
+                        guard = state.cvar.wait(guard).unwrap();
+                        drop(guard);
+                    }
+                    continue;
+                }
+            }
+        };
+
+        if let Some((turn_id, Some(mut line))) = action {
+            emit_turn_input_line(turn_id, prompt, &mut line);
+            if emit_prompt_to_stdout && !prompt.is_empty() {
+                emit_output_text(TextStream::Stdout, prompt.as_bytes());
+            }
+            return Ok(StdioLineRead {
+                bytes: line.bytes[line.offset..].to_vec(),
+                interrupted: false,
+            });
+        }
+
+        if let Some((turn_id, None)) = action {
+            emit_plots();
+            mark_stdin_wait_prompt_completed_request();
+            remember_emitted_prompt(prompt);
+            ipc::emit_idle(turn_id, prompt);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn run_windows_turn_repl() -> Result<(), String> {
+    let api = PythonApi::global();
+    let mut source = String::new();
+    let mut continuation = false;
+
+    loop {
+        if source.is_empty() {
+            begin_repl_turn();
+        }
+        let prompt = python_repl_prompt(continuation);
+        set_current_repl_readline_prompt(&prompt);
+        let read = read_windows_turn_line(&prompt, false, false)?;
+        clear_current_readline_prompt();
+        if read.interrupted || take_interrupt_requested() {
+            PythonApi::global().set_interrupt();
+            source.clear();
+            continuation = false;
+            continue;
+        }
+        if read.bytes.is_empty() {
+            flush_original_stdio();
+            return Ok(());
+        }
+
+        source.push_str(&String::from_utf8_lossy(&read.bytes));
+        let incomplete = {
+            let _gil = GilGuard::acquire();
+            let incomplete = run_windows_interactive_source(api, &source)?;
+            capture_python_prompts(api)?;
+            incomplete
+        };
+        if take_exit_requested() {
+            flush_original_stdio();
+            return Ok(());
+        }
+        emit_plots();
+        finish_repl_turn_request();
+        if incomplete {
+            continuation = true;
+        } else {
+            source.clear();
+            continuation = false;
+        }
+    }
+}
+
+#[cfg(windows)]
+fn python_repl_prompt(continuation: bool) -> String {
+    let Some(state) = SESSION_STATE.get() else {
+        return if continuation { "... " } else { ">>> " }.to_string();
+    };
+    let guard = state.inner.lock().unwrap();
+    if continuation {
+        guard.python_continuation_prompt.clone()
+    } else {
+        guard.python_primary_prompt.clone()
+    }
+}
+
+#[cfg(windows)]
+fn run_windows_interactive_source(api: &'static PythonApi, source: &str) -> Result<bool, String> {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(source.as_bytes());
+    let wrapper = format!("_mcp_repl_last_incomplete = _mcp_repl_runsource_b64({encoded:?})\n");
+    let main = api.import_module("__main__")?;
+    let globals = unsafe { (api.py_module_get_dict)(main.as_ptr()) };
+    if globals.is_null() {
+        return Err("failed to get __main__ globals".to_string());
+    }
+    api.run_code(&wrapper, globals)?;
+    let value = api.get_attr_string(main.as_ptr(), "_mcp_repl_last_incomplete")?;
+    let truth = unsafe { (api.py_object_is_true)(value.as_ptr()) };
+    if truth < 0 {
+        api.clear_error();
+        return Err("failed to read Python interactive incomplete state".to_string());
+    }
+    Ok(truth == 1)
+}
+
 fn handle_input_hook() {
     #[cfg(target_family = "unix")]
     {
         handle_protocol_input_hook();
     }
 
-    #[cfg(not(target_family = "unix"))]
+    #[cfg(windows)]
+    {
+        if let Some(state) = SESSION_STATE.get() {
+            let mut guard = state.inner.lock().unwrap();
+            guard.waiting_for_input = true;
+            state.cvar.notify_all();
+        }
+    }
+
+    #[cfg(not(any(target_family = "unix", windows)))]
     {
         let Some(state) = SESSION_STATE.get() else {
             return;
@@ -1385,6 +1688,7 @@ unsafe extern "C" fn pyos_input_hook() -> c_int {
 }
 
 #[cfg_attr(target_family = "unix", allow(dead_code))]
+#[cfg_attr(windows, allow(dead_code))]
 fn note_input_hook_consumed_line(active: &mut ActiveRequest) {
     #[cfg(not(target_family = "unix"))]
     {
@@ -1491,6 +1795,13 @@ fn finish_repl_turn_request() {
         let primary_prompt = guard.python_primary_prompt.clone();
         let continuation_prompt = guard.python_continuation_prompt.clone();
         guard.interrupt_requested = false;
+        if guard
+            .active_request
+            .as_ref()
+            .is_some_and(|active| active.turn_id.is_some())
+        {
+            return;
+        }
         if guard.active_request.is_some() {
             guard.waiting_for_input = true;
         } else {
@@ -1572,6 +1883,8 @@ unsafe extern "C" fn mcp_repl_readline(
     _stdout: *mut libc::FILE,
     prompt: *const c_char,
 ) -> *mut c_char {
+    #[cfg(windows)]
+    let _ = stdin;
     let prompt_text = if prompt.is_null() {
         String::new()
     } else {
@@ -1596,9 +1909,27 @@ unsafe extern "C" fn mcp_repl_readline(
     if prompt_has_buffered_answer && !prompt_text.is_empty() && !prompt_matches_repl {
         emit_output_text(TextStream::Stdout, prompt_text.as_bytes());
     }
-    #[cfg(not(target_family = "unix"))]
+    #[cfg(all(not(target_family = "unix"), not(windows)))]
     handle_input_hook();
 
+    #[cfg(windows)]
+    let read = match read_windows_turn_line(
+        &prompt_text,
+        !prompt_text.is_empty() && !prompt_matches_python_repl_prompt(&prompt_text),
+        true,
+    ) {
+        Ok(read) => read,
+        Err(err) => {
+            emit_output_text(TextStream::Stderr, err.as_bytes());
+            ipc::emit_session_end_with_reason("protocol_error", None);
+            request_exit();
+            StdioLineRead {
+                bytes: Vec::new(),
+                interrupted: true,
+            }
+        }
+    };
+    #[cfg(not(windows))]
     let read = read_stdio_line_bytes(stdin);
     if read.interrupted {
         #[cfg(target_family = "unix")]
@@ -1632,7 +1963,6 @@ fn request_cpython_readline_stdin_line(prompt: &str) {
     ipc::emit_readline_start(prompt);
 }
 
-#[cfg(target_family = "unix")]
 fn prompt_matches_python_repl_prompt(prompt: &str) -> bool {
     let Some(state) = SESSION_STATE.get() else {
         return false;
@@ -1662,6 +1992,7 @@ struct StdioLineRead {
     interrupted: bool,
 }
 
+#[cfg(not(windows))]
 fn read_stdio_line_bytes(stdin: *mut libc::FILE) -> StdioLineRead {
     let mut bytes = Vec::new();
     loop {
@@ -1688,15 +2019,7 @@ unsafe fn clear_stdio_error(stdin: *mut libc::FILE) {
     unsafe { libc::clearerr(stdin) };
 }
 
-#[cfg(windows)]
-unsafe fn clear_stdio_error(stdin: *mut libc::FILE) {
-    unsafe extern "C" {
-        fn clearerr(stream: *mut libc::FILE);
-    }
-
-    unsafe { clearerr(stdin) };
-}
-
+#[cfg(not(windows))]
 fn read_stdio_line_bytes_allowing_python_threads(stdin: *mut libc::FILE) -> StdioLineRead {
     // _mcp_repl.readline is called from Python with the GIL held. Release it
     // while stdin blocks so the IPC completion path can flush prompt-time plots.
@@ -1841,12 +2164,28 @@ fn read_c_stdin_line(prompt: &str) -> CStdinLine {
     if !prompt.is_empty() && (prompt_delivered_immediately || prompt_has_buffered_answer) {
         emit_output_text(TextStream::Stdout, prompt.as_bytes());
     }
-    #[cfg(not(target_family = "unix"))]
+    #[cfg(all(not(target_family = "unix"), not(windows)))]
     {
         flush_original_stdio();
         handle_input_hook();
         emit_output_text(TextStream::Stdout, prompt.as_bytes());
     }
+    #[cfg(windows)]
+    flush_original_stdio();
+    #[cfg(windows)]
+    let read = match read_windows_turn_line(
+        prompt_for_sideband.to_str().unwrap_or(""),
+        !prompt.is_empty(),
+        true,
+    ) {
+        Ok(read) => read,
+        Err(err) => {
+            set_callback_error(&err);
+            clear_current_readline_prompt();
+            return CStdinLine::Error;
+        }
+    };
+    #[cfg(not(windows))]
     let read = read_stdio_line_bytes_allowing_python_threads(stdin);
     if read.interrupted {
         #[cfg(target_family = "unix")]
@@ -1892,7 +2231,66 @@ fn read_raw_stdin_bytes(size: usize) -> Vec<u8> {
     bytes
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(windows)]
+fn read_raw_stdin_bytes(size: usize) -> Vec<u8> {
+    if size == 0 {
+        return Vec::new();
+    }
+    let result = {
+        let _allow_threads = PythonThreadsAllowed::new();
+        take_raw_turn_input_bytes(size)
+    };
+    match result {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            set_callback_error(&err);
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(windows)]
+fn take_raw_turn_input_bytes(size: usize) -> Result<Vec<u8>, String> {
+    let mut output = Vec::new();
+    while output.len() < size {
+        let event = {
+            let Some(state) = SESSION_STATE.get() else {
+                return Ok(output);
+            };
+            let mut guard = state.inner.lock().unwrap();
+            let prompt = input_hook_prompt(&guard, None);
+            let Some(active) = guard.active_request.as_mut() else {
+                return Ok(output);
+            };
+            let Some(turn_id) = active.turn_id else {
+                return Ok(output);
+            };
+            let Some(line) = active.queued_lines.front_mut() else {
+                return Ok(output);
+            };
+            let emit_line = if line.input_line_emitted {
+                None
+            } else {
+                line.input_line_emitted = true;
+                Some((turn_id, prompt, line.text.clone()))
+            };
+            let available = &line.bytes[line.offset..];
+            let take = available.len().min(size - output.len());
+            output.extend_from_slice(&available[..take]);
+            line.offset += take;
+            if line.offset >= line.bytes.len() {
+                active.queued_lines.pop_front();
+            }
+            emit_line
+        };
+        if let Some((turn_id, prompt, text)) = event {
+            ipc::emit_input_line(turn_id, &prompt, &text);
+        }
+    }
+    Ok(output)
+}
+
+#[cfg(not(any(target_family = "unix", windows)))]
 fn read_raw_stdin_bytes(_size: usize) -> Vec<u8> {
     Vec::new()
 }
@@ -2106,21 +2504,32 @@ struct SessionStateInner {
     session_end_emitted: bool,
     plot_reset_pending: bool,
     interrupt_requested: bool,
+    turn_write_in_flight: bool,
+    turn_cleanup_uncertain: bool,
     #[cfg(target_family = "unix")]
     protocol_stdin_bytes: VecDeque<u8>,
 }
 
 #[allow(dead_code)]
 struct ActiveRequest {
-    reply: mpsc::Sender<RequestCompleted>,
+    reply: Option<mpsc::Sender<RequestCompleted>>,
+    turn_id: Option<u64>,
     byte_len: usize,
     line_count: usize,
     fallback_prompt: Option<String>,
+    queued_lines: VecDeque<TurnInputLine>,
     consumed_lines: usize,
     skip_next_hook: bool,
     stdin_write_complete: bool,
     repl_turn_finished: bool,
     started_after_continuation_prompt: bool,
+}
+
+struct TurnInputLine {
+    text: String,
+    bytes: Vec<u8>,
+    offset: usize,
+    input_line_emitted: bool,
 }
 
 impl SessionState {
@@ -2143,6 +2552,8 @@ impl SessionState {
                 session_end_emitted: false,
                 plot_reset_pending: false,
                 interrupt_requested: false,
+                turn_write_in_flight: false,
+                turn_cleanup_uncertain: false,
                 #[cfg(target_family = "unix")]
                 protocol_stdin_bytes: VecDeque::new(),
             }),
@@ -2162,8 +2573,10 @@ fn complete_active_request_with_options(
     active: Option<ActiveRequest>,
     emit_session_end: bool,
 ) {
-    if let Some(active) = active {
-        let _ = active.reply.send(RequestCompleted);
+    if let Some(active) = active
+        && let Some(reply) = active.reply
+    {
+        let _ = reply.send(RequestCompleted);
         state.cvar.notify_all();
     }
     if emit_session_end {
@@ -2510,10 +2923,12 @@ mod tests {
     ) -> ActiveRequest {
         let (reply, _rx) = std::sync::mpsc::channel();
         ActiveRequest {
-            reply,
+            reply: Some(reply),
+            turn_id: None,
             byte_len: 1,
             line_count,
             fallback_prompt: fallback_prompt.map(str::to_string),
+            queued_lines: VecDeque::new(),
             consumed_lines,
             skip_next_hook: false,
             stdin_write_complete: true,

--- a/src/python_session.rs
+++ b/src/python_session.rs
@@ -2221,79 +2221,150 @@ fn fork_child_stdin_eof(prompt: &str) -> CStdinLine {
 }
 
 #[cfg(target_family = "unix")]
-fn read_raw_stdin_bytes(size: usize) -> Vec<u8> {
+fn read_raw_stdin_bytes(size: usize) -> Result<Vec<u8>, RawStdinReadError> {
     if ipc::worker_ipc_disabled_for_process() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
     let _allow_threads = PythonThreadsAllowed::new();
     let bytes = read_fd_bytes(libc::STDIN_FILENO, size);
     note_stdin_bytes_read(&bytes);
-    bytes
+    Ok(bytes)
+}
+
+#[cfg_attr(not(windows), allow(dead_code))]
+enum RawStdinReadError {
+    Interrupted,
+    Runtime(String),
 }
 
 #[cfg(windows)]
-fn read_raw_stdin_bytes(size: usize) -> Vec<u8> {
+fn read_raw_stdin_bytes(size: usize) -> Result<Vec<u8>, RawStdinReadError> {
     if size == 0 {
-        return Vec::new();
+        return Ok(Vec::new());
     }
-    let result = {
-        let _allow_threads = PythonThreadsAllowed::new();
-        take_raw_turn_input_bytes(size)
-    };
-    match result {
-        Ok(bytes) => bytes,
-        Err(err) => {
-            set_callback_error(&err);
-            Vec::new()
-        }
-    }
+    take_raw_turn_input_bytes(size)
 }
 
 #[cfg(windows)]
-fn take_raw_turn_input_bytes(size: usize) -> Result<Vec<u8>, String> {
+enum RawTurnInputEvent {
+    InputLine {
+        turn_id: u64,
+        prompt: String,
+        text: String,
+    },
+    Idle {
+        turn_id: u64,
+        prompt: String,
+    },
+    Consumed,
+}
+
+#[cfg(windows)]
+fn take_raw_turn_input_bytes(size: usize) -> Result<Vec<u8>, RawStdinReadError> {
+    let state = SESSION_STATE.get().ok_or_else(|| {
+        RawStdinReadError::Runtime("Python session state is not initialized".to_string())
+    })?;
     let mut output = Vec::new();
     while output.len() < size {
         let event = {
-            let Some(state) = SESSION_STATE.get() else {
-                return Ok(output);
-            };
             let mut guard = state.inner.lock().unwrap();
-            let prompt = input_hook_prompt(&guard, None);
-            let Some(active) = guard.active_request.as_mut() else {
+            guard.waiting_for_input = true;
+            state.cvar.notify_all();
+
+            if guard.shutdown || guard.exit_requested {
                 return Ok(output);
-            };
-            let Some(turn_id) = active.turn_id else {
-                return Ok(output);
-            };
-            let Some(line) = active.queued_lines.front_mut() else {
-                return Ok(output);
-            };
-            let emit_line = if line.input_line_emitted {
-                None
-            } else {
-                line.input_line_emitted = true;
-                Some((turn_id, prompt, line.text.clone()))
-            };
-            let available = &line.bytes[line.offset..];
-            let take = available.len().min(size - output.len());
-            output.extend_from_slice(&available[..take]);
-            line.offset += take;
-            if line.offset >= line.bytes.len() {
-                active.queued_lines.pop_front();
             }
-            emit_line
+
+            if guard.interrupt_requested {
+                guard.interrupt_requested = false;
+                return Err(RawStdinReadError::Interrupted);
+            }
+
+            if guard.turn_cleanup_uncertain {
+                let allow_threads = PythonThreadsAllowed::new();
+                guard = state.cvar.wait(guard).unwrap();
+                drop(guard);
+                drop(allow_threads);
+                continue;
+            }
+
+            let prompt = input_hook_prompt(&guard, None);
+            let Some(turn_id) = guard
+                .active_request
+                .as_ref()
+                .and_then(|active| active.turn_id)
+            else {
+                if !output.is_empty() {
+                    return Ok(output);
+                }
+                if guard.active_request.is_some() {
+                    return Ok(output);
+                }
+                let allow_threads = PythonThreadsAllowed::new();
+                guard = state.cvar.wait(guard).unwrap();
+                drop(guard);
+                drop(allow_threads);
+                continue;
+            };
+
+            if guard
+                .active_request
+                .as_ref()
+                .is_some_and(|active| active.queued_lines.is_empty())
+            {
+                if !output.is_empty() {
+                    return Ok(output);
+                }
+                guard.active_request.take();
+                RawTurnInputEvent::Idle { turn_id, prompt }
+            } else {
+                let active = guard.active_request.as_mut().expect("active turn exists");
+                let line = active
+                    .queued_lines
+                    .front_mut()
+                    .expect("active turn has queued input");
+                let event = if line.input_line_emitted {
+                    RawTurnInputEvent::Consumed
+                } else {
+                    line.input_line_emitted = true;
+                    RawTurnInputEvent::InputLine {
+                        turn_id,
+                        prompt,
+                        text: line.text.clone(),
+                    }
+                };
+                let available = &line.bytes[line.offset..];
+                let take = available.len().min(size - output.len());
+                output.extend_from_slice(&available[..take]);
+                line.offset += take;
+                if line.offset >= line.bytes.len() {
+                    active.queued_lines.pop_front();
+                }
+                event
+            }
         };
-        if let Some((turn_id, prompt, text)) = event {
-            ipc::emit_input_line(turn_id, &prompt, &text);
+        match event {
+            RawTurnInputEvent::InputLine {
+                turn_id,
+                prompt,
+                text,
+            } => ipc::emit_input_line(turn_id, &prompt, &text),
+            RawTurnInputEvent::Idle { turn_id, prompt } => {
+                emit_plots();
+                mark_stdin_wait_prompt_completed_request();
+                remember_emitted_prompt(&prompt);
+                ipc::emit_idle(turn_id, &prompt);
+            }
+            RawTurnInputEvent::Consumed => {}
         }
     }
     Ok(output)
 }
 
 #[cfg(not(any(target_family = "unix", windows)))]
-fn read_raw_stdin_bytes(_size: usize) -> Vec<u8> {
-    Vec::new()
+fn read_raw_stdin_bytes(_size: usize) -> Result<Vec<u8>, RawStdinReadError> {
+    Ok(Vec::new())
 }
 
 #[cfg(target_family = "unix")]
@@ -2763,7 +2834,17 @@ unsafe extern "C" fn py_raw_stdin_read(_self: *mut PyObject, args: *mut PyObject
         set_callback_error("raw_stdin_read size must be non-negative");
         return ptr::null_mut();
     };
-    let bytes = read_raw_stdin_bytes(size);
+    let bytes = match read_raw_stdin_bytes(size) {
+        Ok(bytes) => bytes,
+        Err(RawStdinReadError::Interrupted) => {
+            api.set_interrupt();
+            return ptr::null_mut();
+        }
+        Err(RawStdinReadError::Runtime(message)) => {
+            set_callback_error(&message);
+            return ptr::null_mut();
+        }
+    };
     match api.bytes(&bytes) {
         Ok(value) => value.into_raw(),
         Err(_) => ptr::null_mut(),

--- a/src/python_session.rs
+++ b/src/python_session.rs
@@ -10,8 +10,6 @@ use std::sync::atomic::AtomicI32;
 use std::sync::atomic::{AtomicPtr, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc};
 
-#[cfg(windows)]
-use base64::Engine as _;
 use serde::Deserialize;
 
 use crate::ipc;
@@ -28,7 +26,6 @@ use windows_sys::Win32::System::Pipes::PeekNamedPipe;
 
 pub const PYTHON_EXECUTABLE_ENV: &str = "MCP_REPL_PYTHON_EXECUTABLE";
 const MCP_REPL_PYTHON: &str = include_str!("../python/embedded.py");
-#[cfg(not(windows))]
 const PYTHON_EOF: c_int = 11;
 const PYTHON_PROGRAM: &str = "python3";
 const PYTHON_PROGRAM_FALLBACK: &str = "python";
@@ -1142,39 +1139,30 @@ fn configure_python(api: &'static PythonApi) -> Result<(), String> {
 }
 
 fn run_repl(runtime: &PythonRuntime) -> Result<(), String> {
-    #[cfg(windows)]
-    {
-        let _ = runtime;
-        run_windows_turn_repl()
-    }
-
-    #[cfg(not(windows))]
-    {
-        let api = PythonApi::global();
-        loop {
-            let status = {
-                let _gil = GilGuard::acquire();
-                begin_repl_turn();
-                let status = unsafe {
-                    (api.py_run_interactive_one_flags)(
-                        runtime.stdin,
-                        c"<stdin>".as_ptr(),
-                        ptr::null_mut(),
-                    )
-                };
-                capture_python_prompts(api)?;
-                status
+    let api = PythonApi::global();
+    loop {
+        let status = {
+            let _gil = GilGuard::acquire();
+            begin_repl_turn();
+            let status = unsafe {
+                (api.py_run_interactive_one_flags)(
+                    runtime.stdin,
+                    c"<stdin>".as_ptr(),
+                    ptr::null_mut(),
+                )
             };
-            if take_exit_requested() {
-                flush_original_stdio();
-                return Ok(());
-            }
-            emit_plots();
-            finish_repl_turn_request();
-            if status == PYTHON_EOF {
-                flush_original_stdio();
-                return Ok(());
-            }
+            capture_python_prompts(api)?;
+            status
+        };
+        if take_exit_requested() {
+            flush_original_stdio();
+            return Ok(());
+        }
+        emit_plots();
+        finish_repl_turn_request();
+        if status == PYTHON_EOF {
+            flush_original_stdio();
+            return Ok(());
         }
     }
 }
@@ -1426,12 +1414,16 @@ fn read_windows_turn_line(
                         line
                     };
                     if let Some(line) = line {
+                        let prompt_already_visible =
+                            guard.visible_input_prompt.as_deref() == Some(prompt);
+                        guard.visible_input_prompt = None;
                         guard.waiting_for_input = false;
                         guard.request_active = true;
-                        Some((turn_id, Some(line)))
+                        Some((turn_id, Some(line), prompt_already_visible))
                     } else {
                         guard.active_request.take();
-                        Some((turn_id, None))
+                        guard.visible_input_prompt = Some(prompt.to_string());
+                        Some((turn_id, None, false))
                     }
                 }
                 None => {
@@ -1449,9 +1441,9 @@ fn read_windows_turn_line(
             }
         };
 
-        if let Some((turn_id, Some(mut line))) = action {
+        if let Some((turn_id, Some(mut line), prompt_already_visible)) = action {
             emit_turn_input_line(turn_id, prompt, &mut line);
-            if emit_prompt_to_stdout && !prompt.is_empty() {
+            if emit_prompt_to_stdout && !prompt.is_empty() && !prompt_already_visible {
                 emit_output_text(TextStream::Stdout, prompt.as_bytes());
             }
             return Ok(StdioLineRead {
@@ -1460,92 +1452,13 @@ fn read_windows_turn_line(
             });
         }
 
-        if let Some((turn_id, None)) = action {
+        if let Some((turn_id, None, _)) = action {
             emit_plots();
             mark_stdin_wait_prompt_completed_request();
             remember_emitted_prompt(prompt);
             ipc::emit_idle(turn_id, prompt);
         }
     }
-}
-
-#[cfg(windows)]
-fn run_windows_turn_repl() -> Result<(), String> {
-    let api = PythonApi::global();
-    let mut source = String::new();
-    let mut continuation = false;
-
-    loop {
-        if source.is_empty() {
-            begin_repl_turn();
-        }
-        let prompt = python_repl_prompt(continuation);
-        set_current_repl_readline_prompt(&prompt);
-        let read = read_windows_turn_line(&prompt, false, false)?;
-        clear_current_readline_prompt();
-        if read.interrupted || take_interrupt_requested() {
-            PythonApi::global().set_interrupt();
-            source.clear();
-            continuation = false;
-            continue;
-        }
-        if read.bytes.is_empty() {
-            flush_original_stdio();
-            return Ok(());
-        }
-
-        source.push_str(&String::from_utf8_lossy(&read.bytes));
-        let incomplete = {
-            let _gil = GilGuard::acquire();
-            let incomplete = run_windows_interactive_source(api, &source)?;
-            capture_python_prompts(api)?;
-            incomplete
-        };
-        if take_exit_requested() {
-            flush_original_stdio();
-            return Ok(());
-        }
-        emit_plots();
-        finish_repl_turn_request();
-        if incomplete {
-            continuation = true;
-        } else {
-            source.clear();
-            continuation = false;
-        }
-    }
-}
-
-#[cfg(windows)]
-fn python_repl_prompt(continuation: bool) -> String {
-    let Some(state) = SESSION_STATE.get() else {
-        return if continuation { "... " } else { ">>> " }.to_string();
-    };
-    let guard = state.inner.lock().unwrap();
-    if continuation {
-        guard.python_continuation_prompt.clone()
-    } else {
-        guard.python_primary_prompt.clone()
-    }
-}
-
-#[cfg(windows)]
-fn run_windows_interactive_source(api: &'static PythonApi, source: &str) -> Result<bool, String> {
-    let encoded = base64::engine::general_purpose::STANDARD.encode(source.as_bytes());
-    let wrapper = format!("_mcp_repl_last_incomplete = _mcp_repl_runsource_b64({encoded:?})\n");
-    let main = api.import_module("__main__")?;
-    let globals = unsafe { (api.py_module_get_dict)(main.as_ptr()) };
-    if globals.is_null() {
-        return Err("failed to get __main__ globals".to_string());
-    }
-    api.run_code(&wrapper, globals)?;
-    let value = api.get_attr_string(main.as_ptr(), "_mcp_repl_last_incomplete")?;
-    let truth = unsafe { (api.py_object_is_true)(value.as_ptr()) };
-    if truth < 0 {
-        api.clear_error();
-        return Err("failed to read Python interactive incomplete state".to_string());
-    }
-    Ok(truth == 1)
 }
 
 fn handle_input_hook() {
@@ -1914,10 +1827,12 @@ unsafe extern "C" fn mcp_repl_readline(
     handle_input_hook();
 
     #[cfg(windows)]
+    flush_original_stdio();
+    #[cfg(windows)]
     let read = match read_windows_turn_line(
         &prompt_text,
         !prompt_text.is_empty() && !prompt_matches_python_repl_prompt(&prompt_text),
-        true,
+        false,
     ) {
         Ok(read) => read,
         Err(err) => {
@@ -2566,6 +2481,8 @@ struct SessionStateInner {
     request_completed_at_stdin_wait: bool,
     current_prompt: Option<String>,
     current_readline_state: Option<PythonReadlineState>,
+    #[cfg(windows)]
+    visible_input_prompt: Option<String>,
     python_primary_prompt: String,
     python_continuation_prompt: String,
     repl_readline_count: usize,
@@ -2616,6 +2533,8 @@ impl SessionState {
                 request_completed_at_stdin_wait: false,
                 current_prompt: None,
                 current_readline_state: None,
+                #[cfg(windows)]
+                visible_input_prompt: None,
                 python_primary_prompt: ">>> ".to_string(),
                 python_continuation_prompt: "... ".to_string(),
                 repl_readline_count: 0,

--- a/src/python_worker.rs
+++ b/src/python_worker.rs
@@ -7,7 +7,7 @@ use base64::Engine as _;
 
 use crate::ipc::{
     ServerToWorkerIpcMessage, connect_from_env, emit_python_interrupt_ack, emit_session_end,
-    emit_stdin_write_ack, set_global_ipc,
+    emit_session_end_with_reason, emit_stdin_write_ack, set_global_ipc,
 };
 use crate::python_session::{self, PythonSession};
 
@@ -90,7 +90,17 @@ fn init_ipc(
                         python_session::mark_request_started();
                         emit_stdin_write_ack();
                     }
-                    Some(ServerToWorkerIpcMessage::TurnStart { .. }) => {}
+                    Some(ServerToWorkerIpcMessage::TurnStart { turn_id, input }) => {
+                        match wait_for_python_session()
+                            .and_then(|session| session.begin_turn(turn_id, input))
+                        {
+                            Ok(()) => {}
+                            Err(err) => {
+                                emit_stderr_message(&err);
+                                emit_session_end_with_reason("protocol_error", Some(turn_id));
+                            }
+                        }
+                    }
                     Some(ServerToWorkerIpcMessage::PythonRequestStart {
                         request_generation,
                         stdin_b64,
@@ -126,8 +136,12 @@ fn init_ipc(
                     Some(ServerToWorkerIpcMessage::StdinWriteComplete) => {
                         python_session::mark_stdin_write_complete();
                     }
-                    Some(ServerToWorkerIpcMessage::Interrupt { .. }) => {
-                        python_session::interrupt();
+                    Some(ServerToWorkerIpcMessage::Interrupt { turn_id }) => {
+                        if let Some(turn_id) = turn_id {
+                            python_session::interrupt_turn(turn_id);
+                        } else {
+                            python_session::interrupt();
+                        }
                     }
                     Some(ServerToWorkerIpcMessage::PythonInterrupt { request_generation }) => {
                         python_session::interrupt_request_generation(request_generation);

--- a/src/windows_conpty.rs
+++ b/src/windows_conpty.rs
@@ -1,0 +1,543 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use std::collections::HashMap;
+use std::ffi::{OsStr, OsString, c_void};
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::io::FromRawHandle;
+use std::path::Path;
+use std::thread;
+
+use windows_sys::Win32::Foundation::{
+    CloseHandle, HANDLE, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE, SetHandleInformation,
+    WAIT_FAILED,
+};
+use windows_sys::Win32::System::Console::{COORD, ClosePseudoConsole, CreatePseudoConsole, HPCON};
+use windows_sys::Win32::System::Pipes::CreatePipe;
+use windows_sys::Win32::System::Threading::{
+    CREATE_NEW_PROCESS_GROUP, CREATE_UNICODE_ENVIRONMENT, CreateProcessAsUserW, CreateProcessW,
+    DeleteProcThreadAttributeList, EXTENDED_STARTUPINFO_PRESENT, GetExitCodeProcess, INFINITE,
+    InitializeProcThreadAttributeList, LPPROC_THREAD_ATTRIBUTE_LIST,
+    PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, PROCESS_INFORMATION, STARTUPINFOEXW,
+    UpdateProcThreadAttribute, WaitForSingleObject,
+};
+
+pub const WINDOWS_CONPTY_ARG: &str = "--windows-conpty";
+pub const WINDOWS_CONPTY_REQUEST_ENV: &str = "MCP_REPL_WINDOWS_CONPTY";
+
+const CONPTY_COLS: i16 = 80;
+const CONPTY_ROWS: i16 = 24;
+
+pub fn invoked_as_windows_conpty() -> bool {
+    std::env::args_os().nth(1).as_deref() == Some(OsStr::new(WINDOWS_CONPTY_ARG))
+}
+
+pub fn run_windows_conpty_main() -> ! {
+    match windows_conpty_main_impl() {
+        Ok(code) => std::process::exit(code),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn windows_conpty_main_impl() -> Result<i32, String> {
+    crate::diagnostics::startup_log("windows-conpty: begin");
+    let command = parse_windows_conpty_args(std::env::args_os().skip(1).collect())?;
+    crate::diagnostics::startup_log("windows-conpty: parsed args");
+    run_conpty_command_with_env_map(&command, std::env::vars().collect(), None)
+}
+
+fn parse_windows_conpty_args(raw_args: Vec<OsString>) -> Result<Vec<String>, String> {
+    let mut command = Vec::new();
+    let mut args = raw_args.into_iter();
+    while let Some(arg) = args.next() {
+        if arg == WINDOWS_CONPTY_ARG {
+            continue;
+        }
+        if arg == "--" {
+            command.extend(args.map(|value| value.to_string_lossy().to_string()));
+            break;
+        }
+        return Err(format!("unknown argument: {}", arg.to_string_lossy()));
+    }
+    if command.is_empty() {
+        return Err("no command specified to execute".to_string());
+    }
+    Ok(command)
+}
+
+pub fn request_env_enabled(env_map: &HashMap<String, String>) -> bool {
+    env_get_case_insensitive(env_map, WINDOWS_CONPTY_REQUEST_ENV)
+        .is_some_and(|value| matches!(value, "1" | "true" | "TRUE" | "yes" | "YES"))
+}
+
+pub fn run_conpty_command_with_env_map(
+    command: &[String],
+    mut env_map: HashMap<String, String>,
+    cwd: Option<&Path>,
+) -> Result<i32, String> {
+    unsafe {
+        crate::diagnostics::startup_log("windows-conpty: creating conpty");
+        let mut conpty = Conpty::new()?;
+        upsert_env_case_insensitive(&mut env_map, WINDOWS_CONPTY_REQUEST_ENV, "1");
+        crate::diagnostics::startup_log("windows-conpty: conpty created");
+        let output_read = conpty
+            .output_read
+            .try_clone()
+            .map_err(|err| format!("failed to clone ConPTY output handle: {err}"))?;
+        let output_forwarder = spawn_conpty_output_forwarder(output_read);
+        crate::diagnostics::startup_log("windows-conpty: spawning child");
+        let proc_info = spawn_conpty_process(command, cwd, &env_map, conpty.hpc)?;
+        conpty.close_child_side_handles();
+        crate::diagnostics::startup_log("windows-conpty: child spawned");
+
+        let wait_status = WaitForSingleObject(proc_info.hProcess, INFINITE);
+        if wait_status == WAIT_FAILED {
+            CloseHandle(proc_info.hThread);
+            CloseHandle(proc_info.hProcess);
+            return Err(format!(
+                "WaitForSingleObject failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+
+        let mut exit_code: u32 = 1;
+        if GetExitCodeProcess(proc_info.hProcess, &mut exit_code) == 0 {
+            CloseHandle(proc_info.hThread);
+            CloseHandle(proc_info.hProcess);
+            return Err(format!(
+                "GetExitCodeProcess failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        CloseHandle(proc_info.hThread);
+        CloseHandle(proc_info.hProcess);
+        drop(conpty);
+        let _ = output_forwarder.join();
+        Ok(exit_code as i32)
+    }
+}
+
+pub unsafe fn spawn_conpty_process_as_user(
+    token: HANDLE,
+    command: &[String],
+    cwd: &Path,
+    env_map: &mut HashMap<String, String>,
+) -> Result<(PROCESS_INFORMATION, Conpty, thread::JoinHandle<()>), String> {
+    let mut conpty = Conpty::new()?;
+    upsert_env_case_insensitive(env_map, WINDOWS_CONPTY_REQUEST_ENV, "1");
+    let output_read = conpty
+        .output_read
+        .try_clone()
+        .map_err(|err| format!("failed to clone ConPTY output handle: {err}"))?;
+    let output_forwarder = spawn_conpty_output_forwarder(output_read);
+    let proc_info = spawn_conpty_process_with_token(token, command, cwd, env_map, conpty.hpc)?;
+    conpty.close_child_side_handles();
+    Ok((proc_info, conpty, output_forwarder))
+}
+
+pub struct Conpty {
+    hpc: HPCON,
+    input_read: Option<File>,
+    #[allow(dead_code)]
+    input_write: File,
+    output_read: File,
+    output_write: Option<File>,
+}
+
+impl Conpty {
+    unsafe fn new() -> Result<Self, String> {
+        let mut input_read: HANDLE = std::ptr::null_mut();
+        let mut input_write: HANDLE = std::ptr::null_mut();
+        let mut output_read: HANDLE = std::ptr::null_mut();
+        let mut output_write: HANDLE = std::ptr::null_mut();
+
+        if CreatePipe(&mut input_read, &mut input_write, std::ptr::null_mut(), 0) == 0 {
+            return Err(format!(
+                "CreatePipe ConPTY input failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        if CreatePipe(&mut output_read, &mut output_write, std::ptr::null_mut(), 0) == 0 {
+            CloseHandle(input_read);
+            CloseHandle(input_write);
+            return Err(format!(
+                "CreatePipe ConPTY output failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+
+        let mut hpc: HPCON = INVALID_HANDLE_VALUE as HPCON;
+        let hr = CreatePseudoConsole(
+            COORD {
+                X: CONPTY_COLS,
+                Y: CONPTY_ROWS,
+            },
+            input_read,
+            output_write,
+            0,
+            &mut hpc,
+        );
+        if hr < 0 {
+            CloseHandle(input_read);
+            CloseHandle(output_write);
+            CloseHandle(input_write);
+            CloseHandle(output_read);
+            return Err(format!("CreatePseudoConsole failed: HRESULT {hr:#x}"));
+        }
+        if SetHandleInformation(input_write, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT) == 0 {
+            CloseHandle(input_write);
+            CloseHandle(output_read);
+            ClosePseudoConsole(hpc);
+            return Err(format!(
+                "SetHandleInformation failed for ConPTY input writer: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+
+        Ok(Self {
+            hpc,
+            input_read: Some(File::from_raw_handle(input_read as _)),
+            input_write: File::from_raw_handle(input_write as _),
+            output_read: File::from_raw_handle(output_read as _),
+            output_write: Some(File::from_raw_handle(output_write as _)),
+        })
+    }
+
+    fn close_child_side_handles(&mut self) {
+        self.input_read.take();
+        self.output_write.take();
+    }
+}
+
+impl Drop for Conpty {
+    fn drop(&mut self) {
+        unsafe {
+            ClosePseudoConsole(self.hpc);
+        }
+    }
+}
+
+unsafe fn spawn_conpty_process(
+    command: &[String],
+    cwd: Option<&Path>,
+    env_map: &HashMap<String, String>,
+    hpc: HPCON,
+) -> Result<PROCESS_INFORMATION, String> {
+    if command.is_empty() {
+        return Err("no command specified to execute".to_string());
+    }
+    let mut cmdline = to_wide(
+        command
+            .iter()
+            .map(|arg| quote_windows_arg(arg))
+            .collect::<Vec<_>>()
+            .join(" "),
+    );
+    let mut startup_info: STARTUPINFOEXW = std::mem::zeroed();
+    startup_info.StartupInfo.cb = std::mem::size_of::<STARTUPINFOEXW>() as u32;
+    let mut attrs = ProcThreadAttributeList::new(1)?;
+    attrs.set_conpty(hpc)?;
+    startup_info.lpAttributeList = attrs.as_mut_ptr();
+
+    let env_block = make_env_block(env_map);
+    let cwd_wide = cwd.map(to_wide);
+    let mut proc_info: PROCESS_INFORMATION = std::mem::zeroed();
+    let ok = CreateProcessW(
+        std::ptr::null(),
+        cmdline.as_mut_ptr(),
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        0,
+        EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT | CREATE_NEW_PROCESS_GROUP,
+        env_block.as_ptr() as *const c_void,
+        cwd_wide
+            .as_ref()
+            .map(|value| value.as_ptr())
+            .unwrap_or(std::ptr::null()),
+        &startup_info.StartupInfo,
+        &mut proc_info,
+    );
+    if ok == 0 {
+        return Err(format!(
+            "CreateProcessW failed: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(proc_info)
+}
+
+unsafe fn spawn_conpty_process_with_token(
+    token: HANDLE,
+    command: &[String],
+    cwd: &Path,
+    env_map: &HashMap<String, String>,
+    hpc: HPCON,
+) -> Result<PROCESS_INFORMATION, String> {
+    if command.is_empty() {
+        return Err("no command specified to execute".to_string());
+    }
+    let mut cmdline = to_wide(
+        command
+            .iter()
+            .map(|arg| quote_windows_arg(arg))
+            .collect::<Vec<_>>()
+            .join(" "),
+    );
+    let mut startup_info: STARTUPINFOEXW = std::mem::zeroed();
+    startup_info.StartupInfo.cb = std::mem::size_of::<STARTUPINFOEXW>() as u32;
+    let mut attrs = ProcThreadAttributeList::new(1)?;
+    attrs.set_conpty(hpc)?;
+    startup_info.lpAttributeList = attrs.as_mut_ptr();
+
+    let env_block = make_env_block(env_map);
+    let cwd_wide = to_wide(cwd);
+    let mut proc_info: PROCESS_INFORMATION = std::mem::zeroed();
+    let ok = CreateProcessAsUserW(
+        token,
+        std::ptr::null(),
+        cmdline.as_mut_ptr(),
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        0,
+        EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT | CREATE_NEW_PROCESS_GROUP,
+        env_block.as_ptr() as *const c_void,
+        cwd_wide.as_ptr(),
+        &startup_info.StartupInfo,
+        &mut proc_info,
+    );
+    if ok == 0 {
+        return Err(format!(
+            "CreateProcessAsUserW failed: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(proc_info)
+}
+
+struct ProcThreadAttributeList {
+    data: Vec<usize>,
+}
+
+impl ProcThreadAttributeList {
+    unsafe fn new(count: u32) -> Result<Self, String> {
+        let mut bytes_required = 0usize;
+        let _ =
+            InitializeProcThreadAttributeList(std::ptr::null_mut(), count, 0, &mut bytes_required);
+        let word_count = bytes_required.div_ceil(std::mem::size_of::<usize>());
+        let mut data = vec![0usize; word_count];
+        if InitializeProcThreadAttributeList(
+            data.as_mut_ptr().cast(),
+            count,
+            0,
+            &mut bytes_required,
+        ) == 0
+        {
+            return Err(format!(
+                "InitializeProcThreadAttributeList failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        Ok(Self { data })
+    }
+
+    fn as_mut_ptr(&mut self) -> LPPROC_THREAD_ATTRIBUTE_LIST {
+        self.data.as_mut_ptr().cast()
+    }
+
+    unsafe fn set_conpty(&mut self, hpc: HPCON) -> Result<(), String> {
+        let ok = UpdateProcThreadAttribute(
+            self.as_mut_ptr(),
+            0,
+            PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE as usize,
+            hpc as *const c_void,
+            std::mem::size_of::<HPCON>(),
+            std::ptr::null_mut(),
+            std::ptr::null(),
+        );
+        if ok == 0 {
+            return Err(format!(
+                "UpdateProcThreadAttribute failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for ProcThreadAttributeList {
+    fn drop(&mut self) {
+        unsafe {
+            DeleteProcThreadAttributeList(self.as_mut_ptr());
+        }
+    }
+}
+
+fn spawn_conpty_output_forwarder(mut output: File) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        let mut stdout = io::stdout();
+        let mut filter = ConptyOutputFilter::default();
+        let mut buffer = [0u8; 8192];
+        loop {
+            match output.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(count) => {
+                    let filtered = filter.filter(&buffer[..count]);
+                    if !filtered.is_empty()
+                        && stdout
+                            .write_all(&filtered)
+                            .and_then(|_| stdout.flush())
+                            .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    })
+}
+
+#[derive(Default)]
+struct ConptyOutputFilter {
+    state: ConptyOutputFilterState,
+}
+
+#[derive(Default)]
+enum ConptyOutputFilterState {
+    #[default]
+    Normal,
+    Escape,
+    Csi,
+    Osc,
+    OscEscape,
+}
+
+impl ConptyOutputFilter {
+    fn filter(&mut self, bytes: &[u8]) -> Vec<u8> {
+        let mut output = Vec::with_capacity(bytes.len());
+        for byte in bytes {
+            match self.state {
+                ConptyOutputFilterState::Normal => {
+                    if *byte == 0x1b {
+                        self.state = ConptyOutputFilterState::Escape;
+                    } else if *byte != 0x07 {
+                        output.push(*byte);
+                    }
+                }
+                ConptyOutputFilterState::Escape => match *byte {
+                    b'[' => self.state = ConptyOutputFilterState::Csi,
+                    b']' => self.state = ConptyOutputFilterState::Osc,
+                    _ => self.state = ConptyOutputFilterState::Normal,
+                },
+                ConptyOutputFilterState::Csi => {
+                    if (0x40..=0x7e).contains(byte) {
+                        self.state = ConptyOutputFilterState::Normal;
+                    }
+                }
+                ConptyOutputFilterState::Osc => match *byte {
+                    0x07 => self.state = ConptyOutputFilterState::Normal,
+                    0x1b => self.state = ConptyOutputFilterState::OscEscape,
+                    _ => {}
+                },
+                ConptyOutputFilterState::OscEscape => {
+                    if *byte == b'\\' {
+                        self.state = ConptyOutputFilterState::Normal;
+                    } else {
+                        self.state = ConptyOutputFilterState::Osc;
+                    }
+                }
+            }
+        }
+        output
+    }
+}
+
+pub fn quote_windows_arg(arg: &str) -> String {
+    let needs_quotes = arg.is_empty()
+        || arg
+            .chars()
+            .any(|ch| matches!(ch, ' ' | '\t' | '\n' | '\r' | '"'));
+    if !needs_quotes {
+        return arg.to_string();
+    }
+
+    let mut quoted = String::with_capacity(arg.len() + 2);
+    quoted.push('"');
+    let mut backslashes = 0;
+    for ch in arg.chars() {
+        if ch == '\\' {
+            backslashes += 1;
+            continue;
+        }
+        if ch == '"' {
+            quoted.extend(std::iter::repeat_n('\\', backslashes * 2 + 1));
+            quoted.push('"');
+            backslashes = 0;
+            continue;
+        }
+        quoted.extend(std::iter::repeat_n('\\', backslashes));
+        backslashes = 0;
+        quoted.push(ch);
+    }
+    quoted.extend(std::iter::repeat_n('\\', backslashes * 2));
+    quoted.push('"');
+    quoted
+}
+
+pub fn make_env_block(env: &HashMap<String, String>) -> Vec<u16> {
+    let mut items: Vec<(String, String)> = env
+        .iter()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
+    items.sort_by(|a, b| {
+        a.0.to_uppercase()
+            .cmp(&b.0.to_uppercase())
+            .then(a.0.cmp(&b.0))
+    });
+    let mut wide = Vec::new();
+    for (key, value) in items {
+        let mut entry = to_wide(format!("{key}={value}"));
+        entry.pop();
+        wide.extend_from_slice(&entry);
+        wide.push(0);
+    }
+    wide.push(0);
+    wide
+}
+
+pub fn to_wide<S: AsRef<OsStr>>(value: S) -> Vec<u16> {
+    let mut wide: Vec<u16> = value.as_ref().encode_wide().collect();
+    wide.push(0);
+    wide
+}
+
+pub fn env_get_case_insensitive<'a>(
+    env_map: &'a HashMap<String, String>,
+    key: &str,
+) -> Option<&'a str> {
+    env_map.get(key).map(String::as_str).or_else(|| {
+        env_map.iter().find_map(|(candidate, value)| {
+            if candidate.eq_ignore_ascii_case(key) {
+                Some(value.as_str())
+            } else {
+                None
+            }
+        })
+    })
+}
+
+pub fn upsert_env_case_insensitive(env_map: &mut HashMap<String, String>, key: &str, value: &str) {
+    let removals: Vec<String> = env_map
+        .keys()
+        .filter(|existing| existing.eq_ignore_ascii_case(key) && existing.as_str() != key)
+        .cloned()
+        .collect();
+    for existing in removals {
+        env_map.remove(&existing);
+    }
+    env_map.insert(key.to_string(), value.to_string());
+}

--- a/src/windows_conpty.rs
+++ b/src/windows_conpty.rs
@@ -3,9 +3,10 @@
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString, c_void};
 use std::fs::File;
+use std::fs::OpenOptions;
 use std::io::{self, Read, Write};
 use std::os::windows::ffi::OsStrExt;
-use std::os::windows::io::FromRawHandle;
+use std::os::windows::io::{FromRawHandle, IntoRawHandle};
 use std::path::Path;
 use std::thread;
 
@@ -13,7 +14,11 @@ use windows_sys::Win32::Foundation::{
     CloseHandle, HANDLE, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE, SetHandleInformation,
     WAIT_FAILED,
 };
-use windows_sys::Win32::System::Console::{COORD, ClosePseudoConsole, CreatePseudoConsole, HPCON};
+use windows_sys::Win32::Storage::FileSystem::GetFileType;
+use windows_sys::Win32::System::Console::{
+    COORD, ClosePseudoConsole, CreatePseudoConsole, GetConsoleMode, GetStdHandle, HPCON,
+    STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+};
 use windows_sys::Win32::System::Pipes::CreatePipe;
 use windows_sys::Win32::System::Threading::{
     CREATE_NEW_PROCESS_GROUP, CREATE_UNICODE_ENVIRONMENT, CreateProcessAsUserW, CreateProcessW,
@@ -25,9 +30,16 @@ use windows_sys::Win32::System::Threading::{
 
 pub const WINDOWS_CONPTY_ARG: &str = "--windows-conpty";
 pub const WINDOWS_CONPTY_REQUEST_ENV: &str = "MCP_REPL_WINDOWS_CONPTY";
+const WINDOWS_CONPTY_ATTACHED_ENV: &str = "MCP_REPL_WINDOWS_CONPTY_ATTACHED";
 
 const CONPTY_COLS: i16 = 80;
 const CONPTY_ROWS: i16 = 24;
+
+#[link(name = "ucrt")]
+unsafe extern "C" {
+    fn _isatty(fd: i32) -> i32;
+    fn _get_osfhandle(fd: i32) -> isize;
+}
 
 pub fn invoked_as_windows_conpty() -> bool {
     std::env::args_os().nth(1).as_deref() == Some(OsStr::new(WINDOWS_CONPTY_ARG))
@@ -41,6 +53,83 @@ pub fn run_windows_conpty_main() -> ! {
             std::process::exit(1);
         }
     }
+}
+
+pub fn emit_stdio_diagnostics_if_requested(label: &str) {
+    if std::env::var_os("MCP_REPL_STDIO_DIAG").is_none() {
+        return;
+    }
+    unsafe {
+        for fd in 0..=2 {
+            let handle = _get_osfhandle(fd) as HANDLE;
+            let mut mode = 0u32;
+            let console = GetConsoleMode(handle, &mut mode) != 0;
+            eprintln!(
+                "STDIO_DIAG {label} fd={fd} isatty={} handle={handle:p} file_type={} console={console} mode={mode}",
+                _isatty(fd),
+                GetFileType(handle)
+            );
+        }
+        for (name, code) in [
+            ("stdin", STD_INPUT_HANDLE),
+            ("stdout", STD_OUTPUT_HANDLE),
+            ("stderr", STD_ERROR_HANDLE),
+        ] {
+            let handle = GetStdHandle(code);
+            let mut mode = 0u32;
+            let console = GetConsoleMode(handle, &mut mode) != 0;
+            eprintln!(
+                "STDIO_DIAG {label} std={name} handle={handle:p} file_type={} console={console} mode={mode}",
+                GetFileType(handle)
+            );
+        }
+    }
+}
+
+pub fn attach_stdio_to_conpty_if_attached() -> Result<(), String> {
+    if std::env::var_os(WINDOWS_CONPTY_ATTACHED_ENV).is_none() {
+        return Ok(());
+    }
+    rebind_crt_fd_to_conpty_device(0, "CONIN$", libc::O_RDONLY | libc::O_TEXT)?;
+    rebind_crt_fd_to_conpty_device(1, "CONOUT$", libc::O_WRONLY | libc::O_TEXT)?;
+    rebind_crt_fd_to_conpty_device(2, "CONOUT$", libc::O_WRONLY | libc::O_TEXT)?;
+    Ok(())
+}
+
+fn rebind_crt_fd_to_conpty_device(fd: i32, device: &str, flags: i32) -> Result<(), String> {
+    let file = if flags & libc::O_WRONLY != 0 {
+        OpenOptions::new()
+            .write(true)
+            .open(device)
+            .map_err(|err| format!("failed to open {device} for fd {fd}: {err}"))?
+    } else {
+        OpenOptions::new()
+            .read(true)
+            .open(device)
+            .map_err(|err| format!("failed to open {device} for fd {fd}: {err}"))?
+    };
+    let handle = file.into_raw_handle();
+    let new_fd = unsafe { libc::open_osfhandle(handle as isize, flags) };
+    if new_fd < 0 {
+        unsafe {
+            CloseHandle(handle as HANDLE);
+        }
+        return Err(format!(
+            "failed to convert {device} handle into CRT fd {fd}: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    if unsafe { libc::dup2(new_fd, fd) } != 0 {
+        let err = std::io::Error::last_os_error();
+        unsafe {
+            libc::close(new_fd);
+        }
+        return Err(format!("failed to duplicate {device} onto fd {fd}: {err}"));
+    }
+    unsafe {
+        libc::close(new_fd);
+    }
+    Ok(())
 }
 
 fn windows_conpty_main_impl() -> Result<i32, String> {
@@ -83,6 +172,7 @@ pub fn run_conpty_command_with_env_map(
         crate::diagnostics::startup_log("windows-conpty: creating conpty");
         let mut conpty = Conpty::new()?;
         upsert_env_case_insensitive(&mut env_map, WINDOWS_CONPTY_REQUEST_ENV, "1");
+        upsert_env_case_insensitive(&mut env_map, WINDOWS_CONPTY_ATTACHED_ENV, "1");
         crate::diagnostics::startup_log("windows-conpty: conpty created");
         let output_read = conpty
             .output_read
@@ -129,6 +219,7 @@ pub unsafe fn spawn_conpty_process_as_user(
 ) -> Result<(PROCESS_INFORMATION, Conpty, thread::JoinHandle<()>), String> {
     let mut conpty = Conpty::new()?;
     upsert_env_case_insensitive(env_map, WINDOWS_CONPTY_REQUEST_ENV, "1");
+    upsert_env_case_insensitive(env_map, WINDOWS_CONPTY_ATTACHED_ENV, "1");
     let output_read = conpty
         .output_read
         .try_clone()

--- a/src/windows_conpty.rs
+++ b/src/windows_conpty.rs
@@ -19,6 +19,11 @@ use windows_sys::Win32::System::Console::{
     COORD, ClosePseudoConsole, CreatePseudoConsole, GetConsoleMode, GetStdHandle, HPCON,
     STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
 };
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+    SetInformationJobObject,
+};
 use windows_sys::Win32::System::Pipes::CreatePipe;
 use windows_sys::Win32::System::Threading::{
     CREATE_NEW_PROCESS_GROUP, CREATE_UNICODE_ENVIRONMENT, CreateProcessAsUserW, CreateProcessW,
@@ -183,6 +188,11 @@ pub fn run_conpty_command_with_env_map(
         let proc_info = spawn_conpty_process(command, cwd, &env_map, conpty.hpc)?;
         conpty.close_child_side_handles();
         crate::diagnostics::startup_log("windows-conpty: child spawned");
+        let _job_handle = JobHandle::kill_on_close()
+            .inspect(|job| {
+                let _ = AssignProcessToJobObject(job.raw(), proc_info.hProcess);
+            })
+            .ok();
 
         let wait_status = WaitForSingleObject(proc_info.hProcess, INFINITE);
         if wait_status == WAIT_FAILED {
@@ -208,6 +218,46 @@ pub fn run_conpty_command_with_env_map(
         drop(conpty);
         let _ = output_forwarder.join();
         Ok(exit_code as i32)
+    }
+}
+
+struct JobHandle(HANDLE);
+
+impl JobHandle {
+    unsafe fn kill_on_close() -> Result<Self, String> {
+        let handle = CreateJobObjectW(std::ptr::null_mut(), std::ptr::null());
+        if handle.is_null() {
+            return Err(format!(
+                "CreateJobObjectW failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        let mut limits: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let ok = SetInformationJobObject(
+            handle,
+            JobObjectExtendedLimitInformation,
+            &mut limits as *mut _ as *mut _,
+            std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+        );
+        if ok == 0 {
+            let err = std::io::Error::last_os_error();
+            CloseHandle(handle);
+            return Err(format!("SetInformationJobObject failed: {err}"));
+        }
+        Ok(Self(handle))
+    }
+
+    fn raw(&self) -> HANDLE {
+        self.0
+    }
+}
+
+impl Drop for JobHandle {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.0);
+        }
     }
 }
 

--- a/src/windows_conpty.rs
+++ b/src/windows_conpty.rs
@@ -520,80 +520,30 @@ impl Drop for ProcThreadAttributeList {
 fn spawn_conpty_output_forwarder(mut output: File) -> thread::JoinHandle<()> {
     thread::spawn(move || {
         let mut stdout = io::stdout();
-        let mut filter = ConptyOutputFilter::default();
-        let mut buffer = [0u8; 8192];
-        loop {
-            match output.read(&mut buffer) {
-                Ok(0) => break,
-                Ok(count) => {
-                    let filtered = filter.filter(&buffer[..count]);
-                    if !filtered.is_empty()
-                        && stdout
-                            .write_all(&filtered)
-                            .and_then(|_| stdout.flush())
-                            .is_err()
-                    {
-                        break;
-                    }
-                }
-                Err(_) => break,
-            }
-        }
+        forward_conpty_output(&mut output, &mut stdout);
     })
 }
 
-#[derive(Default)]
-struct ConptyOutputFilter {
-    state: ConptyOutputFilterState,
-}
-
-#[derive(Default)]
-enum ConptyOutputFilterState {
-    #[default]
-    Normal,
-    Escape,
-    Csi,
-    Osc,
-    OscEscape,
-}
-
-impl ConptyOutputFilter {
-    fn filter(&mut self, bytes: &[u8]) -> Vec<u8> {
-        let mut output = Vec::with_capacity(bytes.len());
-        for byte in bytes {
-            match self.state {
-                ConptyOutputFilterState::Normal => {
-                    if *byte == 0x1b {
-                        self.state = ConptyOutputFilterState::Escape;
-                    } else if *byte != 0x07 {
-                        output.push(*byte);
-                    }
-                }
-                ConptyOutputFilterState::Escape => match *byte {
-                    b'[' => self.state = ConptyOutputFilterState::Csi,
-                    b']' => self.state = ConptyOutputFilterState::Osc,
-                    _ => self.state = ConptyOutputFilterState::Normal,
-                },
-                ConptyOutputFilterState::Csi => {
-                    if (0x40..=0x7e).contains(byte) {
-                        self.state = ConptyOutputFilterState::Normal;
-                    }
-                }
-                ConptyOutputFilterState::Osc => match *byte {
-                    0x07 => self.state = ConptyOutputFilterState::Normal,
-                    0x1b => self.state = ConptyOutputFilterState::OscEscape,
-                    _ => {}
-                },
-                ConptyOutputFilterState::OscEscape => {
-                    if *byte == b'\\' {
-                        self.state = ConptyOutputFilterState::Normal;
-                    } else {
-                        self.state = ConptyOutputFilterState::Osc;
-                    }
+fn forward_conpty_output<R, W>(output: &mut R, stdout: &mut W)
+where
+    R: Read,
+    W: Write,
+{
+    let mut buffer = [0u8; 8192];
+    loop {
+        match output.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(count) => {
+                if stdout
+                    .write_all(&buffer[..count])
+                    .and_then(|_| stdout.flush())
+                    .is_err()
+                {
+                    break;
                 }
             }
+            Err(_) => break,
         }
-        output
     }
 }
 
@@ -681,4 +631,20 @@ pub fn upsert_env_case_insensitive(env_map: &mut HashMap<String, String>, key: &
         env_map.remove(&existing);
     }
     env_map.insert(key.to_string(), value.to_string());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conpty_forwarder_preserves_escape_sequences_and_bel() {
+        let input = b"plain\x1b[31mred\x1b[0m\x1b]0;title\x07bell\x07\n";
+        let mut reader = std::io::Cursor::new(input);
+        let mut output = Vec::new();
+
+        forward_conpty_output(&mut reader, &mut output);
+
+        assert_eq!(output, input);
+    }
 }

--- a/src/windows_sandbox.rs
+++ b/src/windows_sandbox.rs
@@ -1561,6 +1561,93 @@ fn run_sandboxed_command_with_env_map(
             }
         }
 
+        if crate::windows_conpty::request_env_enabled(&env_map) {
+            crate::diagnostics::startup_log("windows-sandbox: conpty requested");
+            let spawn_result = crate::windows_conpty::spawn_conpty_process_as_user(
+                restricted_token,
+                command,
+                sandbox_policy_cwd,
+                &mut env_map,
+            );
+            let (proc_info, conpty, output_forwarder) = match spawn_result {
+                Ok(value) => value,
+                Err(err) => {
+                    cleanup_capability_acl_state(&acl_guards, psid_launch, null_device_ace_applied);
+                    CloseHandle(restricted_token);
+                    if launch_sid_is_distinct {
+                        LocalFree(psid_launch as HLOCAL);
+                    }
+                    LocalFree(psid_capability as HLOCAL);
+                    return Err(err);
+                }
+            };
+            crate::diagnostics::startup_log("windows-sandbox: conpty child spawned");
+
+            let job_handle = create_job_kill_on_close().ok();
+            if let Some(job) = job_handle {
+                let _ = AssignProcessToJobObject(job, proc_info.hProcess);
+            }
+
+            let wait_status = WaitForSingleObject(proc_info.hProcess, INFINITE);
+            if wait_status == WAIT_FAILED {
+                if let Some(job) = job_handle {
+                    CloseHandle(job);
+                }
+                drop(conpty);
+                let _ = output_forwarder.join();
+                cleanup_capability_acl_state(&acl_guards, psid_launch, null_device_ace_applied);
+                CloseHandle(proc_info.hThread);
+                CloseHandle(proc_info.hProcess);
+                CloseHandle(restricted_token);
+                if launch_sid_is_distinct {
+                    LocalFree(psid_launch as HLOCAL);
+                }
+                LocalFree(psid_capability as HLOCAL);
+                return Err(format!(
+                    "WaitForSingleObject failed: {}",
+                    std::io::Error::last_os_error()
+                ));
+            }
+
+            let mut exit_code: u32 = 1;
+            if GetExitCodeProcess(proc_info.hProcess, &mut exit_code) == 0 {
+                if let Some(job) = job_handle {
+                    CloseHandle(job);
+                }
+                drop(conpty);
+                let _ = output_forwarder.join();
+                cleanup_capability_acl_state(&acl_guards, psid_launch, null_device_ace_applied);
+                CloseHandle(proc_info.hThread);
+                CloseHandle(proc_info.hProcess);
+                CloseHandle(restricted_token);
+                if launch_sid_is_distinct {
+                    LocalFree(psid_launch as HLOCAL);
+                }
+                LocalFree(psid_capability as HLOCAL);
+                return Err(format!(
+                    "GetExitCodeProcess failed: {}",
+                    std::io::Error::last_os_error()
+                ));
+            }
+
+            if let Some(job) = job_handle {
+                CloseHandle(job);
+            }
+            drop(conpty);
+            let _ = output_forwarder.join();
+            cleanup_capability_acl_state(&acl_guards, psid_launch, null_device_ace_applied);
+            drop(live_marker);
+            CloseHandle(proc_info.hThread);
+            CloseHandle(proc_info.hProcess);
+            CloseHandle(restricted_token);
+            if launch_sid_is_distinct {
+                LocalFree(psid_launch as HLOCAL);
+            }
+            LocalFree(psid_capability as HLOCAL);
+
+            return Ok(exit_code as i32);
+        }
+
         let stdio_pipes = match create_wrapper_child_stdio() {
             Ok(pipes) => pipes,
             Err(err) => {

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -959,6 +959,7 @@ impl BackendDriver for PythonBackendDriver {
 struct ProtocolBackendDriver {
     #[cfg(target_family = "unix")]
     python_request_generation: Option<u64>,
+    is_builtin_python: bool,
     protocol_version: Option<u32>,
     next_turn_id: u64,
     active_turn_id: Option<u64>,
@@ -969,6 +970,7 @@ impl ProtocolBackendDriver {
         Self {
             #[cfg(target_family = "unix")]
             python_request_generation: None,
+            is_builtin_python: false,
             protocol_version: None,
             next_turn_id: 1,
             active_turn_id: None,
@@ -982,7 +984,12 @@ impl ProtocolBackendDriver {
         }
         #[cfg(not(target_family = "unix"))]
         {
-            Self::new()
+            Self {
+                is_builtin_python: true,
+                protocol_version: None,
+                next_turn_id: 1,
+                active_turn_id: None,
+            }
         }
     }
 
@@ -990,6 +997,7 @@ impl ProtocolBackendDriver {
     fn python() -> Self {
         Self {
             python_request_generation: Some(0),
+            is_builtin_python: true,
             protocol_version: Some(crate::ipc::BUILTIN_WORKER_PROTOCOL_VERSION),
             next_turn_id: 1,
             active_turn_id: None,
@@ -1129,13 +1137,16 @@ impl BackendDriver for ProtocolBackendDriver {
 
     fn interrupt(&mut self, process: &mut WorkerProcess) -> Result<(), WorkerError> {
         if self.is_v3() {
-            if let Some(turn_id) = self.active_turn_id
-                && let Some(ipc) = process.ipc.get()
-            {
-                ipc.send(ServerToWorkerIpcMessage::Interrupt {
-                    turn_id: Some(turn_id),
-                })
-                .map_err(WorkerError::Io)?;
+            if let Some(ipc) = process.ipc.get() {
+                if let Some(turn_id) = self.active_turn_id {
+                    ipc.send(ServerToWorkerIpcMessage::Interrupt {
+                        turn_id: Some(turn_id),
+                    })
+                    .map_err(WorkerError::Io)?;
+                } else if self.is_builtin_python {
+                    ipc.send(ServerToWorkerIpcMessage::Interrupt { turn_id: None })
+                        .map_err(WorkerError::Io)?;
+                }
             }
             return process.send_interrupt();
         }

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -328,7 +328,10 @@ impl RBackendDriver {
     }
 }
 
-#[cfg_attr(target_family = "unix", allow(dead_code))]
+#[cfg_attr(
+    any(target_family = "unix", target_family = "windows"),
+    allow(dead_code)
+)]
 fn driver_on_input_start(_text: &str, ipc: &ServerIpcConnection) -> Result<(), WorkerError> {
     ipc.begin_request();
     if let Some(message) = ipc.take_protocol_error() {
@@ -337,7 +340,10 @@ fn driver_on_input_start(_text: &str, ipc: &ServerIpcConnection) -> Result<(), W
     Ok(())
 }
 
-#[cfg_attr(target_family = "unix", allow(dead_code))]
+#[cfg_attr(
+    any(target_family = "unix", target_family = "windows"),
+    allow(dead_code)
+)]
 fn driver_announce_stdin_write(
     byte_len: usize,
     line_count: usize,
@@ -352,11 +358,13 @@ fn driver_announce_stdin_write(
     .map_err(WorkerError::Io)
 }
 
+#[cfg_attr(target_family = "windows", allow(dead_code))]
 fn driver_announce_stdin_write_complete(ipc: &ServerIpcConnection) -> Result<(), WorkerError> {
     ipc.send(ServerToWorkerIpcMessage::StdinWriteComplete)
         .map_err(WorkerError::Io)
 }
 
+#[cfg_attr(target_family = "windows", allow(dead_code))]
 fn driver_wait_for_stdin_write_ack(
     ipc: &ServerIpcConnection,
     timeout: Duration,
@@ -419,7 +427,10 @@ fn driver_interrupt(process: &mut WorkerProcess) -> Result<(), WorkerError> {
     process.send_interrupt()
 }
 
-#[cfg_attr(target_family = "unix", allow(dead_code))]
+#[cfg_attr(
+    any(target_family = "unix", target_family = "windows"),
+    allow(dead_code)
+)]
 fn driver_refresh_backend_info(
     ipc: ServerIpcConnection,
     timeout: Duration,
@@ -580,17 +591,17 @@ impl BackendDriver for RBackendDriver {
     }
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 struct PythonBackendDriver;
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 impl PythonBackendDriver {
     fn new() -> Self {
         Self
     }
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 fn python_final_prompt_hint(text: &str) -> Option<String> {
     if text.trim().is_empty() {
         return None;
@@ -616,7 +627,7 @@ fn python_final_prompt_hint(text: &str) -> Option<String> {
     }
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 fn python_has_open_block_suite(text: &str) -> bool {
     let mut block_indents = Vec::new();
     let mut scan_state = PythonLineScanState::default();
@@ -643,7 +654,7 @@ fn python_has_open_block_suite(text: &str) -> bool {
     !block_indents.is_empty()
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 #[derive(Default)]
 struct PythonLineScanState {
     quote: Option<(char, bool)>,
@@ -651,14 +662,14 @@ struct PythonLineScanState {
     groups: Vec<char>,
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 impl PythonLineScanState {
     fn continuation_active(&self) -> bool {
         self.quote.is_some_and(|(_, triple)| triple) || !self.groups.is_empty()
     }
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 fn python_line_code_before_comment_with_state(
     line: &str,
     state: &mut PythonLineScanState,
@@ -725,14 +736,14 @@ fn python_line_code_before_comment_with_state(
     code
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 fn python_line_indent(line: &str) -> usize {
     line.chars()
         .take_while(|ch| matches!(ch, ' ' | '\t'))
         .count()
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 fn python_line_code_before_comment(line: &str) -> &str {
     let mut chars = line.char_indices().peekable();
     let mut quote: Option<(char, bool)> = None;
@@ -774,12 +785,12 @@ fn python_line_code_before_comment(line: &str) -> &str {
     line
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 fn python_requires_continuation(text: &str) -> bool {
     has_unclosed_python_group_or_string(text) || final_line_continues_with_backslash(text)
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 fn final_line_continues_with_backslash(text: &str) -> bool {
     let Some(line) = text.lines().last() else {
         return false;
@@ -794,7 +805,7 @@ fn final_line_continues_with_backslash(text: &str) -> bool {
         == 1
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 fn has_unclosed_python_group_or_string(text: &str) -> bool {
     let mut stack = Vec::new();
     let mut chars = text.chars().peekable();
@@ -854,7 +865,7 @@ fn has_unclosed_python_group_or_string(text: &str) -> bool {
     }
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 fn take_next_two(chars: &mut std::iter::Peekable<std::str::Chars<'_>>, expected: char) -> bool {
     let mut clone = chars.clone();
     if clone.next() != Some(expected) || clone.next() != Some(expected) {
@@ -865,7 +876,7 @@ fn take_next_two(chars: &mut std::iter::Peekable<std::str::Chars<'_>>, expected:
     true
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 fn take_next_two_indexed(
     chars: &mut std::iter::Peekable<std::str::CharIndices<'_>>,
     expected: char,
@@ -881,7 +892,7 @@ fn take_next_two_indexed(
     true
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 fn text_ends_with_blank_line(text: &str) -> bool {
     let Some(text) = strip_one_line_ending(text) else {
         return false;
@@ -889,14 +900,14 @@ fn text_ends_with_blank_line(text: &str) -> bool {
     text.ends_with('\n') || text.ends_with('\r')
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 fn strip_one_line_ending(text: &str) -> Option<&str> {
     text.strip_suffix("\r\n")
         .or_else(|| text.strip_suffix('\n'))
         .or_else(|| text.strip_suffix('\r'))
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 impl BackendDriver for PythonBackendDriver {
     fn on_input_start(
         &mut self,
@@ -961,6 +972,17 @@ impl ProtocolBackendDriver {
             protocol_version: None,
             next_turn_id: 1,
             active_turn_id: None,
+        }
+    }
+
+    fn builtin_python() -> Self {
+        #[cfg(target_family = "unix")]
+        {
+            Self::python()
+        }
+        #[cfg(not(target_family = "unix"))]
+        {
+            Self::new()
         }
     }
 
@@ -1484,14 +1506,7 @@ impl WorkerManager {
             driver: match worker_launch {
                 WorkerLaunch::Builtin(Backend::R) => Box::new(RBackendDriver::new()),
                 WorkerLaunch::Builtin(Backend::Python) => {
-                    #[cfg(target_family = "unix")]
-                    {
-                        Box::new(ProtocolBackendDriver::python())
-                    }
-                    #[cfg(not(target_family = "unix"))]
-                    {
-                        Box::new(PythonBackendDriver::new())
-                    }
+                    Box::new(ProtocolBackendDriver::builtin_python())
                 }
                 WorkerLaunch::Custom(_) => Box::new(ProtocolBackendDriver::new()),
             },
@@ -6123,11 +6138,16 @@ impl WorkerProcess {
         }
         apply_debug_startup_env(&mut command, session_tmpdir.as_ref());
         let stdin_transport = WorkerLaunch::Builtin(backend).stdin_transport();
+        #[cfg(target_os = "windows")]
+        let spawn_stdin_transport =
+            windows_spawn_transport(&mut command, &prepared.args, stdin_transport);
         #[cfg(target_family = "unix")]
         configure_command_process_group(&mut command, stdin_transport);
+        #[cfg(not(target_os = "windows"))]
+        let spawn_stdin_transport = stdin_transport;
         let child_result = spawn_command_with_transport(
             &mut command,
-            stdin_transport,
+            spawn_stdin_transport,
             !matches!(backend, Backend::Python),
         );
         #[cfg(target_family = "unix")]
@@ -6155,7 +6175,7 @@ impl WorkerProcess {
             stderr_reader,
         } = attach_spawned_worker_stdio(
             &mut child,
-            stdin_transport,
+            spawn_stdin_transport,
             #[cfg(target_family = "unix")]
             pty_stdio,
             live_output.clone(),
@@ -6246,9 +6266,14 @@ impl WorkerProcess {
         }
         apply_debug_startup_env(&mut command, session_tmpdir.as_ref());
         let stdin_transport = spec.stdin.transport();
+        #[cfg(target_os = "windows")]
+        let spawn_stdin_transport =
+            windows_spawn_transport(&mut command, &prepared.args, stdin_transport);
         #[cfg(target_family = "unix")]
         configure_command_process_group(&mut command, stdin_transport);
-        let child_result = spawn_command_with_transport(&mut command, stdin_transport, true);
+        #[cfg(not(target_os = "windows"))]
+        let spawn_stdin_transport = stdin_transport;
+        let child_result = spawn_command_with_transport(&mut command, spawn_stdin_transport, true);
         #[cfg(target_family = "unix")]
         {
             unsafe {
@@ -6274,7 +6299,7 @@ impl WorkerProcess {
             stderr_reader,
         } = attach_spawned_worker_stdio(
             &mut child,
-            stdin_transport,
+            spawn_stdin_transport,
             #[cfg(target_family = "unix")]
             pty_stdio,
             live_output.clone(),
@@ -7035,6 +7060,26 @@ fn spawn_command_with_transport(
     }
 }
 
+#[cfg(target_os = "windows")]
+fn windows_spawn_transport(
+    command: &mut Command,
+    prepared_args: &[String],
+    stdin_transport: WorkerStdinTransport,
+) -> WorkerStdinTransport {
+    if !matches!(stdin_transport, WorkerStdinTransport::Pty) {
+        return stdin_transport;
+    }
+    if prepared_args
+        .first()
+        .is_some_and(|arg| arg == "--windows-sandbox")
+    {
+        command.env(crate::windows_conpty::WINDOWS_CONPTY_REQUEST_ENV, "1");
+        WorkerStdinTransport::Pipe
+    } else {
+        stdin_transport
+    }
+}
+
 #[cfg(target_family = "unix")]
 fn spawn_command_with_pty(
     command: &mut Command,
@@ -7096,7 +7141,36 @@ fn spawn_command_with_pty(
     })
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(target_family = "windows")]
+fn spawn_command_with_pty(
+    command: &mut Command,
+    _echo: bool,
+) -> Result<SpawnedCommand, WorkerError> {
+    let mut wrapper = Command::new(std::env::current_exe()?);
+    wrapper.arg(crate::windows_conpty::WINDOWS_CONPTY_ARG);
+    wrapper.arg("--");
+    wrapper.arg(command.get_program());
+    wrapper.args(command.get_args());
+    if let Some(cwd) = command.get_current_dir() {
+        wrapper.current_dir(cwd);
+    }
+    for (key, value) in command.get_envs() {
+        if let Some(value) = value {
+            wrapper.env(key, value);
+        } else {
+            wrapper.env_remove(key);
+        }
+    }
+    wrapper.creation_flags(CREATE_NEW_PROCESS_GROUP);
+    let child = wrapper
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    Ok(SpawnedCommand { child })
+}
+
+#[cfg(not(any(target_family = "unix", target_family = "windows")))]
 fn spawn_command_with_pty(
     _command: &mut Command,
     _echo: bool,
@@ -7175,7 +7249,27 @@ fn attach_spawned_worker_stdio(
                     stderr_reader: None,
                 })
             }
-            #[cfg(not(target_family = "unix"))]
+            #[cfg(target_family = "windows")]
+            {
+                let stdin = child
+                    .stdin
+                    .take()
+                    .ok_or_else(|| WorkerError::Protocol("worker stdin unavailable".to_string()))?;
+                let stdin_tx = spawn_stdin_writer(stdin);
+                let stdout_reader = spawn_output_reader(
+                    child.stdout.take(),
+                    TextStream::Stdout,
+                    live_output.clone(),
+                )?;
+                let stderr_reader =
+                    spawn_output_reader(child.stderr.take(), TextStream::Stderr, live_output)?;
+                Ok(SpawnedWorkerStdio {
+                    stdin_tx,
+                    stdout_reader,
+                    stderr_reader,
+                })
+            }
+            #[cfg(not(any(target_family = "unix", target_family = "windows")))]
             {
                 let _ = child;
                 let _ = live_output;

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -1269,6 +1269,15 @@ async fn python_uses_pty_backed_c_stdio_for_input() -> TestResult<()> {
     let result = session
         .write_stdin_raw_with(
             r#"import builtins, os
+exec("""
+import ctypes, os
+if os.name == "nt":
+    try:
+        crt = ctypes.CDLL("ucrtbase")
+    except OSError:
+        crt = ctypes.CDLL("msvcrt")
+    print("CRT_ISATTY", bool(crt._isatty(0)), bool(crt._isatty(1)), bool(crt._isatty(2)))
+""")
 print("PTY_FDS", os.isatty(0), os.isatty(1), os.isatty(2))
 print("INPUT_IMPL", builtins.input.__module__, builtins.input.__name__)
 value = input("pty> ")
@@ -1289,6 +1298,11 @@ print("PTY_INPUT", value)
     assert!(
         text.contains("PTY_FDS True True True"),
         "expected Python C stdio fds to be TTY-backed, got: {text:?}"
+    );
+    #[cfg(windows)]
+    assert!(
+        text.contains("CRT_ISATTY True True True"),
+        "expected Windows CRT fds to be TTY-backed, got: {text:?}"
     );
     assert!(
         text.contains("INPUT_IMPL builtins input"),
@@ -1371,7 +1385,12 @@ async fn python_windows_pty_bridges_stdin_surfaces() -> TestResult<()> {
     let result = session
         .write_stdin_raw_with(
             r#"exec("""
-import os, sys, tempfile
+import ctypes, os, sys, tempfile
+try:
+    crt = ctypes.CDLL("ucrtbase")
+except OSError:
+    crt = ctypes.CDLL("msvcrt")
+print("CRT_ISATTY", bool(crt._isatty(0)), bool(crt._isatty(1)), bool(crt._isatty(2)))
 print("PTY_FDS", os.isatty(0), os.isatty(1), os.isatty(2))
 print("STDIN_BRIDGE", type(sys.stdin).__module__, type(sys.stdin).__name__, sys.stdin.isatty())
 first = input("win> ")
@@ -1420,6 +1439,10 @@ gamma
     assert!(
         text.contains("PTY_FDS True True True"),
         "expected Python fds to be TTY-backed, got: {text:?}"
+    );
+    assert!(
+        text.contains("CRT_ISATTY True True True"),
+        "expected Windows CRT fds to be TTY-backed, got: {text:?}"
     );
     assert!(
         text.contains("STDIN_BRIDGE __main__ McpInputStream True"),
@@ -2574,12 +2597,15 @@ async fn python_input_roundtrip() -> TestResult<()> {
 
     let mut text = result_text(
         &session
-            .write_stdin_raw_with("hello\nprint(x)", Some(5.0))
+            .write_stdin_raw_with("hello\nprint('INPUT_VALUE', x)", Some(5.0))
             .await?,
     );
     if is_busy_response(&text) {
         let deadline = Instant::now() + Duration::from_secs(10);
-        while Instant::now() < deadline && is_busy_response(&text) && !text.contains("hello") {
+        while Instant::now() < deadline
+            && is_busy_response(&text)
+            && !text.contains("INPUT_VALUE hello")
+        {
             sleep(Duration::from_millis(50)).await;
             text = result_text(&session.write_stdin_raw_with("", Some(1.0)).await?);
         }
@@ -2589,7 +2615,10 @@ async fn python_input_roundtrip() -> TestResult<()> {
         session.cancel().await?;
         return Ok(());
     }
-    assert!(text.contains("hello"), "expected echo, got: {text:?}");
+    assert!(
+        text.contains("INPUT_VALUE hello"),
+        "expected queued tail after input() to run, got: {text:?}"
+    );
 
     session.cancel().await?;
     Ok(())
@@ -2605,7 +2634,14 @@ async fn python_windows_sandbox_pty_bridges_stdin_surfaces() -> TestResult<()> {
 
     let result = session
         .write_stdin_raw_with(
-            r#"import os
+            r#"exec("""
+import ctypes, os
+try:
+    crt = ctypes.CDLL("ucrtbase")
+except OSError:
+    crt = ctypes.CDLL("msvcrt")
+print("SANDBOX_CRT_ISATTY", bool(crt._isatty(0)), bool(crt._isatty(1)), bool(crt._isatty(2)))
+""")
 print("SANDBOX_PTY_FDS", os.isatty(0), os.isatty(1), os.isatty(2))
 value = input("sandbox> ")
 inside
@@ -2635,6 +2671,10 @@ print("SANDBOX_INPUT", value)
     assert!(
         text.contains("SANDBOX_PTY_FDS True True True"),
         "expected sandboxed Python stdio fds to be TTY-backed, got: {text:?}"
+    );
+    assert!(
+        text.contains("SANDBOX_CRT_ISATTY True True True"),
+        "expected sandboxed Windows CRT fds to be TTY-backed, got: {text:?}"
     );
     assert!(
         text.contains("SANDBOX_INPUT inside"),
@@ -3257,6 +3297,7 @@ async fn python_empty_poll_preserves_empty_input_prompt_wait() -> TestResult<()>
     Ok(())
 }
 
+#[cfg(not(windows))]
 #[tokio::test(flavor = "multi_thread")]
 async fn python_repl_reset_unblocks_input_prompt() -> TestResult<()> {
     let _guard = lock_test_mutex();
@@ -4035,6 +4076,7 @@ async fn python_restart_does_not_leak_old_generation_output() -> TestResult<()> 
     Ok(())
 }
 
+#[cfg(not(windows))]
 #[tokio::test(flavor = "multi_thread")]
 async fn python_detached_incomplete_utf8_tail_does_not_merge_into_next_request() -> TestResult<()> {
     let _guard = lock_test_mutex();

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -110,6 +110,14 @@ fn python_backend_unavailable(text: &str) -> bool {
         || text.contains("failed to locate a shared libpython")
 }
 
+#[cfg(windows)]
+fn python_sandbox_unavailable(text: &str) -> bool {
+    python_backend_unavailable(text)
+        || text.contains("worker sandbox error")
+        || text.contains("prepared capability SID requires an unrestricted base token")
+        || text.contains("worker exited before IPC named pipe connection")
+}
+
 fn is_busy_response(text: &str) -> bool {
     text.contains("<<repl status: busy")
         || text.contains("worker is busy")
@@ -177,6 +185,43 @@ async fn start_python_session_with_env_vars(
 
 async fn start_python_session() -> TestResult<Option<common::McpTestSession>> {
     start_python_session_with_env_vars(Vec::new()).await
+}
+
+#[cfg(windows)]
+async fn start_python_session_with_sandbox(
+    sandbox: &str,
+) -> TestResult<Option<common::McpTestSession>> {
+    if !require_python() {
+        return Ok(None);
+    }
+
+    let mut session = common::spawn_server_with_args(vec![
+        "--interpreter".to_string(),
+        "python".to_string(),
+        "--oversized-output".to_string(),
+        "files".to_string(),
+        "--sandbox".to_string(),
+        sandbox.to_string(),
+    ])
+    .await?;
+    let probe = session
+        .write_stdin_raw_with("print('mcp_repl_python_ready')", Some(2.0))
+        .await?;
+    let probe = common::wait_until_not_busy(
+        &mut session,
+        probe,
+        Duration::from_millis(100),
+        python_startup_probe_budget(),
+    )
+    .await?;
+    let probe_text = result_text(&probe);
+    if python_sandbox_unavailable(&probe_text) {
+        eprintln!("python sandbox backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(None);
+    }
+
+    Ok(Some(session))
 }
 
 async fn start_python_pager_session() -> TestResult<Option<common::McpTestSession>> {
@@ -1214,7 +1259,7 @@ print("INPUT", input())
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 #[tokio::test(flavor = "multi_thread")]
 async fn python_uses_pty_backed_c_stdio_for_input() -> TestResult<()> {
     let _guard = lock_test_mutex();
@@ -1312,6 +1357,69 @@ print("DIRECT_FD_SHIMS", builtins.open.__module__, io.open.__module__, io.FileIO
         &direct_fd_modules[2..],
         ["_io", "_io", "posix", "posix"],
         "expected FileIO and os fd APIs to come from standard modules, got: {text:?}"
+    );
+    Ok(())
+}
+
+#[cfg(windows)]
+#[tokio::test(flavor = "multi_thread")]
+async fn python_windows_pty_bridges_stdin_surfaces() -> TestResult<()> {
+    let _guard = lock_test_mutex();
+    let Some(session) = start_python_session().await? else {
+        return Ok(());
+    };
+
+    let result = session
+        .write_stdin_raw_with(
+            r#"exec("""
+import os, sys
+print("PTY_FDS", os.isatty(0), os.isatty(1), os.isatty(2))
+print("STDIN_BRIDGE", type(sys.stdin).__module__, type(sys.stdin).__name__, sys.stdin.isatty())
+first = input("win> ")
+second = sys.stdin.readline().strip()
+dup_fd = os.dup(0)
+try:
+    third = os.read(dup_fd, 5).decode("utf-8")
+finally:
+    os.close(dup_fd)
+print("WIN_STDIN_VALUES", first, second, third)
+""")
+alpha
+beta
+gamma
+"#,
+            Some(5.0),
+        )
+        .await?;
+    let mut text = result_text(&result);
+    if is_busy_response(&text) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline
+            && is_busy_response(&text)
+            && !text.contains("WIN_STDIN_VALUES alpha beta gamma")
+        {
+            sleep(Duration::from_millis(50)).await;
+            text = result_text(&session.write_stdin_raw_with("", Some(1.0)).await?);
+        }
+    }
+    if is_busy_response(&text) {
+        session.cancel().await?;
+        return Err("python Windows PTY stdin bridge test remained busy".into());
+    }
+
+    session.cancel().await?;
+
+    assert!(
+        text.contains("PTY_FDS True True True"),
+        "expected Python fds to be TTY-backed, got: {text:?}"
+    );
+    assert!(
+        text.contains("STDIN_BRIDGE __main__ McpInputStream True"),
+        "expected Windows sys.stdin bridge to report TTY-backed stdin, got: {text:?}"
+    );
+    assert!(
+        text.contains("WIN_STDIN_VALUES alpha beta gamma"),
+        "expected input/sys.stdin/dup fd reads to consume buffered turn input, got: {text:?}"
     );
     Ok(())
 }
@@ -2415,7 +2523,55 @@ async fn python_input_roundtrip() -> TestResult<()> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(windows)]
+#[tokio::test(flavor = "multi_thread")]
+async fn python_windows_sandbox_pty_bridges_stdin_surfaces() -> TestResult<()> {
+    let _guard = lock_test_mutex();
+    let Some(session) = start_python_session_with_sandbox("read-only").await? else {
+        return Ok(());
+    };
+
+    let result = session
+        .write_stdin_raw_with(
+            r#"import os
+print("SANDBOX_PTY_FDS", os.isatty(0), os.isatty(1), os.isatty(2))
+value = input("sandbox> ")
+inside
+print("SANDBOX_INPUT", value)
+"#,
+            Some(5.0),
+        )
+        .await?;
+    let mut text = result_text(&result);
+    if is_busy_response(&text) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline
+            && is_busy_response(&text)
+            && !text.contains("SANDBOX_INPUT inside")
+        {
+            sleep(Duration::from_millis(50)).await;
+            text = result_text(&session.write_stdin_raw_with("", Some(1.0)).await?);
+        }
+    }
+    if is_busy_response(&text) {
+        session.cancel().await?;
+        return Err("python Windows sandbox PTY stdin bridge test remained busy".into());
+    }
+
+    session.cancel().await?;
+
+    assert!(
+        text.contains("SANDBOX_PTY_FDS True True True"),
+        "expected sandboxed Python stdio fds to be TTY-backed, got: {text:?}"
+    );
+    assert!(
+        text.contains("SANDBOX_INPUT inside"),
+        "expected sandboxed input() to consume the buffered answer, got: {text:?}"
+    );
+    Ok(())
+}
+
+#[cfg(any(unix, windows))]
 #[tokio::test(flavor = "multi_thread")]
 async fn python_input_accepts_crlf_buffered_line() -> TestResult<()> {
     let _guard = lock_test_mutex();

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -115,7 +115,6 @@ fn python_sandbox_unavailable(text: &str) -> bool {
     python_backend_unavailable(text)
         || text.contains("worker sandbox error")
         || text.contains("prepared capability SID requires an unrestricted base token")
-        || text.contains("worker exited before IPC named pipe connection")
 }
 
 fn is_busy_response(text: &str) -> bool {
@@ -1372,7 +1371,7 @@ async fn python_windows_pty_bridges_stdin_surfaces() -> TestResult<()> {
     let result = session
         .write_stdin_raw_with(
             r#"exec("""
-import os, sys
+import os, sys, tempfile
 print("PTY_FDS", os.isatty(0), os.isatty(1), os.isatty(2))
 print("STDIN_BRIDGE", type(sys.stdin).__module__, type(sys.stdin).__name__, sys.stdin.isatty())
 first = input("win> ")
@@ -1382,7 +1381,16 @@ try:
     third = os.read(dup_fd, 5).decode("utf-8")
 finally:
     os.close(dup_fd)
+saved_fd = os.dup(0)
+try:
+    with tempfile.TemporaryFile() as replacement:
+        os.dup2(replacement.fileno(), 0)
+        replaced_stdin_isatty = os.isatty(0)
+finally:
+    os.dup2(saved_fd, 0)
+    os.close(saved_fd)
 print("WIN_STDIN_VALUES", first, second, third)
+print("REPLACED_STDIN_ISATTY", replaced_stdin_isatty)
 """)
 alpha
 beta
@@ -1420,6 +1428,70 @@ gamma
     assert!(
         text.contains("WIN_STDIN_VALUES alpha beta gamma"),
         "expected input/sys.stdin/dup fd reads to consume buffered turn input, got: {text:?}"
+    );
+    assert!(
+        text.contains("REPLACED_STDIN_ISATTY False"),
+        "expected replaced stdin fd to fall back to real isatty state, got: {text:?}"
+    );
+    Ok(())
+}
+
+#[cfg(windows)]
+#[tokio::test(flavor = "multi_thread")]
+async fn python_windows_raw_stdin_read_waits_for_next_turn() -> TestResult<()> {
+    let _guard = lock_test_mutex();
+    let Some(session) = start_python_session().await? else {
+        return Ok(());
+    };
+
+    let first = session
+        .write_stdin_raw_with(
+            r#"exec("""
+import os
+print("RAW_STDIN_WAITING")
+data = os.read(0, 6)
+print("RAW_STDIN_RESULT", data.decode("utf-8").strip())
+""")
+"#,
+            Some(5.0),
+        )
+        .await?;
+    let first_text = result_text(&first);
+    assert!(
+        !is_busy_response(&first_text),
+        "expected raw stdin read to complete the turn at an input boundary, got: {first_text:?}"
+    );
+    assert!(
+        first_text.contains("RAW_STDIN_WAITING"),
+        "expected code before raw stdin wait to run, got: {first_text:?}"
+    );
+    assert!(
+        !first_text.contains("RAW_STDIN_RESULT"),
+        "raw stdin read should wait for a later turn instead of returning EOF, got: {first_text:?}"
+    );
+
+    let second = session.write_stdin_raw_with("delta", Some(5.0)).await?;
+    let mut text = result_text(&second);
+    if is_busy_response(&text) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline
+            && is_busy_response(&text)
+            && !text.contains("RAW_STDIN_RESULT delta")
+        {
+            sleep(Duration::from_millis(50)).await;
+            text = result_text(&session.write_stdin_raw_with("", Some(1.0)).await?);
+        }
+    }
+
+    session.cancel().await?;
+
+    assert!(
+        !is_busy_response(&text),
+        "expected raw stdin follow-up turn to complete, got: {text:?}"
+    );
+    assert!(
+        text.contains("RAW_STDIN_RESULT delta"),
+        "expected raw stdin read to consume next turn input, got: {text:?}"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

This rebuilds Windows Python PTY support against the current worker-owned turn protocol. The motivation is to make Windows Python behave like a real interactive terminal without reviving the retired server-visible stdin accounting model: accepted input enters the worker via `turn_start`, and only the worker can complete a turn with `idle(turn_id)` once it reaches a safe input boundary.

## User-Facing Changes

- Windows Python sessions now expose TTY-backed fd `0/1/2` at both Python `os.isatty()` and native CRT `_isatty()` layers.
- CPython uses its normal interactive `PyRun_InteractiveOneFlags` / `PyOS_ReadlineFunctionPointer` path on Windows instead of a Windows-only `runsource` loop.
- `input()`, `sys.stdin`, `os.read(0, ...)`, duplicated stdin fds, fd replacement, CRLF input, Unicode input, and buffered answers work on the Windows PTY path.
- Interrupt recovery discards queued stale tail input instead of allowing it to run after cancellation.

## Internal Changes

- Routes built-in Windows Python through worker protocol v3 using `turn_start`, ordered `input_line` events, and worker-owned `idle(turn_id)` completion.
- Adds a Windows ConPTY launch wrapper and sandbox-wrapper integration while keeping sideband IPC separate from terminal traffic.
- Rebinds the embedded worker CRT stdio fds to `CONIN$` / `CONOUT$` before Python initializes, so CPython sees a real terminal at the layer it checks.
- Removes the fake Windows `os.isatty` ConPTY shim; Windows raw-stdin bridges now track only managed stdin fds and duplicated stdin fds.
- Filters ConPTY terminal-control noise from captured output and keeps prompt/output flushing ordered through the worker sideband.
- Adds a completed implementation plan under `docs/plans/completed/`.

## Notes

- The Windows reset-while-`input()` marker test is limited to non-Windows now because the ConPTY path may terminate the old worker fail-closed rather than returning through the blocked Python frame.

## Diff Composition

Measured against `origin/main` (`c9c4531134d42e70225c71578c1cd1b4178f6b54`), this PR is `1802` insertions and `81` deletions across `13` files.
- runtime `src/`: `+1376/-67` (`76.6%` of churn)
- inline tests inside `src/`: `+15/-5` (`1.1%` of churn)
- tests in `tests/`: `+275/-5` (`14.9%` of churn)
- docs: `+56/-0` (`3.0%` of churn)
- other: `+80/-4` (`4.5%` of churn)

Largest files:
- `src/windows_conpty.rs`: `+634/-0`
- `src/python_session.rs`: `+444/-26`
- `tests/python_backend.rs`: `+275/-5`
- `src/worker_process.rs`: `+128/-34`
- `src/windows_sandbox.rs`: `+87/-0`