### PR TITLE
Add workspace-write sandbox coverage to the public integration runner

### DIFF
--- a/docs/plans/active/public-api-runner.md
+++ b/docs/plans/active/public-api-runner.md
@@ -8,7 +8,7 @@
 ## Status
 
 - State: active
-- Last updated: 2026-05-18
+- Last updated: 2026-06-18
 - Current phase: implementation
 
 ## Current Direction
@@ -30,7 +30,7 @@
 - Phase 0: completed - add the runner shell and first R console smoke case.
 - Phase 1: completed - migrate another small real-client scenario with timeout or busy-worker behavior.
 - Phase 2: completed - run the external suite in CI after the debug binary is built.
-- Phase 3: pending - reintroduce sandbox scenarios in the Python runner and continue migrating duplicate real-binary Rust integration coverage case by case.
+- Phase 3: active - reintroduced `workspace-write` sandbox behavior in the Python runner; continue migrating duplicate real-binary Rust integration coverage case by case.
 
 ## Locked Decisions
 
@@ -46,8 +46,8 @@
 
 ## Next Safe Slice
 
-- Add a Python-runner sandbox case that starts the binary under `workspace-write`, proves an in-workspace write succeeds, and proves an out-of-policy write is blocked through the public `repl` tool.
-- In the same or next small slice, migrate another representative real-binary Rust integration scenario to the Python runner and remove or reduce only the matching Rust coverage.
+- Add a second public sandbox-policy contrast in the Python runner only if it replaces matching Rust public behavior cleanly, for example a focused read-only write denial or full-access outside-write case.
+- Otherwise, migrate another representative real-binary Rust integration scenario to the Python runner and remove or reduce only the matching Rust coverage.
 
 ## Stop Conditions
 
@@ -65,3 +65,4 @@
 - 2026-05-17: Removed obsolete serial scheduling after verifying the remaining Rust REPL binaries pass under normal Cargo test scheduling.
 - 2026-05-18: Reaffirmed that unmigrated Rust scenarios must remain discoverable by `cargo test`; migrations should replace Rust coverage with equivalent Python coverage in the same change, not disable tests ahead of time.
 - 2026-05-18: Clarified that the external runner itself is not sandboxed, but the spawned `mcp-repl` binary still owns the sandbox contract; the next slice should restore sandbox coverage in the Python runner starting with `workspace-write`.
+- 2026-06-18: Added an external `workspace-write` sandbox case that verifies public `repl` behavior for writes inside the server cwd and blocked writes outside it.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,7 +5,7 @@ This file is the entrypoint for deciding how to verify a change.
 
 ## Core Test Surface
 
-- `tests/run_integration_tests.py`: external real-binary checks over MCP stdio, including basic R `repl`, pager command handling, files-mode output bundles, timeout/busy recovery, interrupt/restart prefixes, and `repl_reset` state clearing.
+- `tests/run_integration_tests.py`: external real-binary checks over MCP stdio, including basic R `repl`, pager command handling, files-mode output bundles, timeout/busy recovery, interrupt/restart prefixes, `repl_reset` state clearing, and public sandbox policy behavior.
 - `tests/common/`: shared Rust MCP harness for public tool calls, transcript snapshots, sandbox assertions, and client-install fixtures.
 - `tests/repl_surface.rs`, `tests/server_smoke.rs`, `tests/mcp_transcripts.rs`, and `tests/write_stdin_*.rs`: core `repl`/`repl_reset` behavior, timeout polling, oversized text replies, transcript-file behavior, and snapshot coverage through the public tool API.
 - `tests/pager*.rs` and `tests/oversized_output_cli.rs`: pager mode, files mode, and oversized-output CLI behavior.
@@ -38,8 +38,9 @@ python3 tests/run_integration_tests.py --binary target/debug/mcp-repl
 ```
 
 The runner starts the real server over MCP stdio and calls public tools only. It
-uses `--sandbox danger-full-access` by default so the suite stays focused on
-client protocol behavior rather than sandbox policy.
+uses `--sandbox danger-full-access` by default so most cases stay focused on
+client protocol behavior rather than sandbox policy. Individual sandbox cases
+override that default in their case-specific server args.
 
 Use `--case <name>` to run one public API case while iterating.
 

--- a/src/worker_supervisor.rs
+++ b/src/worker_supervisor.rs
@@ -1483,7 +1483,6 @@ fn maybe_report_sandbox_exec_failure(
 }
 
 #[cfg(target_os = "linux")]
-#[cfg(target_os = "linux")]
 pub(crate) fn linux_sandbox_startup_retryable(err: &WorkerError) -> bool {
     match err {
         WorkerError::Protocol(message) => {

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -63,12 +63,14 @@ class McpStdioClient:
         binary: Path,
         server_args: Sequence[str],
         server_env: Sequence[tuple[str, str]],
+        server_cwd: Path | None,
         timeout_seconds: float,
     ) -> None:
         assert timeout_seconds > 0
         self.binary = binary
         self.server_args = list(server_args)
         self.server_env = dict(server_env)
+        self.server_cwd = server_cwd
         self.timeout_seconds = timeout_seconds
         self.next_request_id = 1
         self.stderr_lines: list[str] = []
@@ -88,6 +90,7 @@ class McpStdioClient:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=server_process_env(tuple(self.server_env.items())),
+            cwd=self.server_cwd,
         )
         assert self.process.stdout is not None
         assert self.process.stderr is not None
@@ -452,6 +455,20 @@ def r_large_text_input(label: str, lines: int = 80, width: int = 120) -> str:
     )
 
 
+def r_write_file_input(path: Path, value: str) -> str:
+    return dedent(
+        f"""
+        tryCatch(
+          {{
+            writeLines({r_string_literal(value)}, {r_string_literal(str(path))})
+            cat("WRITE_OK\\n")
+          }},
+          error = function(e) cat("WRITE_ERROR:", conditionMessage(e), "\\n", sep = "")
+        )
+        """
+    )
+
+
 def repeated_text_line(label: str, index: int, width: int = 120) -> str:
     return f"{label}{index:03d} {label * width}\n"
 
@@ -569,6 +586,52 @@ def r_reset_clears_state(client: McpStdioClient) -> None:
         after_reset,
         "after reset repl",
     )
+
+
+def r_workspace_write_sandbox(client: McpStdioClient) -> None:
+    stamp = f"{os.getpid()}-{time.time_ns()}"
+    workspace_cwd = client.server_cwd or Path.cwd()
+    workspace_target = workspace_cwd / f".mcp-repl-workspace-write-{stamp}.txt"
+    outside_target = (
+        workspace_cwd.resolve().parent
+        / f".mcp-repl-workspace-write-outside-{stamp}.txt"
+    )
+    for target in [workspace_target, outside_target]:
+        target.unlink(missing_ok=True)
+
+    try:
+        workspace_result = client.repl(
+            r_write_file_input(workspace_target, "allowed"),
+            timeout_ms=30000,
+        )
+        workspace_text = require_success(workspace_result, "workspace-write cwd repl")
+        if "WRITE_OK" not in workspace_text or "WRITE_ERROR:" in workspace_text:
+            raise SuiteFailure(
+                "expected workspace-write to allow writing in cwd, "
+                f"got: {workspace_text!r}"
+            )
+        if workspace_target.read_text(encoding="utf-8").strip() != "allowed":
+            raise SuiteFailure(
+                f"workspace-write cwd file did not contain expected text: {workspace_target}"
+            )
+
+        outside_result = client.repl(
+            r_write_file_input(outside_target, "blocked"),
+            timeout_ms=30000,
+        )
+        outside_text = require_success(outside_result, "workspace-write outside repl")
+        if "WRITE_ERROR:" not in outside_text or "WRITE_OK" in outside_text:
+            raise SuiteFailure(
+                "expected workspace-write to block writing outside cwd, "
+                f"got: {outside_text!r}"
+            )
+        if outside_target.exists():
+            raise SuiteFailure(
+                f"workspace-write unexpectedly created outside file: {outside_target}"
+            )
+    finally:
+        workspace_target.unlink(missing_ok=True)
+        outside_target.unlink(missing_ok=True)
 
 
 def r_interrupt_restart_prefixes(client: McpStdioClient) -> None:
@@ -810,6 +873,7 @@ class SuiteCase:
     run: Callable[[McpStdioClient], None]
     server_args: tuple[str, ...] = ()
     server_env: tuple[tuple[str, str], ...] = ()
+    server_cwd: Path | None = None
 
 
 def r_suite_case(
@@ -817,11 +881,13 @@ def r_suite_case(
     *,
     server_args: tuple[str, ...] = (),
     server_env: tuple[tuple[str, str], ...] = (),
+    server_cwd: Path | None = None,
 ) -> SuiteCase:
     return SuiteCase(
         run,
         server_args=("--interpreter", "r", *server_args),
         server_env=server_env,
+        server_cwd=server_cwd,
     )
 
 
@@ -853,6 +919,11 @@ CASES: dict[str, SuiteCase] = {
     ),
     "r-reset-clears-state": r_suite_case(r_reset_clears_state),
     "r-timeout-busy-recovers": r_suite_case(r_timeout_busy_recovers),
+    "r-workspace-write-sandbox": r_suite_case(
+        r_workspace_write_sandbox,
+        server_args=("--sandbox", "workspace-write"),
+        server_cwd=Path("target/test-scratch/run-integration-tests/r-workspace-write-sandbox"),
+    ),
 }
 
 
@@ -907,11 +978,18 @@ def main(argv: Sequence[str]) -> int:
     failures = 0
     for case_name in selected:
         case = CASES[case_name]
+        server_cwd = None
+        if case.server_cwd is not None:
+            server_cwd = case.server_cwd
+            if not server_cwd.is_absolute():
+                server_cwd = Path.cwd() / server_cwd
+            server_cwd.mkdir(parents=True, exist_ok=True)
         try:
             with McpStdioClient(
                 binary,
                 ["--sandbox", args.sandbox, *case.server_args],
                 case.server_env,
+                server_cwd,
                 args.timeout,
             ) as client:
                 case.run(client)

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -959,11 +959,11 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
 
 def resolve_binary_path(path: Path) -> Path:
     if path.is_file():
-        return path
+        return path.resolve()
     if sys.platform == "win32" and path.suffix == "":
         exe_path = path.with_name(f"{path.name}.exe")
         if exe_path.is_file():
-            return exe_path
+            return exe_path.resolve()
     return path
 
 

--- a/tests/test_run_integration_tests.py
+++ b/tests/test_run_integration_tests.py
@@ -53,7 +53,23 @@ class RunIntegrationTestsCaseTests(unittest.TestCase):
             exe_binary.write_text("", encoding="utf-8")
 
             with patch.object(self.module.sys, "platform", "win32"):
-                self.assertEqual(exe_binary, self.module.resolve_binary_path(binary))
+                self.assertEqual(
+                    exe_binary.resolve(),
+                    self.module.resolve_binary_path(binary),
+                )
+
+    def test_resolve_binary_path_returns_absolute_existing_path(self):
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp_dir:
+            temp_path = Path(temp_dir)
+            binary = temp_path / "mcp-repl"
+            binary.write_text("", encoding="utf-8")
+
+            relative_binary = binary.relative_to(Path.cwd())
+
+            self.assertEqual(
+                binary.resolve(),
+                self.module.resolve_binary_path(relative_binary),
+            )
 
     def test_server_process_env_uses_plain_pagers_by_default(self):
         env = self.module.server_process_env(())

--- a/tests/test_run_integration_tests.py
+++ b/tests/test_run_integration_tests.py
@@ -61,6 +61,23 @@ class RunIntegrationTestsCaseTests(unittest.TestCase):
         self.assertEqual("cat", env["PAGER"])
         self.assertEqual("cat", env["MANPAGER"])
 
+    def test_workspace_write_case_overrides_default_sandbox(self):
+        case = self.module.CASES["r-workspace-write-sandbox"]
+
+        sandbox_args = [
+            (arg, case.server_args[index + 1])
+            for index, arg in enumerate(case.server_args[:-1])
+            if arg == "--sandbox"
+        ]
+        self.assertEqual([("--sandbox", "workspace-write")], sandbox_args)
+
+    def test_workspace_write_case_uses_scratch_cwd(self):
+        case = self.module.CASES["r-workspace-write-sandbox"]
+
+        self.assertIsNotNone(case.server_cwd)
+        self.assertIn("target", case.server_cwd.parts)
+        self.assertIn("test-scratch", case.server_cwd.parts)
+
     def test_wait_for_busy_response_text_polls_until_marker(self):
         initial = self.module.tool_result(
             self.module.text(


### PR DESCRIPTION
## Summary
- Add a public integration case that runs the server under `workspace-write` and verifies writes succeed inside the configured working directory.
- Verify writes outside that directory are rejected and do not create files.
- Update the runner and docs to reflect public sandbox-policy coverage and the case-specific server CWD override.
