### PR TITLE
Document Python REPL continuation recovery

### DIFF
--- a/docs/tool-descriptions/repl_tool_python.md
+++ b/docs/tool-descriptions/repl_tool_python.md
@@ -7,6 +7,9 @@ Arguments:
 
 Python REPL affordances:
 - Session state persists across calls; treat persistence as an iteration aid, not a correctness guarantee.
+- Input is sent to CPython interactive mode line by line, not script or notebook-cell mode; script-like blocks may execute earlier than they would in a file or cell.
+- When a compound block may continue, end the submitted input with two newline characters (`\n\n`) or put `\n\n` before unrelated top-level code.
+- If Python is waiting at the continuation prompt, send a blank line (`\n`) to run a complete block, or send `\u0003` to abandon pending input without resetting the session.
 - While work is still running, concurrent non-empty input is discarded; use empty `input` to poll.
 - Empty `input` polls for more output from a timed-out request or for detached background output while idle.
 - If a request times out, keep polling with empty `input` until the remaining worker output is drained. New non-empty input is discarded while that timed-out request is still active.

--- a/docs/tool-descriptions/repl_tool_python_pager.md
+++ b/docs/tool-descriptions/repl_tool_python_pager.md
@@ -7,6 +7,9 @@ Arguments:
 
 Python REPL affordances:
 - Session state persists across calls; treat persistence as an iteration aid, not a correctness guarantee.
+- Input is sent to CPython interactive mode line by line, not script or notebook-cell mode; script-like blocks may execute earlier than they would in a file or cell.
+- When a compound block may continue, end the submitted input with two newline characters (`\n\n`) or put `\n\n` before unrelated top-level code.
+- If Python is waiting at the continuation prompt, send a blank line (`\n`) to run a complete block, or send `\u0003` to abandon pending input without resetting the session.
 - While work is still running, concurrent non-empty input is discarded; use empty `input` to poll.
 - Empty `input` polls for more output from a timed-out request or for detached background output while idle. While pager mode is active, empty input advances one page.
 - If a request times out, keep polling with empty `input` until the remaining worker output is drained. New non-empty input is discarded while that timed-out request is still active.


### PR DESCRIPTION
## Summary
Clarifies Python REPL continuation recovery after a client treated a continuation prompt as stuck and reached for `repl_reset`, even though a blank line would have run the complete pending block.

## User-facing changes
Adds Python tool-description guidance that input is fed line by line, ambiguous compound blocks may need `\n\n`, and `\n` or `\u0003` can recover from continuation input without resetting the session.

## Internal changes
Docs only; no runtime behavior changes.
