### PR TITLE
Migrate workspace network checks to public runner

### DIFF
--- a/docs/plans/active/public-api-runner.md
+++ b/docs/plans/active/public-api-runner.md
@@ -30,7 +30,7 @@
 - Phase 0: completed - add the runner shell and first R console smoke case.
 - Phase 1: completed - migrate another small real-client scenario with timeout or busy-worker behavior.
 - Phase 2: completed - run the external suite in CI after the debug binary is built.
-- Phase 3: active - reintroduced `workspace-write` sandbox behavior in the Python runner; continue migrating duplicate real-binary Rust integration coverage case by case.
+- Phase 3: active - reintroduced `workspace-write` sandbox behavior in the Python runner, including write policy and network-access policy; continue migrating duplicate real-binary Rust integration coverage case by case.
 
 ## Locked Decisions
 
@@ -46,7 +46,7 @@
 
 ## Next Safe Slice
 
-- The basic sandbox write-policy contrasts now live in the Python runner.
+- The basic sandbox write-policy contrasts and workspace-write network policy contrasts now live in the Python runner.
 - Migrate another representative real-binary Rust integration scenario to the Python runner and remove or reduce only the matching Rust coverage.
 - Keep additional sandbox migrations focused on public behavior that does not require internal server or launch-state inspection.
 
@@ -69,3 +69,4 @@
 - 2026-06-18: Added an external `workspace-write` sandbox case that verifies public `repl` behavior for writes inside the server cwd and blocked writes outside it.
 - 2026-06-18: Migrated the public read-only workspace write denial check into the external runner and removed the duplicate Rust integration case.
 - 2026-06-18: Migrated the public full-access outside-write check into the external runner and removed the duplicate Rust integration case.
+- 2026-06-18: Migrated workspace-write network block/allow coverage into the external runner and removed the duplicate Unix Rust integration cases.

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -6,6 +6,7 @@ import difflib
 import json
 import os
 import queue
+import socket
 import subprocess
 import sys
 import tempfile
@@ -26,8 +27,68 @@ class SuiteFailure(Exception):
     pass
 
 
+class SuiteSkip(Exception):
+    pass
+
+
 class McpProtocolError(SuiteFailure):
     pass
+
+
+class LoopbackServer:
+    def __init__(self) -> None:
+        self.listener: socket.socket | None = None
+        self.thread: threading.Thread | None = None
+        self.stop_event = threading.Event()
+        self.address: tuple[str, int] | None = None
+
+    def __enter__(self) -> LoopbackServer:
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            listener.bind(("127.0.0.1", 0))
+            listener.listen(1)
+            listener.settimeout(0.1)
+        except PermissionError as exc:
+            listener.close()
+            raise SuiteSkip(f"loopback unavailable in this environment: {exc}") from exc
+        self.listener = listener
+        host, port = listener.getsockname()
+        self.address = (host, port)
+        self.thread = threading.Thread(target=self._serve, daemon=True)
+        self.thread.start()
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.stop_event.set()
+        if self.listener is not None:
+            self.listener.close()
+        if self.thread is not None:
+            self.thread.join(timeout=1.0)
+
+    @property
+    def host(self) -> str:
+        assert self.address is not None
+        return self.address[0]
+
+    @property
+    def port(self) -> int:
+        assert self.address is not None
+        return self.address[1]
+
+    def _serve(self) -> None:
+        listener = self.listener
+        assert listener is not None
+        while not self.stop_event.is_set():
+            try:
+                conn, _addr = listener.accept()
+            except TimeoutError:
+                continue
+            except OSError:
+                return
+            with conn:
+                conn.sendall(b"ok")
+                return
 
 
 def collect_stderr(stream: Any, sink: list[str]) -> None:
@@ -469,6 +530,27 @@ def r_write_file_input(path: Path, value: str) -> str:
     )
 
 
+def r_network_input(host: str, port: int) -> str:
+    return dedent(
+        f"""
+        tryCatch(
+          {{
+            con <- socketConnection(
+              {r_string_literal(host)},
+              {port},
+              blocking = TRUE,
+              open = "r+",
+              timeout = 1
+            )
+            on.exit(close(con))
+            cat("NETWORK_OK\\n")
+          }},
+          error = function(e) cat("NETWORK_ERROR:", conditionMessage(e), "\\n", sep = "")
+        )
+        """
+    )
+
+
 def repeated_text_line(label: str, index: int, width: int = 120) -> str:
     return f"{label}{index:03d} {label * width}\n"
 
@@ -680,6 +762,34 @@ def r_full_access_sandbox(client: McpStdioClient) -> None:
             )
     finally:
         target.unlink(missing_ok=True)
+
+
+def r_workspace_write_network_blocked(client: McpStdioClient) -> None:
+    with LoopbackServer() as server:
+        received = client.repl(
+            r_network_input(server.host, server.port),
+            timeout_ms=30000,
+        )
+    received_text = require_success(received, "workspace-write network blocked repl")
+    if "NETWORK_ERROR:" not in received_text or "NETWORK_OK" in received_text:
+        raise SuiteFailure(
+            "expected workspace-write to block network access, "
+            f"got: {received_text!r}"
+        )
+
+
+def r_workspace_write_network_allowed(client: McpStdioClient) -> None:
+    with LoopbackServer() as server:
+        received = client.repl(
+            r_network_input(server.host, server.port),
+            timeout_ms=30000,
+        )
+    received_text = require_success(received, "workspace-write network allowed repl")
+    if "NETWORK_OK" not in received_text or "NETWORK_ERROR:" in received_text:
+        raise SuiteFailure(
+            "expected workspace-write network_access=true to allow network access, "
+            f"got: {received_text!r}"
+        )
 
 
 def r_interrupt_restart_prefixes(client: McpStdioClient) -> None:
@@ -922,6 +1032,7 @@ class SuiteCase:
     server_args: tuple[str, ...] = ()
     server_env: tuple[tuple[str, str], ...] = ()
     server_cwd: Path | None = None
+    platforms: tuple[str, ...] = ()
 
 
 def r_suite_case(
@@ -930,12 +1041,14 @@ def r_suite_case(
     server_args: tuple[str, ...] = (),
     server_env: tuple[tuple[str, str], ...] = (),
     server_cwd: Path | None = None,
+    platforms: tuple[str, ...] = (),
 ) -> SuiteCase:
     return SuiteCase(
         run,
         server_args=("--interpreter", "r", *server_args),
         server_env=server_env,
         server_cwd=server_cwd,
+        platforms=platforms,
     )
 
 
@@ -981,6 +1094,21 @@ CASES: dict[str, SuiteCase] = {
         r_workspace_write_sandbox,
         server_args=("--sandbox", "workspace-write"),
         server_cwd=Path("target/test-scratch/run-integration-tests/r-workspace-write-sandbox"),
+    ),
+    "r-workspace-write-network-allowed": r_suite_case(
+        r_workspace_write_network_allowed,
+        server_args=(
+            "--sandbox",
+            "workspace-write",
+            "--config",
+            "sandbox_workspace_write.network_access=true",
+        ),
+        platforms=("darwin", "linux"),
+    ),
+    "r-workspace-write-network-blocked": r_suite_case(
+        r_workspace_write_network_blocked,
+        server_args=("--sandbox", "workspace-write"),
+        platforms=("darwin", "linux"),
     ),
 }
 
@@ -1036,6 +1164,9 @@ def main(argv: Sequence[str]) -> int:
     failures = 0
     for case_name in selected:
         case = CASES[case_name]
+        if case.platforms and sys.platform not in case.platforms:
+            print(f"ok {case_name} # skip unsupported platform {sys.platform}")
+            continue
         server_cwd = None
         if case.server_cwd is not None:
             server_cwd = case.server_cwd
@@ -1051,6 +1182,8 @@ def main(argv: Sequence[str]) -> int:
                 args.timeout,
             ) as client:
                 case.run(client)
+        except SuiteSkip as exc:
+            print(f"ok {case_name} # skip {exc}")
         except SuiteFailure as exc:
             failures += 1
             print(f"not ok {case_name}: {exc}", file=sys.stderr)

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -894,34 +894,6 @@ async fn sandbox_reticulate_keras_backend() -> TestResult<()> {
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[tokio::test(flavor = "multi_thread")]
-async fn sandbox_workspace_write_blocks_network_access() -> TestResult<()> {
-    assert!(sandbox_available(), "sandbox-exec unavailable");
-    let Some(addr) = start_loopback_server_if_available().await? else {
-        return Ok(());
-    };
-    let session = spawn_server_with_sandbox_state(sandbox_state_workspace_write(false)).await?;
-    let result = session
-        .write_stdin_raw_with(network_test_code(addr), Some(10.0))
-        .await?;
-    let text = collect_text(&result);
-    if skip_backend_unavailable("sandbox_workspace_write_blocks_network_access", &text) {
-        session.cancel().await?;
-        return Ok(());
-    }
-    assert!(
-        text.contains("NETWORK_ERROR:"),
-        "expected network to be blocked, got: {text}"
-    );
-    assert!(
-        !text.contains("NETWORK_OK"),
-        "network request unexpectedly succeeded: {text}"
-    );
-    session.cancel().await?;
-    Ok(())
-}
-
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-#[tokio::test(flavor = "multi_thread")]
 async fn sandbox_tempdir_stable_across_restart() -> TestResult<()> {
     assert!(sandbox_available(), "sandbox-exec unavailable");
     let mut session = spawn_server_with_sandbox_state(sandbox_state_read_only()).await?;
@@ -1007,30 +979,6 @@ cat("MCP_TMPDIR=", Sys.getenv("MCP_REPL_R_SESSION_TMPDIR"), "\n", sep = "")
     assert_eq!(
         tmpdir, mcp_tmpdir,
         "expected TMPDIR to match MCP_TMPDIR, got: {text}"
-    );
-    session.cancel().await?;
-    Ok(())
-}
-
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-#[tokio::test(flavor = "multi_thread")]
-async fn sandbox_workspace_write_allows_network_access() -> TestResult<()> {
-    assert!(sandbox_available(), "sandbox-exec unavailable");
-    let Some(addr) = start_loopback_server_if_available().await? else {
-        return Ok(());
-    };
-    let session = spawn_server_with_sandbox_state(sandbox_state_workspace_write(true)).await?;
-    let result = session
-        .write_stdin_raw_with(network_test_code(addr), Some(10.0))
-        .await?;
-    let text = collect_text(&result);
-    if skip_backend_unavailable("sandbox_workspace_write_allows_network_access", &text) {
-        session.cancel().await?;
-        return Ok(());
-    }
-    assert!(
-        text.contains("NETWORK_OK"),
-        "expected network to succeed, got: {text}"
     );
     session.cancel().await?;
     Ok(())


### PR DESCRIPTION
## Summary

Migrate workspace-write network sandbox coverage from Rust integration tests into the external public API runner. This keeps the migration moving toward real-binary MCP stdio checks for public behavior while reducing duplicate Rust integration coverage.

## User Facing Changes

No runtime behavior changes. The same workspace-write network block/allow behavior remains covered.

## Internal Changes

- Added Unix public API runner cases for default workspace-write network denial and `sandbox_workspace_write.network_access=true` allowance.
- Added small runner support for platform-gated cases and loopback-unavailable skips.
- Removed the matching Unix Rust workspace-write network tests.
- Updated the active public API runner plan with the completed migration.
