### PR TITLE
Preserve visible Python input prompts that match `sys.ps1`

### DIFF
--- a/src/python_session.rs
+++ b/src/python_session.rs
@@ -1943,13 +1943,22 @@ unsafe extern "C" fn mcp_repl_readline(
     if ipc::worker_ipc_disabled_for_process() {
         return allocate_readline_result(&[]);
     }
+    #[cfg(any(target_family = "unix", windows))]
+    let readline_state = set_current_repl_readline_prompt(&prompt_text);
+    #[cfg(not(any(target_family = "unix", windows)))]
     set_current_repl_readline_prompt(&prompt_text);
-    #[cfg(target_family = "unix")]
-    let prompt_matches_repl = prompt_matches_python_repl_prompt(&prompt_text);
+    #[cfg(any(target_family = "unix", windows))]
+    // This uses CPython's current readline callback and tracked turn state, not
+    // rendered output parsing. Suppress only actual REPL prompts; client-input
+    // prompts can intentionally equal sys.ps1/sys.ps2 and must stay visible.
+    let suppress_repl_prompt_echo = matches!(
+        readline_state,
+        PythonReadlineState::Primary | PythonReadlineState::Continuation
+    ) && prompt_matches_python_repl_prompt(&prompt_text);
     #[cfg(target_family = "unix")]
     flush_original_stdio();
     #[cfg(target_family = "unix")]
-    if !prompt_text.is_empty() && !prompt_matches_repl {
+    if !prompt_text.is_empty() && !suppress_repl_prompt_echo {
         emit_output_text(TextStream::Stdout, prompt_text.as_bytes());
     }
     #[cfg(target_family = "unix")]
@@ -1962,7 +1971,7 @@ unsafe extern "C" fn mcp_repl_readline(
     #[cfg(windows)]
     let read = match read_windows_turn_line(
         &prompt_text,
-        !prompt_text.is_empty() && !prompt_matches_python_repl_prompt(&prompt_text),
+        !prompt_text.is_empty() && !suppress_repl_prompt_echo,
         false,
     ) {
         Ok(read) => read,
@@ -2140,9 +2149,9 @@ fn begin_repl_turn() {
     guard.repl_readline_count = 0;
 }
 
-fn set_current_repl_readline_prompt(prompt: &str) {
+fn set_current_repl_readline_prompt(prompt: &str) -> PythonReadlineState {
     let Some(state) = SESSION_STATE.get() else {
-        return;
+        return PythonReadlineState::Primary;
     };
     let mut guard = state.inner.lock().unwrap();
     let started_after_continuation_prompt = guard
@@ -2165,6 +2174,7 @@ fn set_current_repl_readline_prompt(prompt: &str) {
         Some(prompt.to_string())
     };
     guard.current_readline_state = Some(readline_state);
+    readline_state
 }
 
 fn remember_emitted_prompt(prompt: &str) {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -965,6 +965,22 @@ impl McpSnapshot {
         Ok(())
     }
 
+    pub async fn python_files_session<F>(&mut self, name: impl Into<String>, f: F) -> TestResult<()>
+    where
+        F: for<'a> FnOnce(
+            &'a mut McpTestSession,
+        )
+            -> Pin<Box<dyn std::future::Future<Output = TestResult<()>> + Send + 'a>>,
+    {
+        let name = name.into();
+        let mut session = spawn_python_server_with_files().await?;
+        f(&mut session).await?;
+        let steps = session.steps.clone();
+        session.cancel().await?;
+        self.sessions.push((name, steps));
+        Ok(())
+    }
+
     pub async fn pager_session<F>(
         &mut self,
         name: impl Into<String>,

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -4613,6 +4613,42 @@ async fn python_input_can_consume_buffered_lines() -> TestResult<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn python_buffered_input_prompt_matching_primary_prompt_stays_visible() -> TestResult<()> {
+    let _guard = lock_test_mutex();
+    let Some(session) = start_python_session().await? else {
+        return Ok(());
+    };
+
+    let result = session
+        .write_stdin_raw_with(
+            r#"import sys
+sys.ps1 = "same> "
+value = input("same> ")
+buffered
+print("MATCHED_PROMPT_VALUE", value)
+"#,
+            Some(5.0),
+        )
+        .await?;
+    let text = result_text(&result);
+    session.cancel().await?;
+
+    assert!(
+        !is_busy_response(&text),
+        "expected buffered input request to complete, got: {text:?}"
+    );
+    assert!(
+        text.matches("same> ").count() >= 2,
+        "expected input() prompt matching sys.ps1 and final prompt to stay visible, got: {text:?}"
+    );
+    assert!(
+        text.contains("MATCHED_PROMPT_VALUE buffered"),
+        "expected input() to consume buffered line, got: {text:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn python_input_releases_gil_while_waiting_for_line() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let Some(session) = start_python_session().await? else {

--- a/tests/python_snapshots.rs
+++ b/tests/python_snapshots.rs
@@ -1,0 +1,52 @@
+mod common;
+
+#[cfg(not(windows))]
+use common::{McpSnapshot, TestResult};
+
+#[cfg(not(windows))]
+fn assert_snapshot_or_skip(name: &str, snapshot: &McpSnapshot) -> TestResult<()> {
+    let rendered = snapshot.render();
+    let transcript = snapshot.render_transcript();
+    if common::backend_unavailable(&rendered) || common::backend_unavailable(&transcript) {
+        eprintln!("python snapshot backend unavailable in this environment; skipping");
+        return Ok(());
+    }
+
+    insta::assert_snapshot!(name, rendered);
+    insta::with_settings!({ snapshot_suffix => "transcript" }, {
+        insta::assert_snapshot!(name, transcript);
+    });
+    Ok(())
+}
+
+#[cfg(not(windows))]
+#[tokio::test(flavor = "multi_thread")]
+async fn snapshots_buffered_input_prompt_matching_primary_prompt() -> TestResult<()> {
+    if !common::python_available() {
+        eprintln!("python not available; skipping");
+        return Ok(());
+    }
+
+    let mut snapshot = McpSnapshot::new();
+    snapshot
+        .python_files_session(
+            "input_prompt_matching_ps1",
+            mcp_script! {
+                write_stdin(
+                    r#"import sys
+sys.ps1 = "same> "
+value = input("same> ")
+buffered
+print("MATCHED_PROMPT_VALUE", value)
+"#,
+                    timeout = 5.0
+                );
+            },
+        )
+        .await?;
+
+    assert_snapshot_or_skip(
+        "snapshots_buffered_input_prompt_matching_primary_prompt",
+        &snapshot,
+    )
+}

--- a/tests/snapshots/python_snapshots__snapshots_buffered_input_prompt_matching_primary_prompt.snap
+++ b/tests/snapshots/python_snapshots__snapshots_buffered_input_prompt_matching_primary_prompt.snap
@@ -1,0 +1,29 @@
+---
+source: tests/python_snapshots.rs
+expression: rendered
+---
+== session: input_prompt_matching_ps1 ==
+-- step 1 --
+call:
+{
+  "tool": "py_repl",
+  "arguments": {
+    "input": "import sys\nsys.ps1 = \"same> \"\nvalue = input(\"same> \")\nbuffered\nprint(\"MATCHED_PROMPT_VALUE\", value)\n",
+    "timeout_ms": 5000
+  }
+}
+response:
+{
+  "type": "tool_result",
+  "is_error": false,
+  "content": [
+    {
+      "type": "text",
+      "text": "same> MATCHED_PROMPT_VALUE buffered"
+    },
+    {
+      "type": "text",
+      "text": "same> "
+    }
+  ]
+}

--- a/tests/snapshots/python_snapshots__snapshots_buffered_input_prompt_matching_primary_prompt@transcript.snap
+++ b/tests/snapshots/python_snapshots__snapshots_buffered_input_prompt_matching_primary_prompt@transcript.snap
@@ -1,0 +1,13 @@
+---
+source: tests/python_snapshots.rs
+expression: transcript
+---
+== session: input_prompt_matching_ps1 ==
+1) py_repl timeout_ms=5000
+>>> import sys
+>>> sys.ps1 = "same> "
+>>> value = input("same> ")
+>>> buffered
+>>> print("MATCHED_PROMPT_VALUE", value)
+<<< same> MATCHED_PROMPT_VALUE buffered
+<<< same>


### PR DESCRIPTION
## Summary
- Keep Python `input()` prompts visible when the prompt text matches the active REPL prompt state, so client input is not silently suppressed just because it looks like `sys.ps1`.
- This fixes a real ambiguity in buffered input handling: the server should hide only actual REPL prompts, not user-facing prompts that happen to reuse the same text.

## Changes
- Updated Python readline prompt suppression to consult the tracked readline state before deciding whether to echo a prompt.
- Suppression now applies only to true primary or continuation REPL prompts, rather than to any prompt text equal to `sys.ps1` or `sys.ps2`.
- Added a regression test covering buffered input with a prompt string that matches `sys.ps1`.
- Added a snapshot-based coverage case to lock in the visible transcript and rendered output.

## Notes
- No broader prompt parsing behavior changed outside this suppression path.
- The new test coverage exercises the Python files-backed session path to match the affected runtime behavior.