### PR TITLE
Migrate the full-access sandbox coverage to the Python runner

### DIFF
--- a/docs/plans/active/public-api-runner.md
+++ b/docs/plans/active/public-api-runner.md
@@ -46,8 +46,9 @@
 
 ## Next Safe Slice
 
-- Add a second public sandbox-policy contrast in the Python runner only if it replaces matching Rust public behavior cleanly, for example a focused read-only write denial or full-access outside-write case.
-- Otherwise, migrate another representative real-binary Rust integration scenario to the Python runner and remove or reduce only the matching Rust coverage.
+- The basic sandbox write-policy contrasts now live in the Python runner.
+- Migrate another representative real-binary Rust integration scenario to the Python runner and remove or reduce only the matching Rust coverage.
+- Keep additional sandbox migrations focused on public behavior that does not require internal server or launch-state inspection.
 
 ## Stop Conditions
 
@@ -67,3 +68,4 @@
 - 2026-05-18: Clarified that the external runner itself is not sandboxed, but the spawned `mcp-repl` binary still owns the sandbox contract; the next slice should restore sandbox coverage in the Python runner starting with `workspace-write`.
 - 2026-06-18: Added an external `workspace-write` sandbox case that verifies public `repl` behavior for writes inside the server cwd and blocked writes outside it.
 - 2026-06-18: Migrated the public read-only workspace write denial check into the external runner and removed the duplicate Rust integration case.
+- 2026-06-18: Migrated the public full-access outside-write check into the external runner and removed the duplicate Rust integration case.

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -657,6 +657,31 @@ def r_read_only_sandbox(client: McpStdioClient) -> None:
         target.unlink(missing_ok=True)
 
 
+def r_full_access_sandbox(client: McpStdioClient) -> None:
+    stamp = f"{os.getpid()}-{time.time_ns()}"
+    workspace_cwd = client.server_cwd or Path.cwd()
+    target = workspace_cwd.resolve().parent / f".mcp-repl-full-access-{stamp}.txt"
+    target.unlink(missing_ok=True)
+
+    try:
+        received = client.repl(
+            r_write_file_input(target, "allowed"),
+            timeout_ms=30000,
+        )
+        received_text = require_success(received, "full-access outside repl")
+        if "WRITE_OK" not in received_text or "WRITE_ERROR:" in received_text:
+            raise SuiteFailure(
+                "expected full access to allow writing outside cwd, "
+                f"got: {received_text!r}"
+            )
+        if target.read_text(encoding="utf-8").strip() != "allowed":
+            raise SuiteFailure(
+                f"full-access outside file did not contain expected text: {target}"
+            )
+    finally:
+        target.unlink(missing_ok=True)
+
+
 def r_interrupt_restart_prefixes(client: McpStdioClient) -> None:
     set_var = client.repl("x <- 1\n", timeout_ms=30000)
     assert_identical(
@@ -916,6 +941,11 @@ def r_suite_case(
 
 CASES: dict[str, SuiteCase] = {
     "r-console-basic": r_suite_case(r_console_basic),
+    "r-full-access-sandbox": r_suite_case(
+        r_full_access_sandbox,
+        server_args=("--sandbox", "danger-full-access"),
+        server_cwd=Path("target/test-scratch/run-integration-tests/r-full-access-sandbox"),
+    ),
     "r-interrupt-restart-prefixes": r_suite_case(r_interrupt_restart_prefixes),
     "r-output-bundle-files": r_suite_case(
         r_output_bundle_files,

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -816,30 +816,6 @@ async fn sandbox_read_only_blocks_r_package_cache_root_writes() -> TestResult<()
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
-async fn sandbox_full_access_allows_writes_outside_workspace() -> TestResult<()> {
-    assert!(sandbox_available(), "sandbox-exec unavailable");
-    let target = unique_path(&std::env::temp_dir(), "full-access");
-    let session = spawn_server_with_sandbox_state(sandbox_state_full_access()).await?;
-    let result = session
-        .write_stdin_raw_with(write_test_code(&target), Some(10.0))
-        .await?;
-    let text = collect_text(&result);
-    let _ = std::fs::remove_file(&target);
-    if skip_backend_unavailable("sandbox_full_access_allows_writes_outside_workspace", &text) {
-        session.cancel().await?;
-        return Ok(());
-    }
-
-    assert!(
-        text.contains("WRITE_OK"),
-        "expected write to succeed, got: {text}"
-    );
-    session.cancel().await?;
-    Ok(())
-}
-
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-#[tokio::test(flavor = "multi_thread")]
 async fn sandbox_read_only_blocks_network_access() -> TestResult<()> {
     assert!(sandbox_available(), "sandbox-exec unavailable");
     let Some(addr) = start_loopback_server_if_available().await? else {

--- a/tests/test_run_integration_tests.py
+++ b/tests/test_run_integration_tests.py
@@ -94,6 +94,23 @@ class RunIntegrationTestsCaseTests(unittest.TestCase):
         self.assertIn("target", case.server_cwd.parts)
         self.assertIn("test-scratch", case.server_cwd.parts)
 
+    def test_full_access_case_overrides_default_sandbox(self):
+        case = self.module.CASES["r-full-access-sandbox"]
+
+        sandbox_args = [
+            (arg, case.server_args[index + 1])
+            for index, arg in enumerate(case.server_args[:-1])
+            if arg == "--sandbox"
+        ]
+        self.assertEqual([("--sandbox", "danger-full-access")], sandbox_args)
+
+    def test_full_access_case_uses_scratch_cwd(self):
+        case = self.module.CASES["r-full-access-sandbox"]
+
+        self.assertIsNotNone(case.server_cwd)
+        self.assertIn("target", case.server_cwd.parts)
+        self.assertIn("test-scratch", case.server_cwd.parts)
+
     def test_wait_for_busy_response_text_polls_until_marker(self):
         initial = self.module.tool_result(
             self.module.text(


### PR DESCRIPTION
## Summary
- Move the public full-access sandbox write case into the Python integration runner so the external test harness covers the same user-facing behavior the Rust suite previously verified.
- Keep the coverage focused on public `repl` behavior: the case now confirms that a write outside the server cwd succeeds under `danger-full-access`, and it cleans up the temporary file afterward.
- Remove the duplicated Rust integration test to avoid maintaining the same contract in two places.
- Update the active runner plan to reflect that the basic sandbox write-policy contrasts now live in the Python runner and that future migrations should stay focused on public behavior.
