### PR TITLE
Extract write preflight and dispatch helpers

### DIFF
--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -60,9 +60,11 @@ use crate::worker_supervisor::{
 
 mod control_prefix;
 mod output_state;
+mod write_preflight;
 
 use self::control_prefix::ControlPrefixInput;
 use self::output_state::PrefixCapture;
+use self::write_preflight::{WritePreflightInput, WritePreflightOutcome};
 
 const WORKER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(target_os = "linux")]
@@ -1062,9 +1064,6 @@ impl WorkerManager {
         server_timeout: Duration,
         options: WriteStdinOptions,
     ) -> Result<WorkerReply, WorkerError> {
-        let pending_state_prechecked = options.pending_state_prechecked;
-        let deferred_sandbox_state_update = options.deferred_sandbox_state_update.clone();
-        let suppress_session_end_reset = options.suppress_session_end_reset;
         self.last_detached_prefix_item_count = 0;
         if let Some(reply) = self.write_stdin_control_prefix(
             WriteStdinMode::Files,
@@ -1076,85 +1075,16 @@ impl WorkerManager {
             return Ok(reply);
         }
 
-        if self.guardrail_busy_event_pending() {
-            // Don't execute new input; the previous request was aborted.
-            self.maybe_emit_guardrail_notice();
-            let event = self
-                .guardrail
-                .event
-                .lock()
-                .expect("guardrail event mutex poisoned")
-                .take()
-                .expect("guardrail event should be present");
-            self.guardrail.busy.store(false, Ordering::Relaxed);
-            let input_context = self.prepare_input_context_files();
-            let err = WorkerError::Guardrail(event.message);
-            let reply = self.build_reply_from_worker_error_files(&err, input_context);
-            let _ = self.reset_preserving_detached_prefix_item_count();
-            let reply = self.finalize_reply(reply);
-            self.maybe_reset_after_session_end_with_options(None, false, false)?;
-            return Ok(reply);
-        }
-
-        let empty_input = text.is_empty();
-        self.maybe_emit_guardrail_notice();
-        if !pending_state_prechecked {
-            self.resolve_timeout_marker();
-        }
-        if empty_input {
-            if self.pending_request
-                || self.pending_output_tape.has_pending()
-                || self.settled_pending_completion.is_some()
-            {
-                let reply = self.poll_pending_output_files(worker_timeout)?;
-                let reply = self.finalize_reply(reply);
-                self.maybe_reset_after_session_end_with_options(
-                    deferred_sandbox_state_update,
-                    suppress_session_end_reset,
-                    pending_state_prechecked,
-                )?;
-                return Ok(reply);
-            }
-            if pending_state_prechecked && self.control_only_interrupt_requires_spawn()? {
-                return Err(prechecked_follow_up_requires_meta_error());
-            }
-            if let Err(err) = self.ensure_process() {
-                let input_context = self.prepare_input_context_files();
-                let reply = self.build_reply_from_worker_error_files(&err, input_context);
-                let reply = self.finalize_reply(reply);
-                self.maybe_reset_after_session_end_with_options(None, false, false)?;
-                return Ok(reply);
-            }
-            let reply = self.build_idle_poll_reply_files();
-            let reply = self.finalize_reply(reply);
-            self.maybe_reset_after_session_end_with_options(None, false, false)?;
-            return Ok(reply);
-        }
-        if !pending_state_prechecked && self.pending_request {
-            self.resolve_timeout_marker_with_wait(Duration::from_millis(25));
-        }
-        if self.pending_request {
-            let mut reply = self.poll_pending_output_files(worker_timeout)?;
-            let detached_prefix_item_count = match &reply.reply {
-                WorkerReply::Output { contents, .. } => contents.len(),
-            };
-            self.last_detached_prefix_item_count = detached_prefix_item_count;
-            mark_busy_follow_up_reply(&mut reply.reply);
-            let reply = self.finalize_reply(reply);
-            self.maybe_reset_after_session_end_with_options(
-                deferred_sandbox_state_update,
-                suppress_session_end_reset,
-                pending_state_prechecked,
-            )?;
-            return Ok(reply);
-        }
-        self.apply_deferred_sandbox_state_update(deferred_sandbox_state_update)?;
-        if let Err(err) = self.ensure_process() {
-            let input_context = self.prepare_input_context_files();
-            let reply = self.build_reply_from_worker_error_files(&err, input_context);
-            let reply = self.finalize_reply(reply);
-            self.maybe_reset_after_session_end_with_options(None, false, false)?;
-            return Ok(reply);
+        match self.write_preflight(WritePreflightInput {
+            mode: WriteStdinMode::Files,
+            text: &text,
+            worker_timeout,
+            page_bytes: 0,
+            echo_input: false,
+            options: &options,
+        })? {
+            WritePreflightOutcome::Continue => {}
+            WritePreflightOutcome::Reply(reply) => return Ok(reply),
         }
 
         let input_context = self.prepare_input_context_files();
@@ -1183,9 +1113,6 @@ impl WorkerManager {
     ) -> Result<WorkerReply, WorkerError> {
         let page_bytes_override = options.page_bytes_override;
         let echo_input = options.echo_input;
-        let pending_state_prechecked = options.pending_state_prechecked;
-        let deferred_sandbox_state_update = options.deferred_sandbox_state_update.clone();
-        let suppress_session_end_reset = options.suppress_session_end_reset;
         self.last_detached_prefix_item_count = 0;
         if let Some(reply) = self.write_stdin_control_prefix(
             WriteStdinMode::Pager,
@@ -1197,113 +1124,18 @@ impl WorkerManager {
             return Ok(reply);
         }
 
-        if self.guardrail_busy_event_pending() {
-            self.maybe_emit_guardrail_notice();
-            let event = self
-                .guardrail
-                .event
-                .lock()
-                .expect("guardrail event mutex poisoned")
-                .take()
-                .expect("guardrail event should be present");
-            self.guardrail.busy.store(false, Ordering::Relaxed);
-            let page_bytes = pager::resolve_page_bytes(page_bytes_override);
-            let input_context = self.prepare_input_context_pager(&text, echo_input);
-            let err = WorkerError::Guardrail(event.message);
-            let reply = self.build_reply_from_worker_error_pager(&err, input_context, page_bytes);
-            let preserve_pager = self.pager.is_active();
-            let _ = self.reset_with_pager_preserving_detached_prefix_item_count(preserve_pager);
-            let reply = self.finalize_reply(reply);
-            self.maybe_reset_after_session_end_with_options(None, false, false)?;
-            return Ok(reply);
-        }
-
         let page_bytes = pager::resolve_page_bytes(page_bytes_override);
-        let empty_input = text.is_empty();
-        if !empty_input && self.pager.is_active() {
-            let trimmed = text.trim();
-            if trimmed.is_empty() || trimmed.starts_with(':') {
-                if let Some(reply) = self.handle_pager_command(&text) {
-                    let reply = self.finalize_reply(reply);
-                    self.maybe_reset_after_session_end_with_options(None, true, false)?;
-                    return Ok(reply);
-                }
-            } else {
-                self.pager.dismiss();
-                self.pager_prompt = None;
-            }
+        match self.write_preflight(WritePreflightInput {
+            mode: WriteStdinMode::Pager,
+            text: &text,
+            worker_timeout,
+            page_bytes,
+            echo_input,
+            options: &options,
+        })? {
+            WritePreflightOutcome::Continue => {}
+            WritePreflightOutcome::Reply(reply) => return Ok(reply),
         }
-
-        if empty_input {
-            self.output.start_capture();
-            self.maybe_emit_guardrail_notice();
-            if !pending_state_prechecked {
-                self.resolve_timeout_marker();
-            }
-            if self.pending_request
-                || self.output.has_pending_output()
-                || self.settled_pending_completion.is_some()
-            {
-                let reply = self.poll_pending_output_pager(worker_timeout, page_bytes)?;
-                let reply = self.finalize_reply(reply);
-                self.maybe_reset_after_session_end_with_options(
-                    deferred_sandbox_state_update,
-                    suppress_session_end_reset,
-                    pending_state_prechecked,
-                )?;
-                return Ok(reply);
-            }
-            if self.pager.is_active()
-                && let Some(reply) = self.handle_pager_command(&text)
-            {
-                let reply = self.finalize_reply(reply);
-                self.maybe_reset_after_session_end_with_options(None, true, false)?;
-                return Ok(reply);
-            }
-            if pending_state_prechecked && self.control_only_interrupt_requires_spawn()? {
-                return Err(prechecked_follow_up_requires_meta_error());
-            }
-        }
-
-        if let Err(err) = self.ensure_process() {
-            let input_context = self.prepare_input_context_pager(&text, echo_input);
-            let reply = self.build_reply_from_worker_error_pager(&err, input_context, page_bytes);
-            let reply = self.finalize_reply(reply);
-            self.maybe_reset_after_session_end_with_options(None, false, false)?;
-            return Ok(reply);
-        }
-        if !empty_input {
-            self.output.start_capture();
-            self.maybe_emit_guardrail_notice();
-            if !pending_state_prechecked {
-                self.resolve_timeout_marker();
-            }
-        }
-        if empty_input {
-            let reply = self.build_idle_poll_reply_pager();
-            let reply = self.finalize_reply(reply);
-            self.maybe_reset_after_session_end_with_options(None, false, false)?;
-            return Ok(reply);
-        }
-        if !pending_state_prechecked && self.pending_request {
-            self.resolve_timeout_marker_with_wait(Duration::from_millis(25));
-        }
-        if self.pending_request {
-            let mut reply = self.poll_pending_output_pager(worker_timeout, page_bytes)?;
-            let detached_prefix_item_count = match &reply.reply {
-                WorkerReply::Output { contents, .. } => contents.len(),
-            };
-            self.last_detached_prefix_item_count = detached_prefix_item_count;
-            mark_busy_follow_up_reply(&mut reply.reply);
-            let reply = self.finalize_reply(reply);
-            self.maybe_reset_after_session_end_with_options(
-                deferred_sandbox_state_update,
-                suppress_session_end_reset,
-                pending_state_prechecked,
-            )?;
-            return Ok(reply);
-        }
-        self.apply_deferred_sandbox_state_update(deferred_sandbox_state_update)?;
 
         let input_context = self.prepare_input_context_pager(&text, echo_input);
 

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -60,10 +60,12 @@ use crate::worker_supervisor::{
 
 mod control_prefix;
 mod output_state;
+mod write_dispatch;
 mod write_preflight;
 
 use self::control_prefix::ControlPrefixInput;
 use self::output_state::PrefixCapture;
+use self::write_dispatch::WriteDispatchInput;
 use self::write_preflight::{WritePreflightInput, WritePreflightOutcome};
 
 const WORKER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
@@ -1087,21 +1089,16 @@ impl WorkerManager {
             WritePreflightOutcome::Reply(reply) => return Ok(reply),
         }
 
-        let input_context = self.prepare_input_context_files();
-
-        let request = match self.send_worker_request(text, worker_timeout, server_timeout) {
-            Ok(result) => result,
-            Err(err) => {
-                self.guardrail.busy.store(false, Ordering::Relaxed);
-                let reply = self.build_reply_from_worker_error_files(&err, input_context);
-                let _ = self.reset_preserving_detached_prefix_item_count();
-                return Ok(self.finalize_reply(reply));
-            }
-        };
-        let reply = self.build_reply_from_request_files(request, input_context)?;
-        let reply = self.finalize_reply(reply);
-        self.maybe_reset_after_session_end_with_options(None, false, false)?;
-        Ok(reply)
+        self.dispatch_write_request(WriteDispatchInput {
+            mode: WriteStdinMode::Files,
+            text,
+            worker_timeout,
+            server_timeout,
+            deferred_sandbox_state_update: options.deferred_sandbox_state_update,
+            page_bytes: 0,
+            echo_input: false,
+            process_prechecked: false,
+        })
     }
 
     fn write_stdin_pager(
@@ -1137,23 +1134,16 @@ impl WorkerManager {
             WritePreflightOutcome::Reply(reply) => return Ok(reply),
         }
 
-        let input_context = self.prepare_input_context_pager(&text, echo_input);
-
-        let request = match self.send_worker_request(text, worker_timeout, server_timeout) {
-            Ok(result) => result,
-            Err(err) => {
-                self.guardrail.busy.store(false, Ordering::Relaxed);
-                let reply =
-                    self.build_reply_from_worker_error_pager(&err, input_context, page_bytes);
-                let preserve_pager = self.pager.is_active();
-                let _ = self.reset_with_pager_preserving_detached_prefix_item_count(preserve_pager);
-                return Ok(self.finalize_reply(reply));
-            }
-        };
-        let reply = self.build_reply_from_request_pager(request, input_context, page_bytes)?;
-        let reply = self.finalize_reply(reply);
-        self.maybe_reset_after_session_end_with_options(None, false, false)?;
-        Ok(reply)
+        self.dispatch_write_request(WriteDispatchInput {
+            mode: WriteStdinMode::Pager,
+            text,
+            worker_timeout,
+            server_timeout,
+            deferred_sandbox_state_update: options.deferred_sandbox_state_update,
+            page_bytes,
+            echo_input,
+            process_prechecked: true,
+        })
     }
 
     fn handle_pager_command(&mut self, text: &str) -> Option<ReplyWithOffset> {

--- a/src/worker_process/write_dispatch.rs
+++ b/src/worker_process/write_dispatch.rs
@@ -1,0 +1,136 @@
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use crate::completion_reply::{InputContext, ReplyWithOffset};
+use crate::sandbox::SandboxStateUpdate;
+use crate::worker_protocol::WorkerReply;
+
+use super::{WorkerError, WorkerManager, WriteStdinMode};
+
+pub(super) struct WriteDispatchInput {
+    pub(super) mode: WriteStdinMode,
+    pub(super) text: String,
+    pub(super) worker_timeout: Duration,
+    pub(super) server_timeout: Duration,
+    pub(super) deferred_sandbox_state_update: Option<SandboxStateUpdate>,
+    pub(super) page_bytes: u64,
+    pub(super) echo_input: bool,
+    pub(super) process_prechecked: bool,
+}
+
+impl WorkerManager {
+    pub(super) fn dispatch_write_request(
+        &mut self,
+        input: WriteDispatchInput,
+    ) -> Result<WorkerReply, WorkerError> {
+        self.apply_deferred_sandbox_state_update(input.deferred_sandbox_state_update.clone())?;
+        if !input.process_prechecked
+            && let Err(err) = self.ensure_process()
+        {
+            let reply = self.build_write_dispatch_worker_error_reply(&err, &input);
+            return self.finish_write_dispatch_reply(reply);
+        }
+
+        let mode = input.mode;
+        let page_bytes = input.page_bytes;
+        let input_context = self.prepare_write_dispatch_input_context(&input);
+        let request = match self.send_worker_request(
+            input.text,
+            input.worker_timeout,
+            input.server_timeout,
+        ) {
+            Ok(request) => request,
+            Err(err) => {
+                self.guardrail.busy.store(false, Ordering::Relaxed);
+                let reply = self.build_write_dispatch_worker_error_reply_from_context(
+                    &err,
+                    input_context,
+                    mode,
+                    page_bytes,
+                );
+                self.reset_after_write_dispatch_send_error(mode);
+                return Ok(self.finalize_reply(reply));
+            }
+        };
+
+        let reply =
+            self.build_write_dispatch_request_reply(request, input_context, mode, page_bytes)?;
+        let reply = self.finalize_reply(reply);
+        self.maybe_reset_after_session_end_with_options(None, false, false)?;
+        Ok(reply)
+    }
+
+    fn prepare_write_dispatch_input_context(&mut self, input: &WriteDispatchInput) -> InputContext {
+        match input.mode {
+            WriteStdinMode::Files => self.prepare_input_context_files(),
+            WriteStdinMode::Pager => {
+                self.prepare_input_context_pager(&input.text, input.echo_input)
+            }
+        }
+    }
+
+    fn build_write_dispatch_worker_error_reply(
+        &mut self,
+        err: &WorkerError,
+        input: &WriteDispatchInput,
+    ) -> ReplyWithOffset {
+        let input_context = self.prepare_write_dispatch_input_context(input);
+        self.build_write_dispatch_worker_error_reply_from_context(
+            err,
+            input_context,
+            input.mode,
+            input.page_bytes,
+        )
+    }
+
+    fn build_write_dispatch_worker_error_reply_from_context(
+        &mut self,
+        err: &WorkerError,
+        input_context: InputContext,
+        mode: WriteStdinMode,
+        page_bytes: u64,
+    ) -> ReplyWithOffset {
+        match mode {
+            WriteStdinMode::Files => self.build_reply_from_worker_error_files(err, input_context),
+            WriteStdinMode::Pager => {
+                self.build_reply_from_worker_error_pager(err, input_context, page_bytes)
+            }
+        }
+    }
+
+    fn reset_after_write_dispatch_send_error(&mut self, mode: WriteStdinMode) {
+        match mode {
+            WriteStdinMode::Files => {
+                let _ = self.reset_preserving_detached_prefix_item_count();
+            }
+            WriteStdinMode::Pager => {
+                let preserve_pager = self.pager.is_active();
+                let _ = self.reset_with_pager_preserving_detached_prefix_item_count(preserve_pager);
+            }
+        }
+    }
+
+    fn build_write_dispatch_request_reply(
+        &mut self,
+        request: super::RequestState,
+        input_context: InputContext,
+        mode: WriteStdinMode,
+        page_bytes: u64,
+    ) -> Result<ReplyWithOffset, WorkerError> {
+        match mode {
+            WriteStdinMode::Files => self.build_reply_from_request_files(request, input_context),
+            WriteStdinMode::Pager => {
+                self.build_reply_from_request_pager(request, input_context, page_bytes)
+            }
+        }
+    }
+
+    fn finish_write_dispatch_reply(
+        &mut self,
+        reply: ReplyWithOffset,
+    ) -> Result<WorkerReply, WorkerError> {
+        let reply = self.finalize_reply(reply);
+        self.maybe_reset_after_session_end_with_options(None, false, false)?;
+        Ok(reply)
+    }
+}

--- a/src/worker_process/write_preflight.rs
+++ b/src/worker_process/write_preflight.rs
@@ -65,13 +65,6 @@ impl WorkerManager {
             return Ok(outcome);
         }
 
-        self.apply_deferred_sandbox_state_update(
-            input.options.deferred_sandbox_state_update.clone(),
-        )?;
-        if let Some(outcome) = self.ensure_process_or_error_reply(&input)? {
-            return Ok(outcome);
-        }
-
         Ok(WritePreflightOutcome::Continue)
     }
 
@@ -106,9 +99,6 @@ impl WorkerManager {
             return Ok(outcome);
         }
 
-        self.apply_deferred_sandbox_state_update(
-            input.options.deferred_sandbox_state_update.clone(),
-        )?;
         Ok(WritePreflightOutcome::Continue)
     }
 

--- a/src/worker_process/write_preflight.rs
+++ b/src/worker_process/write_preflight.rs
@@ -1,0 +1,334 @@
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use crate::completion_reply::ReplyWithOffset;
+use crate::worker_protocol::WorkerReply;
+
+use super::{
+    WorkerError, WorkerManager, WriteStdinMode, WriteStdinOptions, mark_busy_follow_up_reply,
+    prechecked_follow_up_requires_meta_error,
+};
+
+pub(super) struct WritePreflightInput<'a> {
+    pub(super) mode: WriteStdinMode,
+    pub(super) text: &'a str,
+    pub(super) worker_timeout: Duration,
+    pub(super) page_bytes: u64,
+    pub(super) echo_input: bool,
+    pub(super) options: &'a WriteStdinOptions,
+}
+
+pub(super) enum WritePreflightOutcome {
+    Continue,
+    Reply(WorkerReply),
+}
+
+impl WorkerManager {
+    pub(super) fn write_preflight(
+        &mut self,
+        input: WritePreflightInput<'_>,
+    ) -> Result<WritePreflightOutcome, WorkerError> {
+        if let Some(outcome) = self.guardrail_busy_abort(&input)? {
+            return Ok(outcome);
+        }
+
+        if let Some(outcome) = self.handle_nonempty_pager_command(&input)? {
+            return Ok(outcome);
+        }
+
+        match input.mode {
+            WriteStdinMode::Files => self.write_preflight_files(input),
+            WriteStdinMode::Pager => self.write_preflight_pager(input),
+        }
+    }
+
+    fn write_preflight_files(
+        &mut self,
+        input: WritePreflightInput<'_>,
+    ) -> Result<WritePreflightOutcome, WorkerError> {
+        self.emit_guardrail_notice_and_resolve_timeout_marker(&input);
+
+        if input.text.is_empty() {
+            if let Some(outcome) = self.empty_input_pending_poll(&input)? {
+                return Ok(outcome);
+            }
+            self.reject_prechecked_empty_follow_up_without_current_state(&input)?;
+            if let Some(outcome) = self.ensure_process_or_error_reply(&input)? {
+                return Ok(outcome);
+            }
+            let reply = self.build_idle_reply_for_mode(input.mode);
+            return self.finish_default_preflight_reply(reply);
+        }
+
+        self.resolve_pending_request_before_busy_reply(&input);
+        if let Some(outcome) = self.pending_request_busy_follow_up(&input)? {
+            return Ok(outcome);
+        }
+
+        self.apply_deferred_sandbox_state_update(
+            input.options.deferred_sandbox_state_update.clone(),
+        )?;
+        if let Some(outcome) = self.ensure_process_or_error_reply(&input)? {
+            return Ok(outcome);
+        }
+
+        Ok(WritePreflightOutcome::Continue)
+    }
+
+    fn write_preflight_pager(
+        &mut self,
+        input: WritePreflightInput<'_>,
+    ) -> Result<WritePreflightOutcome, WorkerError> {
+        if input.text.is_empty() {
+            self.output.start_capture();
+            self.emit_guardrail_notice_and_resolve_timeout_marker(&input);
+            if let Some(outcome) = self.empty_input_pending_poll(&input)? {
+                return Ok(outcome);
+            }
+            if let Some(outcome) = self.empty_input_pager_command(&input)? {
+                return Ok(outcome);
+            }
+            self.reject_prechecked_empty_follow_up_without_current_state(&input)?;
+            if let Some(outcome) = self.ensure_process_or_error_reply(&input)? {
+                return Ok(outcome);
+            }
+            let reply = self.build_idle_reply_for_mode(input.mode);
+            return self.finish_default_preflight_reply(reply);
+        }
+
+        if let Some(outcome) = self.ensure_process_or_error_reply(&input)? {
+            return Ok(outcome);
+        }
+        self.output.start_capture();
+        self.emit_guardrail_notice_and_resolve_timeout_marker(&input);
+        self.resolve_pending_request_before_busy_reply(&input);
+        if let Some(outcome) = self.pending_request_busy_follow_up(&input)? {
+            return Ok(outcome);
+        }
+
+        self.apply_deferred_sandbox_state_update(
+            input.options.deferred_sandbox_state_update.clone(),
+        )?;
+        Ok(WritePreflightOutcome::Continue)
+    }
+
+    fn guardrail_busy_abort(
+        &mut self,
+        input: &WritePreflightInput<'_>,
+    ) -> Result<Option<WritePreflightOutcome>, WorkerError> {
+        if !self.guardrail_busy_event_pending() {
+            return Ok(None);
+        }
+
+        self.maybe_emit_guardrail_notice();
+        let event = self
+            .guardrail
+            .event
+            .lock()
+            .expect("guardrail event mutex poisoned")
+            .take()
+            .expect("guardrail event should be present");
+        self.guardrail.busy.store(false, Ordering::Relaxed);
+        let err = WorkerError::Guardrail(event.message);
+        let reply = self.build_worker_error_reply_for_mode(&err, input);
+        self.reset_after_worker_error(input.mode);
+        self.finish_default_preflight_reply(reply).map(Some)
+    }
+
+    fn handle_nonempty_pager_command(
+        &mut self,
+        input: &WritePreflightInput<'_>,
+    ) -> Result<Option<WritePreflightOutcome>, WorkerError> {
+        if !matches!(input.mode, WriteStdinMode::Pager)
+            || input.text.is_empty()
+            || !self.pager.is_active()
+        {
+            return Ok(None);
+        }
+
+        let trimmed = input.text.trim();
+        if trimmed.is_empty() || trimmed.starts_with(':') {
+            if let Some(reply) = self.handle_pager_command(input.text) {
+                return self.finish_pager_local_reply(reply).map(Some);
+            }
+        } else {
+            self.pager.dismiss();
+            self.pager_prompt = None;
+        }
+        Ok(None)
+    }
+
+    fn empty_input_pager_command(
+        &mut self,
+        input: &WritePreflightInput<'_>,
+    ) -> Result<Option<WritePreflightOutcome>, WorkerError> {
+        if matches!(input.mode, WriteStdinMode::Pager)
+            && self.pager.is_active()
+            && let Some(reply) = self.handle_pager_command(input.text)
+        {
+            return self.finish_pager_local_reply(reply).map(Some);
+        }
+        Ok(None)
+    }
+
+    fn emit_guardrail_notice_and_resolve_timeout_marker(
+        &mut self,
+        input: &WritePreflightInput<'_>,
+    ) {
+        self.maybe_emit_guardrail_notice();
+        if !input.options.pending_state_prechecked {
+            self.resolve_timeout_marker();
+        }
+    }
+
+    fn empty_input_pending_poll(
+        &mut self,
+        input: &WritePreflightInput<'_>,
+    ) -> Result<Option<WritePreflightOutcome>, WorkerError> {
+        if !self.empty_input_has_pending_output(input.mode) {
+            return Ok(None);
+        }
+
+        let reply = self.poll_pending_output_for_mode(input)?;
+        self.finish_caller_preflight_reply(reply, input).map(Some)
+    }
+
+    fn reject_prechecked_empty_follow_up_without_current_state(
+        &mut self,
+        input: &WritePreflightInput<'_>,
+    ) -> Result<(), WorkerError> {
+        if input.options.pending_state_prechecked && self.control_only_interrupt_requires_spawn()? {
+            return Err(prechecked_follow_up_requires_meta_error());
+        }
+        Ok(())
+    }
+
+    fn ensure_process_or_error_reply(
+        &mut self,
+        input: &WritePreflightInput<'_>,
+    ) -> Result<Option<WritePreflightOutcome>, WorkerError> {
+        if let Err(err) = self.ensure_process() {
+            let reply = self.build_worker_error_reply_for_mode(&err, input);
+            return self.finish_default_preflight_reply(reply).map(Some);
+        }
+        Ok(None)
+    }
+
+    fn resolve_pending_request_before_busy_reply(&mut self, input: &WritePreflightInput<'_>) {
+        if !input.options.pending_state_prechecked && self.pending_request {
+            self.resolve_timeout_marker_with_wait(Duration::from_millis(25));
+        }
+    }
+
+    fn pending_request_busy_follow_up(
+        &mut self,
+        input: &WritePreflightInput<'_>,
+    ) -> Result<Option<WritePreflightOutcome>, WorkerError> {
+        if !self.pending_request {
+            return Ok(None);
+        }
+
+        let mut reply = self.poll_pending_output_for_mode(input)?;
+        let detached_prefix_item_count = match &reply.reply {
+            WorkerReply::Output { contents, .. } => contents.len(),
+        };
+        self.last_detached_prefix_item_count = detached_prefix_item_count;
+        mark_busy_follow_up_reply(&mut reply.reply);
+        self.finish_caller_preflight_reply(reply, input).map(Some)
+    }
+
+    fn empty_input_has_pending_output(&self, mode: WriteStdinMode) -> bool {
+        match mode {
+            WriteStdinMode::Files => {
+                self.pending_request
+                    || self.pending_output_tape.has_pending()
+                    || self.settled_pending_completion.is_some()
+            }
+            WriteStdinMode::Pager => {
+                self.pending_request
+                    || self.output.has_pending_output()
+                    || self.settled_pending_completion.is_some()
+            }
+        }
+    }
+
+    fn poll_pending_output_for_mode(
+        &mut self,
+        input: &WritePreflightInput<'_>,
+    ) -> Result<ReplyWithOffset, WorkerError> {
+        match input.mode {
+            WriteStdinMode::Files => self.poll_pending_output_files(input.worker_timeout),
+            WriteStdinMode::Pager => {
+                self.poll_pending_output_pager(input.worker_timeout, input.page_bytes)
+            }
+        }
+    }
+
+    fn build_worker_error_reply_for_mode(
+        &mut self,
+        err: &WorkerError,
+        input: &WritePreflightInput<'_>,
+    ) -> ReplyWithOffset {
+        match input.mode {
+            WriteStdinMode::Files => {
+                let input_context = self.prepare_input_context_files();
+                self.build_reply_from_worker_error_files(err, input_context)
+            }
+            WriteStdinMode::Pager => {
+                let input_context = self.prepare_input_context_pager(input.text, input.echo_input);
+                self.build_reply_from_worker_error_pager(err, input_context, input.page_bytes)
+            }
+        }
+    }
+
+    fn reset_after_worker_error(&mut self, mode: WriteStdinMode) {
+        match mode {
+            WriteStdinMode::Files => {
+                let _ = self.reset_preserving_detached_prefix_item_count();
+            }
+            WriteStdinMode::Pager => {
+                let preserve_pager = self.pager.is_active();
+                let _ = self.reset_with_pager_preserving_detached_prefix_item_count(preserve_pager);
+            }
+        }
+    }
+
+    fn build_idle_reply_for_mode(&mut self, mode: WriteStdinMode) -> ReplyWithOffset {
+        match mode {
+            WriteStdinMode::Files => self.build_idle_poll_reply_files(),
+            WriteStdinMode::Pager => self.build_idle_poll_reply_pager(),
+        }
+    }
+
+    fn finish_default_preflight_reply(
+        &mut self,
+        reply: ReplyWithOffset,
+    ) -> Result<WritePreflightOutcome, WorkerError> {
+        let reply = self.finalize_reply(reply);
+        self.maybe_reset_after_session_end_with_options(None, false, false)?;
+        Ok(WritePreflightOutcome::Reply(reply))
+    }
+
+    fn finish_caller_preflight_reply(
+        &mut self,
+        reply: ReplyWithOffset,
+        input: &WritePreflightInput<'_>,
+    ) -> Result<WritePreflightOutcome, WorkerError> {
+        let reply = self.finalize_reply(reply);
+        self.maybe_reset_after_session_end_with_options(
+            input.options.deferred_sandbox_state_update.clone(),
+            input.options.suppress_session_end_reset,
+            input.options.pending_state_prechecked,
+        )?;
+        Ok(WritePreflightOutcome::Reply(reply))
+    }
+
+    fn finish_pager_local_reply(
+        &mut self,
+        reply: ReplyWithOffset,
+    ) -> Result<WritePreflightOutcome, WorkerError> {
+        let reply = self.finalize_reply(reply);
+        self.maybe_reset_after_session_end_with_options(None, true, false)?;
+        Ok(WritePreflightOutcome::Reply(reply))
+    }
+}


### PR DESCRIPTION
## Summary
- Split the `write_stdin` flow into dedicated preflight and dispatch helpers to centralize the shared control flow between files and pager modes.
- Keeps the user-facing behavior the same while making the busy, idle, pending-poll, guardrail, and process-start paths easier to follow and maintain.
- Preserves mode-specific handling internally, including pager commands, prompt dismissal, sandbox updates, and worker-error reply construction.

## Notes
- The refactor reduces duplication in `worker_process.rs` without changing the public MCP surface.
- Shared decision-making now lives in `write_preflight.rs` and request execution in `write_dispatch.rs`.