### PR TITLE
Migrate Python smoke check to public API runner

### DIFF
--- a/docs/plans/active/public-api-runner.md
+++ b/docs/plans/active/public-api-runner.md
@@ -70,3 +70,4 @@
 - 2026-06-18: Migrated the public read-only workspace write denial check into the external runner and removed the duplicate Rust integration case.
 - 2026-06-18: Migrated the public full-access outside-write check into the external runner and removed the duplicate Rust integration case.
 - 2026-06-18: Migrated workspace-write network block/allow coverage into the external runner and removed the duplicate Unix Rust integration cases.
+- 2026-06-18: Migrated the basic Python console smoke check into the external runner and removed the duplicate Rust integration case.

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -690,26 +690,6 @@ print("ipc background ready")
     Ok(holder)
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn python_smoke() -> TestResult<()> {
-    let _guard = lock_test_mutex();
-    let Some(session) = start_python_session().await? else {
-        return Ok(());
-    };
-
-    let result = session.write_stdin_raw_with("1+1", Some(5.0)).await?;
-    let text = result_text(&result);
-    if is_busy_response(&text) {
-        eprintln!("python_smoke remained busy; skipping");
-        session.cancel().await?;
-        return Ok(());
-    }
-    assert!(text.contains("2"), "expected 2, got: {text:?}");
-
-    session.cancel().await?;
-    Ok(())
-}
-
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread")]
 async fn python_plot_hook_flushes_before_stdin_wait_reply() -> TestResult<()> {

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -387,6 +387,22 @@ def wait_for_response(
     raise SuiteFailure(f"{context} remained busy after polling: {last_received!r}")
 
 
+def wait_until_not_busy(
+    client: McpStdioClient,
+    received: dict[str, Any],
+    context: str,
+    deadline_seconds: float = 5.0,
+) -> dict[str, Any]:
+    assert deadline_seconds > 0
+    deadline = time.monotonic() + deadline_seconds
+    last_received = received
+    while is_busy_response(last_received):
+        if time.monotonic() >= deadline:
+            raise SuiteFailure(f"{context} remained busy after polling: {last_received!r}")
+        last_received = client.repl("", timeout_ms=500)
+    return last_received
+
+
 def wait_for_busy_response_text(
     client: McpStdioClient,
     received: dict[str, Any],
@@ -603,6 +619,23 @@ def r_console_basic(client: McpStdioClient) -> None:
     )
 
     assert_identical(expected, received, "repl")
+
+
+def python_startup_deadline_seconds() -> float:
+    return 90.0 if sys.platform == "darwin" else 20.0
+
+
+def python_console_basic(client: McpStdioClient) -> None:
+    received = client.repl("1+1", timeout_ms=2000)
+    received = wait_until_not_busy(
+        client,
+        received,
+        "python console repl",
+        deadline_seconds=python_startup_deadline_seconds(),
+    )
+    received_text = require_success(received, "python console repl")
+    if "2" not in received_text:
+        raise SuiteFailure(f"expected Python repl output to contain 2, got: {received_text!r}")
 
 
 def r_timeout_busy_recovers(client: McpStdioClient) -> None:
@@ -1052,7 +1085,25 @@ def r_suite_case(
     )
 
 
+def python_suite_case(
+    run: Callable[[McpStdioClient], None],
+    *,
+    server_args: tuple[str, ...] = (),
+    server_env: tuple[tuple[str, str], ...] = (),
+    server_cwd: Path | None = None,
+    platforms: tuple[str, ...] = (),
+) -> SuiteCase:
+    return SuiteCase(
+        run,
+        server_args=("--interpreter", "python", "--oversized-output", "files", *server_args),
+        server_env=server_env,
+        server_cwd=server_cwd,
+        platforms=platforms,
+    )
+
+
 CASES: dict[str, SuiteCase] = {
+    "python-console-basic": python_suite_case(python_console_basic),
     "r-console-basic": r_suite_case(r_console_basic),
     "r-full-access-sandbox": r_suite_case(
         r_full_access_sandbox,

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -633,9 +633,12 @@ def python_console_basic(client: McpStdioClient) -> None:
         "python console repl",
         deadline_seconds=python_startup_deadline_seconds(),
     )
-    received_text = require_success(received, "python console repl")
-    if "2" not in received_text:
-        raise SuiteFailure(f"expected Python repl output to contain 2, got: {received_text!r}")
+    expected = tool_result(
+        text("2\n"),
+        text(">>> "),
+    )
+
+    assert_identical(expected, normalize_response(received), "python console repl")
 
 
 def r_timeout_busy_recovers(client: McpStdioClient) -> None:

--- a/tests/test_run_integration_tests.py
+++ b/tests/test_run_integration_tests.py
@@ -31,6 +31,14 @@ class RunIntegrationTestsCaseTests(unittest.TestCase):
                 self.assertLess(index + 1, len(case.server_args))
                 self.assertEqual(case.server_args[index + 1], "r")
 
+    def test_python_console_basic_case_pins_python_interpreter(self):
+        case = self.module.CASES["python-console-basic"]
+
+        self.assertIn("--interpreter", case.server_args)
+        index = case.server_args.index("--interpreter")
+        self.assertLess(index + 1, len(case.server_args))
+        self.assertEqual(case.server_args[index + 1], "python")
+
     def test_tool_result_builder_matches_mcp_response_shape(self):
         self.assertEqual(
             self.module.tool_result(

--- a/tests/test_run_integration_tests.py
+++ b/tests/test_run_integration_tests.py
@@ -39,6 +39,26 @@ class RunIntegrationTestsCaseTests(unittest.TestCase):
         self.assertLess(index + 1, len(case.server_args))
         self.assertEqual(case.server_args[index + 1], "python")
 
+    def test_python_console_basic_rejects_startup_failure_text(self):
+        startup_failure = self.module.tool_result(
+            self.module.text(
+                "failed to start Python backend: No such file or directory (os error 2)"
+            )
+        )
+        test_case = self
+
+        class FakeClient:
+            def repl(self, input_text, *, timeout_ms=None):
+                test_case.assertEqual("1+1", input_text)
+                test_case.assertEqual(2000, timeout_ms)
+                return startup_failure
+
+        with self.assertRaisesRegex(
+            self.module.SuiteFailure,
+            "python console repl response mismatch",
+        ):
+            self.module.python_console_basic(FakeClient())
+
     def test_tool_result_builder_matches_mcp_response_shape(self):
         self.assertEqual(
             self.module.tool_result(


### PR DESCRIPTION
## Summary

Migrate the basic Python console smoke scenario from the Rust integration suite into the external public API runner.

This continues the public API runner migration by checking Python through the same real-binary MCP stdio path already used for R cases.

## User-facing changes

- No runtime behavior changes.
- The public API suite now exercises Python `repl` behavior through `--interpreter python`.

## Internal changes

- Added a `python-console-basic` runner case with files-mode Python server arguments.
- Added polling for slow first Python startup before asserting the console result.
- Removed the duplicate Rust `python_smoke` integration test.
- Updated the active public runner plan decision log.
