### PR TITLE
Move the read-only sandbox check to the external runner

### DIFF
--- a/docs/plans/active/public-api-runner.md
+++ b/docs/plans/active/public-api-runner.md
@@ -66,3 +66,4 @@
 - 2026-05-18: Reaffirmed that unmigrated Rust scenarios must remain discoverable by `cargo test`; migrations should replace Rust coverage with equivalent Python coverage in the same change, not disable tests ahead of time.
 - 2026-05-18: Clarified that the external runner itself is not sandboxed, but the spawned `mcp-repl` binary still owns the sandbox contract; the next slice should restore sandbox coverage in the Python runner starting with `workspace-write`.
 - 2026-06-18: Added an external `workspace-write` sandbox case that verifies public `repl` behavior for writes inside the server cwd and blocked writes outside it.
+- 2026-06-18: Migrated the public read-only workspace write denial check into the external runner and removed the duplicate Rust integration case.

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -634,6 +634,29 @@ def r_workspace_write_sandbox(client: McpStdioClient) -> None:
         outside_target.unlink(missing_ok=True)
 
 
+def r_read_only_sandbox(client: McpStdioClient) -> None:
+    stamp = f"{os.getpid()}-{time.time_ns()}"
+    workspace_cwd = client.server_cwd or Path.cwd()
+    target = workspace_cwd / f".mcp-repl-read-only-{stamp}.txt"
+    target.unlink(missing_ok=True)
+
+    try:
+        received = client.repl(
+            r_write_file_input(target, "blocked"),
+            timeout_ms=30000,
+        )
+        received_text = require_success(received, "read-only cwd repl")
+        if "WRITE_ERROR:" not in received_text or "WRITE_OK" in received_text:
+            raise SuiteFailure(
+                "expected read-only to block writing in cwd, "
+                f"got: {received_text!r}"
+            )
+        if target.exists():
+            raise SuiteFailure(f"read-only unexpectedly created file: {target}")
+    finally:
+        target.unlink(missing_ok=True)
+
+
 def r_interrupt_restart_prefixes(client: McpStdioClient) -> None:
     set_var = client.repl("x <- 1\n", timeout_ms=30000)
     assert_identical(
@@ -916,6 +939,11 @@ CASES: dict[str, SuiteCase] = {
         r_pager_command_smoke,
         server_args=("--oversized-output", "pager"),
         server_env=(("MCP_REPL_PAGER_PAGE_CHARS", "80"),),
+    ),
+    "r-read-only-sandbox": r_suite_case(
+        r_read_only_sandbox,
+        server_args=("--sandbox", "read-only"),
+        server_cwd=Path("target/test-scratch/run-integration-tests/r-read-only-sandbox"),
     ),
     "r-reset-clears-state": r_suite_case(r_reset_clears_state),
     "r-timeout-busy-recovers": r_suite_case(r_timeout_busy_recovers),

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -672,35 +672,6 @@ fn prepopulate_reticulate_keras_jax_cache() -> TestResult<bool> {
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
-async fn sandbox_read_only_blocks_workspace_writes() -> TestResult<()> {
-    assert!(sandbox_available(), "sandbox-exec unavailable");
-    let repo_root = std::env::current_dir()?;
-    let target = unique_path(&repo_root, "read-only");
-    let session = spawn_server_with_sandbox_state(sandbox_state_read_only()).await?;
-    let result = session
-        .write_stdin_raw_with(write_test_code(&target), Some(10.0))
-        .await?;
-    let text = collect_text(&result);
-    let _ = std::fs::remove_file(&target);
-    if skip_backend_unavailable("sandbox_read_only_blocks_workspace_writes", &text) {
-        session.cancel().await?;
-        return Ok(());
-    }
-
-    assert!(
-        text.contains("WRITE_ERROR:"),
-        "expected write to be blocked, got: {text}"
-    );
-    assert!(
-        !text.contains("WRITE_OK"),
-        "write unexpectedly succeeded: {text}"
-    );
-    session.cancel().await?;
-    Ok(())
-}
-
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-#[tokio::test(flavor = "multi_thread")]
 async fn sandbox_workspace_write_allows_workspace_writes() -> TestResult<()> {
     assert!(sandbox_available(), "sandbox-exec unavailable");
     let repo_root = std::env::current_dir()?;


### PR DESCRIPTION
## Summary
- Move the public read-only sandbox denial check into the Python integration runner so it exercises the external path used by users.
- Keep the existing behavior coverage for blocked writes in a read-only server sandbox, while removing the duplicate Rust integration case.
- Add a dedicated `r-read-only-sandbox` case that writes inside the server cwd and asserts the write is rejected without creating the file.

## Notes
- The change keeps the public API coverage in the external runner and trims the internal Rust-only duplication.
- The plan note was updated to reflect the migration.