### PR TITLE
Extract worker restart handling into a dedicated module

### DIFF
--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -61,6 +61,7 @@ mod control_prefix;
 mod interrupt;
 mod output_state;
 mod pending_poll;
+mod restart;
 mod write_dispatch;
 mod write_preflight;
 
@@ -1832,94 +1833,6 @@ impl WorkerManager {
                 suppress_session_end_reset,
             ),
         }
-    }
-
-    pub fn restart(&mut self, timeout: Duration) -> Result<WorkerReply, WorkerError> {
-        match self.oversized_output {
-            OversizedOutputMode::Files => self.restart_files(timeout),
-            OversizedOutputMode::Pager => self.restart_pager(timeout),
-        }
-    }
-
-    fn restart_files(&mut self, timeout: Duration) -> Result<WorkerReply, WorkerError> {
-        crate::event_log::log(
-            "worker_restart_begin",
-            serde_json::json!({
-                "timeout_ms": timeout.as_millis(),
-            }),
-        );
-        if self.missing_inherited_sandbox_state() {
-            return Err(WorkerError::Sandbox(
-                MISSING_INHERITED_SANDBOX_STATE_MESSAGE.to_string(),
-            ));
-        }
-        self.maybe_emit_pending_server_notice();
-        let pre_shutdown_output = self
-            .process
-            .is_some()
-            .then(|| self.drain_sealed_formatted_output());
-        if let Some(process) = self.process.take() {
-            let _ = process.shutdown_graceful(timeout);
-            self.pending_output_tape.clear();
-        }
-        self.guardrail.busy.store(false, Ordering::Relaxed);
-
-        let reply = match pre_shutdown_output {
-            Some(output) => {
-                self.build_session_reset_reply_files_from_formatted("new session started", output)
-            }
-            None => self.build_session_reset_reply_files("new session started"),
-        };
-        self.clear_preserved_prefixes();
-        self.reset_output_state_files(true);
-        self.note_respawn_during_write();
-        crate::event_log::log("worker_restart_end", serde_json::json!({"status": "ok"}));
-        Ok(self.finalize_reply(reply))
-    }
-
-    fn restart_pager(&mut self, timeout: Duration) -> Result<WorkerReply, WorkerError> {
-        crate::event_log::log(
-            "worker_restart_begin",
-            serde_json::json!({
-                "timeout_ms": timeout.as_millis(),
-            }),
-        );
-        if self.missing_inherited_sandbox_state() {
-            return Err(WorkerError::Sandbox(
-                MISSING_INHERITED_SANDBOX_STATE_MESSAGE.to_string(),
-            ));
-        }
-        self.maybe_emit_pending_server_notice();
-        let pre_shutdown_end_offset = self
-            .process
-            .is_some()
-            .then(|| self.output.end_offset().unwrap_or(0));
-        if let Some(process) = self.process.take() {
-            let _ = process.shutdown_graceful(timeout);
-        }
-        let post_shutdown_end_offset = self.output.end_offset();
-        self.guardrail.busy.store(false, Ordering::Relaxed);
-
-        let page_bytes = pager::resolve_page_bytes(None);
-        let reply = match pre_shutdown_end_offset {
-            Some(end_offset) => {
-                let reply = self.build_session_reset_reply_pager_to_offset(
-                    page_bytes,
-                    "new session started",
-                    end_offset,
-                );
-                if let Some(end_offset) = post_shutdown_end_offset {
-                    self.output.advance_offset_to(end_offset);
-                }
-                reply
-            }
-            None => self.build_session_reset_reply_pager(page_bytes, "new session started"),
-        };
-        self.clear_preserved_prefixes();
-        self.reset_output_state_pager(true, false);
-        self.note_respawn_during_write();
-        crate::event_log::log("worker_restart_end", serde_json::json!({"status": "ok"}));
-        Ok(self.finalize_reply(reply))
     }
 
     pub fn shutdown(&mut self) {

--- a/src/worker_process/restart.rs
+++ b/src/worker_process/restart.rs
@@ -1,0 +1,177 @@
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use super::{WorkerError, WorkerManager};
+use crate::completion_reply::ReplyWithOffset;
+use crate::oversized_output::OversizedOutputMode;
+use crate::pager;
+use crate::pending_output_tape::FormattedPendingOutput;
+use crate::sandbox_cli::MISSING_INHERITED_SANDBOX_STATE_MESSAGE;
+use crate::worker_protocol::WorkerReply;
+
+#[derive(Clone, Copy)]
+enum RestartMode {
+    Files,
+    Pager,
+}
+
+enum RestartShutdownSnapshot {
+    Files {
+        output: Option<FormattedPendingOutput>,
+    },
+    Pager {
+        pre_shutdown_end_offset: Option<u64>,
+        post_shutdown_end_offset: Option<u64>,
+    },
+}
+
+impl WorkerManager {
+    pub fn restart(&mut self, timeout: Duration) -> Result<WorkerReply, WorkerError> {
+        match self.oversized_output {
+            OversizedOutputMode::Files => self.restart_files(timeout),
+            OversizedOutputMode::Pager => self.restart_pager(timeout),
+        }
+    }
+
+    pub(super) fn restart_files(&mut self, timeout: Duration) -> Result<WorkerReply, WorkerError> {
+        self.restart_for_mode(RestartMode::Files, timeout)
+    }
+
+    pub(super) fn restart_pager(&mut self, timeout: Duration) -> Result<WorkerReply, WorkerError> {
+        self.restart_for_mode(RestartMode::Pager, timeout)
+    }
+
+    fn restart_for_mode(
+        &mut self,
+        mode: RestartMode,
+        timeout: Duration,
+    ) -> Result<WorkerReply, WorkerError> {
+        Self::begin_restart(timeout);
+        self.require_inherited_sandbox_for_restart()?;
+        self.maybe_emit_pending_server_notice();
+        let snapshot = self.shutdown_existing_worker_for_restart(mode, timeout);
+        self.clear_restart_busy_guardrail();
+        let reply = self.build_restart_reply_for_mode(snapshot);
+        self.finish_restart_for_mode(mode);
+        Self::end_restart_ok();
+        Ok(self.finalize_reply(reply))
+    }
+
+    fn begin_restart(timeout: Duration) {
+        crate::event_log::log(
+            "worker_restart_begin",
+            serde_json::json!({
+                "timeout_ms": timeout.as_millis(),
+            }),
+        );
+    }
+
+    fn end_restart_ok() {
+        crate::event_log::log("worker_restart_end", serde_json::json!({"status": "ok"}));
+    }
+
+    fn require_inherited_sandbox_for_restart(&self) -> Result<(), WorkerError> {
+        if self.missing_inherited_sandbox_state() {
+            return Err(WorkerError::Sandbox(
+                MISSING_INHERITED_SANDBOX_STATE_MESSAGE.to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn shutdown_existing_worker_for_restart(
+        &mut self,
+        mode: RestartMode,
+        timeout: Duration,
+    ) -> RestartShutdownSnapshot {
+        match mode {
+            RestartMode::Files => self.shutdown_existing_files_worker_for_restart(timeout),
+            RestartMode::Pager => self.shutdown_existing_pager_worker_for_restart(timeout),
+        }
+    }
+
+    fn shutdown_existing_files_worker_for_restart(
+        &mut self,
+        timeout: Duration,
+    ) -> RestartShutdownSnapshot {
+        let output = self
+            .process
+            .is_some()
+            .then(|| self.drain_sealed_formatted_output());
+        if let Some(process) = self.process.take() {
+            let _ = process.shutdown_graceful(timeout);
+            self.pending_output_tape.clear();
+        }
+        RestartShutdownSnapshot::Files { output }
+    }
+
+    fn shutdown_existing_pager_worker_for_restart(
+        &mut self,
+        timeout: Duration,
+    ) -> RestartShutdownSnapshot {
+        let pre_shutdown_end_offset = self
+            .process
+            .is_some()
+            .then(|| self.output.end_offset().unwrap_or(0));
+        if let Some(process) = self.process.take() {
+            let _ = process.shutdown_graceful(timeout);
+        }
+        let post_shutdown_end_offset = self.output.end_offset();
+        RestartShutdownSnapshot::Pager {
+            pre_shutdown_end_offset,
+            post_shutdown_end_offset,
+        }
+    }
+
+    fn clear_restart_busy_guardrail(&self) {
+        self.guardrail.busy.store(false, Ordering::Relaxed);
+    }
+
+    fn build_restart_reply_for_mode(
+        &mut self,
+        snapshot: RestartShutdownSnapshot,
+    ) -> ReplyWithOffset {
+        match snapshot {
+            RestartShutdownSnapshot::Files { output } => match output {
+                Some(output) => self
+                    .build_session_reset_reply_files_from_formatted("new session started", output),
+                None => self.build_session_reset_reply_files("new session started"),
+            },
+            RestartShutdownSnapshot::Pager {
+                pre_shutdown_end_offset,
+                post_shutdown_end_offset,
+            } => self.build_restart_reply_pager(pre_shutdown_end_offset, post_shutdown_end_offset),
+        }
+    }
+
+    fn build_restart_reply_pager(
+        &mut self,
+        pre_shutdown_end_offset: Option<u64>,
+        post_shutdown_end_offset: Option<u64>,
+    ) -> ReplyWithOffset {
+        let page_bytes = pager::resolve_page_bytes(None);
+        match pre_shutdown_end_offset {
+            Some(end_offset) => {
+                let reply = self.build_session_reset_reply_pager_to_offset(
+                    page_bytes,
+                    "new session started",
+                    end_offset,
+                );
+                if let Some(end_offset) = post_shutdown_end_offset {
+                    self.output.advance_offset_to(end_offset);
+                }
+                reply
+            }
+            None => self.build_session_reset_reply_pager(page_bytes, "new session started"),
+        }
+    }
+
+    fn finish_restart_for_mode(&mut self, mode: RestartMode) {
+        self.clear_preserved_prefixes();
+        match mode {
+            RestartMode::Files => self.reset_output_state_files(true),
+            RestartMode::Pager => self.reset_output_state_pager(true, false),
+        }
+        self.note_respawn_during_write();
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts worker restart logic from `worker_process.rs` into `worker_process/restart.rs` to keep the main manager file smaller and easier to navigate.
- Preserves the existing restart behavior for both oversized-output modes while making the restart flow easier to follow and maintain.
- User-facing behavior stays the same: restarts still shut down the worker, preserve the expected output state, and return the same session reset reply.
- Internally, the restart path is now split into smaller helpers for sandbox preconditions, shutdown snapshots, reply construction, and post-restart state reset.
- The event log markers and busy-guardrail handling remain in place, but the sequencing is now centralized around the new restart module.