### PR TITLE
Migrate Python busy test to public runner

### DIFF
--- a/docs/plans/active/public-api-runner.md
+++ b/docs/plans/active/public-api-runner.md
@@ -71,3 +71,4 @@
 - 2026-06-18: Migrated the public full-access outside-write check into the external runner and removed the duplicate Rust integration case.
 - 2026-06-18: Migrated workspace-write network block/allow coverage into the external runner and removed the duplicate Unix Rust integration cases.
 - 2026-06-18: Migrated the basic Python console smoke check into the external runner and removed the duplicate Rust integration case.
+- 2026-06-18: Migrated the Python busy-input discard check into the external runner and removed the duplicate Rust integration case.

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -3805,29 +3805,6 @@ async fn python_help_flows_stay_inline() -> TestResult<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn python_busy_discards_input() -> TestResult<()> {
-    let _guard = lock_test_mutex();
-    let Some(session) = start_python_session().await? else {
-        return Ok(());
-    };
-
-    let _ = session
-        .write_stdin_raw_with("import time; time.sleep(2)", Some(0.1))
-        .await?;
-
-    let result = session.write_stdin_raw_with("1+1", Some(0.2)).await?;
-    let text = result_text(&result);
-    assert!(
-        text.contains("input discarded while worker busy"),
-        "expected busy discard message, got: {text:?}"
-    );
-    assert_ne!(result.is_error, Some(true));
-
-    session.cancel().await?;
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn python_stderr_merged_into_output() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let Some(session) = start_python_session().await? else {

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -641,6 +641,48 @@ def python_console_basic(client: McpStdioClient) -> None:
     assert_identical(expected, normalize_response(received), "python console repl")
 
 
+def python_busy_discards_input(client: McpStdioClient) -> None:
+    warmup = client.repl("print('PYTHON_BUSY_READY')", timeout_ms=2000)
+    warmup = wait_until_not_busy(
+        client,
+        warmup,
+        "python busy warmup repl",
+        deadline_seconds=python_startup_deadline_seconds(),
+    )
+    warmup_text = require_success(warmup, "python busy warmup repl")
+    if "PYTHON_BUSY_READY" not in warmup_text:
+        raise SuiteFailure(f"expected Python warmup output, got: {warmup_text!r}")
+
+    timed_out = client.repl("import time; time.sleep(2)", timeout_ms=100)
+    timed_out_text = require_success(timed_out, "python busy timeout repl")
+    if not is_busy_response(timed_out):
+        raise SuiteFailure(
+            f"expected sleeping Python request to remain busy, got: {timed_out_text!r}"
+        )
+
+    busy_follow_up = client.repl("1+1", timeout_ms=200)
+    busy_follow_up_text = require_success(busy_follow_up, "python busy follow-up repl")
+    if "input discarded while worker busy" not in busy_follow_up_text:
+        raise SuiteFailure(
+            "expected busy Python worker to discard follow-up input, "
+            f"got: {busy_follow_up_text!r}"
+        )
+
+    wait_until_not_busy(
+        client,
+        client.repl("", timeout_ms=500),
+        "python busy settle repl",
+        deadline_seconds=5.0,
+    )
+
+    recovered = client.repl("1+1", timeout_ms=5000)
+    assert_identical(
+        tool_result(text("2\n"), text(">>> ")),
+        normalize_response(recovered),
+        "python busy recovery repl",
+    )
+
+
 def r_timeout_busy_recovers(client: McpStdioClient) -> None:
     warmup = client.repl("1+1\n", timeout_ms=30000)
     assert_identical(
@@ -1106,6 +1148,7 @@ def python_suite_case(
 
 
 CASES: dict[str, SuiteCase] = {
+    "python-busy-discards-input": python_suite_case(python_busy_discards_input),
     "python-console-basic": python_suite_case(python_console_basic),
     "r-console-basic": r_suite_case(r_console_basic),
     "r-full-access-sandbox": r_suite_case(


### PR DESCRIPTION
## Summary

Migrate the Python busy-input discard coverage into the external public API runner so the behavior is checked against the built `mcp-repl` binary over MCP stdio. This continues the public runner migration and keeps Rust integration coverage focused on behavior not already covered externally.

## User-facing changes

- No product behavior changes.
- The external public API suite now includes `python-busy-discards-input`.

## Internal changes

- Added a Python runner case that warms up the interpreter, starts a timed-out sleep, verifies follow-up input is discarded while the worker is busy, waits for recovery, and verifies the session can execute again.
- Removed the duplicate Rust `python_busy_discards_input` integration test.
- Updated the active public API runner plan.
