### PR TITLE
Extract restart reply builders

### DIFF
--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -62,6 +62,7 @@ mod interrupt;
 mod output_state;
 mod pending_poll;
 mod restart;
+mod session_reset_reply;
 mod write_dispatch;
 mod write_preflight;
 
@@ -2481,98 +2482,6 @@ impl WorkerManager {
         InputFallback {
             transcript,
             raw_input,
-        }
-    }
-
-    fn build_session_reset_reply_files(&mut self, meta: &str) -> ReplyWithOffset {
-        let formatted = self.drain_sealed_formatted_output();
-        self.build_session_reset_reply_files_from_formatted(meta, formatted)
-    }
-
-    fn build_session_reset_reply_files_from_formatted(
-        &mut self,
-        meta: &str,
-        formatted: FormattedPendingOutput,
-    ) -> ReplyWithOffset {
-        let FormattedPendingOutput {
-            mut contents,
-            saw_stderr,
-        } = formatted;
-        contents.retain(|content| match content {
-            WorkerContent::ContentText { text, .. } => !text.trim().is_empty(),
-            _ => true,
-        });
-        let is_error = saw_stderr;
-        if !meta.is_empty() {
-            contents.push(WorkerContent::server_stderr(format!("[repl] {meta}")));
-        }
-
-        ReplyWithOffset {
-            reply: WorkerReply::Output {
-                contents,
-                is_error,
-                error_code: None,
-                prompt: None,
-                prompt_variants: None,
-            },
-            end_offset: 0,
-        }
-    }
-
-    fn build_session_reset_reply_pager(&mut self, page_bytes: u64, meta: &str) -> ReplyWithOffset {
-        let end_offset = self.output.end_offset().unwrap_or(0);
-        self.build_session_reset_reply_pager_to_offset(page_bytes, meta, end_offset)
-    }
-
-    fn build_session_reset_reply_pager_to_offset(
-        &mut self,
-        page_bytes: u64,
-        meta: &str,
-        end_offset: u64,
-    ) -> ReplyWithOffset {
-        let mut is_error = false;
-
-        let SnapshotWithImages {
-            mut contents,
-            pages_left,
-            buffer,
-            last_range,
-        } = snapshot_page_with_images(&self.output, end_offset, page_bytes);
-
-        contents.retain(|content| match content {
-            WorkerContent::ContentText { text, .. } => !text.trim().is_empty(),
-            _ => true,
-        });
-
-        if !contents.is_empty() {
-            let start_offset = self.output.current_offset().unwrap_or(end_offset);
-            is_error = self
-                .output
-                .saw_stderr_in_range(start_offset.min(end_offset), end_offset);
-        }
-
-        if !meta.is_empty() {
-            contents.push(WorkerContent::server_stderr(format!("[repl] {meta}")));
-        }
-
-        pager::maybe_activate_and_append_footer(
-            &mut self.pager,
-            &mut contents,
-            pages_left,
-            is_error,
-            buffer,
-            last_range,
-        );
-
-        ReplyWithOffset {
-            reply: WorkerReply::Output {
-                contents,
-                is_error,
-                error_code: None,
-                prompt: None,
-                prompt_variants: None,
-            },
-            end_offset,
         }
     }
 }

--- a/src/worker_process/session_reset_reply.rs
+++ b/src/worker_process/session_reset_reply.rs
@@ -1,0 +1,104 @@
+use super::WorkerManager;
+use crate::completion_reply::ReplyWithOffset;
+use crate::output_snapshot::{SnapshotWithImages, snapshot_page_with_images};
+use crate::pager;
+use crate::pending_output_tape::FormattedPendingOutput;
+use crate::worker_protocol::{WorkerContent, WorkerReply};
+
+impl WorkerManager {
+    pub(super) fn build_session_reset_reply_files(&mut self, meta: &str) -> ReplyWithOffset {
+        let formatted = self.drain_sealed_formatted_output();
+        self.build_session_reset_reply_files_from_formatted(meta, formatted)
+    }
+
+    pub(super) fn build_session_reset_reply_files_from_formatted(
+        &mut self,
+        meta: &str,
+        formatted: FormattedPendingOutput,
+    ) -> ReplyWithOffset {
+        let FormattedPendingOutput {
+            mut contents,
+            saw_stderr,
+        } = formatted;
+        contents.retain(|content| match content {
+            WorkerContent::ContentText { text, .. } => !text.trim().is_empty(),
+            _ => true,
+        });
+        let is_error = saw_stderr;
+        if !meta.is_empty() {
+            contents.push(WorkerContent::server_stderr(format!("[repl] {meta}")));
+        }
+
+        ReplyWithOffset {
+            reply: WorkerReply::Output {
+                contents,
+                is_error,
+                error_code: None,
+                prompt: None,
+                prompt_variants: None,
+            },
+            end_offset: 0,
+        }
+    }
+
+    pub(super) fn build_session_reset_reply_pager(
+        &mut self,
+        page_bytes: u64,
+        meta: &str,
+    ) -> ReplyWithOffset {
+        let end_offset = self.output.end_offset().unwrap_or(0);
+        self.build_session_reset_reply_pager_to_offset(page_bytes, meta, end_offset)
+    }
+
+    pub(super) fn build_session_reset_reply_pager_to_offset(
+        &mut self,
+        page_bytes: u64,
+        meta: &str,
+        end_offset: u64,
+    ) -> ReplyWithOffset {
+        let mut is_error = false;
+
+        let SnapshotWithImages {
+            mut contents,
+            pages_left,
+            buffer,
+            last_range,
+        } = snapshot_page_with_images(&self.output, end_offset, page_bytes);
+
+        contents.retain(|content| match content {
+            WorkerContent::ContentText { text, .. } => !text.trim().is_empty(),
+            _ => true,
+        });
+
+        if !contents.is_empty() {
+            let start_offset = self.output.current_offset().unwrap_or(end_offset);
+            is_error = self
+                .output
+                .saw_stderr_in_range(start_offset.min(end_offset), end_offset);
+        }
+
+        if !meta.is_empty() {
+            contents.push(WorkerContent::server_stderr(format!("[repl] {meta}")));
+        }
+
+        pager::maybe_activate_and_append_footer(
+            &mut self.pager,
+            &mut contents,
+            pages_left,
+            is_error,
+            buffer,
+            last_range,
+        );
+
+        ReplyWithOffset {
+            reply: WorkerReply::Output {
+                contents,
+                is_error,
+                error_code: None,
+                prompt: None,
+                prompt_variants: None,
+            },
+            end_offset,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Split restart handling into dedicated `restart` and `session_reset_reply` modules to keep worker restart flow focused and easier to follow.
- Preserve the existing restart behavior while separating shutdown, reply construction, and post-restart state reset into smaller internal steps.
- Keep the user-facing restart result unchanged: the worker still reports a new session start and continues to handle files and pager modes the same way.

## Internal changes
- Moved restart orchestration out of `worker_process.rs` into `src/worker_process/restart.rs`.
- Moved session reset reply construction helpers into `src/worker_process/session_reset_reply.rs`.
- Introduced small internal helpers for restart mode selection, shutdown snapshotting, and restart finalization.