### PR TITLE
Remove stale stdin request payload path

### DIFF
--- a/docs/futurework/per-turn-history-bundles.md
+++ b/docs/futurework/per-turn-history-bundles.md
@@ -65,8 +65,9 @@ Important rule for control prefixes:
 - `\u0003foo` is one turn that starts with interrupt handling and ends with the reply for evaluating `foo`
 - `\u0004foo` is one turn that starts with restart handling and ends with the reply for evaluating `foo`
 
-This matters because the current worker path recursively re-enters `write_stdin()` after handling
-the control prefix. The turn layer must not mirror that recursion into a second turn.
+This matters because the current write-flow composes the control reply with the tail evaluation
+inside one top-level tool call. The turn layer must not mirror that internal composition into a
+second turn.
 
 ## Session Root
 

--- a/docs/plans/active/public-api-runner.md
+++ b/docs/plans/active/public-api-runner.md
@@ -46,9 +46,8 @@
 
 ## Next Safe Slice
 
-- The basic sandbox write-policy contrasts and workspace-write network policy contrasts now live in the Python runner.
-- A representative R `write_stdin` public-behavior cluster now lives in the Python runner.
 - Migrate another representative real-binary Rust integration scenario to the Python runner and remove or reduce only the matching Rust coverage.
+- Rename, split, or retire temporary staging suites such as `tests/refactor_coverage.rs` when equivalent scenarios have clearer homes in the external runner or behavior-specific Rust suites.
 - Keep additional sandbox migrations focused on public behavior that does not require internal server or launch-state inspection.
 
 ## Stop Conditions

--- a/docs/plans/active/windows-test-parity.md
+++ b/docs/plans/active/windows-test-parity.md
@@ -41,11 +41,12 @@
 
 - Whether Windows managed-network/domain enforcement should be implemented so the external workspace-write network allow/block cases can run instead of reporting unsupported platform skips.
 - Whether optional reticulate help coverage should gain a Windows-specific server fix for hosts where reticulate initializes under `Rscript` but hangs inside the MCP R worker.
-- Whether the shared Windows suite server startup mutex is still necessary now that live test sessions pass under ordinary Cargo scheduling.
+- Whether the shared Windows suite server startup mutex can be deleted entirely. Current tests prove it is checkout-scoped, recovers after an abandoned owner, and does not block a second live session.
 
 ## Next Safe Slice
 
 - Investigate Windows managed-network enforcement for the external public API suite, or prove it should remain a documented unsupported sandbox feature.
+- Audit the shared Windows suite server startup mutex for removal now that it no longer blocks concurrent live sessions.
 - Investigate the reticulate Windows MCP-worker initialization hang separately from test scheduling.
 
 ## Stop Conditions

--- a/src/python_session/unix_stdin.rs
+++ b/src/python_session/unix_stdin.rs
@@ -1,6 +1,5 @@
 use crate::ipc;
 use crate::python_input_queue::normalize_pty_input_payload;
-use crate::stdin_payload::prepare_worker_stdin_payload;
 use crate::worker_protocol::TextStream;
 
 use super::state::{
@@ -11,6 +10,14 @@ use super::stdio::{PythonThreadsAllowed, StdioLineRead};
 use super::{CStdinLine, emit_output_text, emit_plots, record_background_plots};
 
 pub(super) fn set_runtime_stdin_fd(_fd: libc::c_int) {}
+
+fn prepare_worker_stdin_payload(input: &str) -> Vec<u8> {
+    let mut payload = input.as_bytes().to_vec();
+    if !payload.is_empty() && !payload.ends_with(b"\n") {
+        payload.push(b'\n');
+    }
+    payload
+}
 
 pub(super) fn flush_terminal_input() {
     let _ = unsafe { libc::tcflush(libc::STDIN_FILENO, libc::TCIFLUSH) };

--- a/src/stdin_payload.rs
+++ b/src/stdin_payload.rs
@@ -11,14 +11,6 @@ pub(crate) enum TimeoutBundleReuse {
     FollowUpInput,
 }
 
-pub(crate) fn prepare_worker_stdin_payload(input: &str) -> Vec<u8> {
-    let mut payload = input.as_bytes().to_vec();
-    if !payload.is_empty() && !payload.ends_with(b"\n") {
-        payload.push(b'\n');
-    }
-    payload
-}
-
 pub(crate) fn split_write_stdin_control_prefix(
     input: &str,
 ) -> Option<(WriteStdinControlAction, &str)> {

--- a/src/worker_process/backend_driver.rs
+++ b/src/worker_process/backend_driver.rs
@@ -5,7 +5,6 @@ use crate::completion_reply::CompletionInfo;
 use crate::ipc::{IpcWaitError, ServerIpcConnection, ServerToWorkerIpcMessage};
 use crate::output_capture::OutputTextSource;
 use crate::oversized_output::OversizedOutputMode;
-use crate::stdin_payload::prepare_worker_stdin_payload;
 use crate::worker_supervisor::WorkerProcess;
 
 use super::WorkerError;
@@ -23,31 +22,18 @@ pub(super) trait BackendDriver: Send {
         text
     }
 
-    fn prepare_input_payload(&self, text: &str) -> Vec<u8> {
-        prepare_worker_stdin_payload(text)
-    }
-
     fn on_input_start(
         &mut self,
         text: &str,
-        payload: &[u8],
         ipc: &ServerIpcConnection,
         timeout: Duration,
     ) -> Result<(), WorkerError>;
-
-    fn on_input_written(&mut self, _ipc: &ServerIpcConnection) -> Result<(), WorkerError> {
-        Ok(())
-    }
 
     fn should_settle_output_after_timeout(
         &self,
         oversized_output: OversizedOutputMode,
         pending_input: Option<&str>,
     ) -> bool;
-
-    fn should_write_stdin_payload(&self) -> bool {
-        true
-    }
 
     fn clear_active_input(&mut self) {}
 
@@ -144,7 +130,6 @@ impl BackendDriver for RBackendDriver {
     fn on_input_start(
         &mut self,
         text: &str,
-        _payload: &[u8],
         ipc: &ServerIpcConnection,
         timeout: Duration,
     ) -> Result<(), WorkerError> {
@@ -168,10 +153,6 @@ impl BackendDriver for RBackendDriver {
             return Err(WorkerError::Protocol(message));
         }
         Ok(())
-    }
-
-    fn should_write_stdin_payload(&self) -> bool {
-        false
     }
 
     fn clear_active_input(&mut self) {}
@@ -222,11 +203,9 @@ impl BackendDriver for ProtocolBackendDriver {
     fn on_input_start(
         &mut self,
         text: &str,
-        payload: &[u8],
         ipc: &ServerIpcConnection,
         timeout: Duration,
     ) -> Result<(), WorkerError> {
-        let _ = payload;
         if let Some(message) = ipc.take_protocol_error() {
             return Err(WorkerError::Protocol(message));
         }
@@ -249,20 +228,11 @@ impl BackendDriver for ProtocolBackendDriver {
         Ok(())
     }
 
-    fn on_input_written(&mut self, ipc: &ServerIpcConnection) -> Result<(), WorkerError> {
-        let _ = ipc;
-        Ok(())
-    }
-
     fn should_settle_output_after_timeout(
         &self,
         _oversized_output: OversizedOutputMode,
         _pending_input: Option<&str>,
     ) -> bool {
-        false
-    }
-
-    fn should_write_stdin_payload(&self) -> bool {
         false
     }
 
@@ -311,19 +281,15 @@ mod tests {
     }
 
     #[test]
-    fn r_driver_sends_input_batch_without_stdin_payload_write() {
+    fn r_driver_sends_input_batch() {
         let (server, worker) = crate::ipc::test_connection_pair().expect("ipc pair");
         let mut driver = RBackendDriver::new();
         make_ready_for_input(&server, &worker, "> ");
 
         driver
-            .on_input_start("1+1", b"1+1\n", &server, Duration::from_millis(200))
+            .on_input_start("1+1", &server, Duration::from_millis(200))
             .expect("R input_batch should send");
 
-        assert!(
-            !driver.should_write_stdin_payload(),
-            "R driver should not ask the server to write managed input to stdin"
-        );
         assert!(matches!(
             worker.recv(Some(Duration::from_millis(200))),
             Some(ServerToWorkerIpcMessage::InputBatch { input }) if input == "1+1"
@@ -375,12 +341,7 @@ mod tests {
         make_ready_for_input(&server, &worker, ">>> ");
 
         driver
-            .on_input_start(
-                "answer = input('p> ')",
-                b"answer = input('p> ')\n",
-                &server,
-                Duration::from_millis(200),
-            )
+            .on_input_start("answer = input('p> ')", &server, Duration::from_millis(200))
             .expect("input_batch should send");
         assert!(matches!(
             worker.recv(Some(Duration::from_millis(200))),
@@ -397,7 +358,7 @@ mod tests {
         assert_eq!(completion.prompt.as_deref(), Some("p> "));
 
         driver
-            .on_input_start("ok\n", b"ok\n", &server, Duration::from_millis(200))
+            .on_input_start("ok\n", &server, Duration::from_millis(200))
             .expect("next input_batch should send");
         assert!(matches!(
             worker.recv(Some(Duration::from_millis(200))),
@@ -414,7 +375,6 @@ mod tests {
         driver
             .on_input_start(
                 "answer <- readline('p> ')",
-                b"answer <- readline('p> ')\n",
                 &server,
                 Duration::from_millis(200),
             )
@@ -434,7 +394,7 @@ mod tests {
         assert_eq!(completion.prompt.as_deref(), Some("p> "));
 
         driver
-            .on_input_start("ok\n", b"ok\n", &server, Duration::from_millis(200))
+            .on_input_start("ok\n", &server, Duration::from_millis(200))
             .expect("next input_batch should send");
         assert!(matches!(
             worker.recv(Some(Duration::from_millis(200))),

--- a/src/worker_process/request_lifecycle.rs
+++ b/src/worker_process/request_lifecycle.rs
@@ -127,24 +127,15 @@ impl WorkerManager {
         if remaining.is_zero() {
             return Err(WorkerError::Timeout(server_timeout));
         }
-        let payload = self.driver.prepare_input_payload(&text);
         if let Some(process) = self.process.as_ref() {
             process.note_accepted_input_starting();
         }
-        self.driver
-            .on_input_start(&text, &payload, &ipc, remaining)?;
+        self.driver.on_input_start(&text, &ipc, remaining)?;
         self.settled_pending_completion = None;
         self.guardrail.busy.store(true, Ordering::Relaxed);
         let remaining = server_deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
             return Err(WorkerError::Timeout(server_timeout));
-        }
-        if self.driver.should_write_stdin_payload() {
-            self.process
-                .as_mut()
-                .expect("worker process should be available")
-                .write_stdin_payload(payload, remaining)?;
-            self.driver.on_input_written(&ipc)?;
         }
         Ok(RequestState {
             timeout: worker_timeout,

--- a/src/worker_supervisor.rs
+++ b/src/worker_supervisor.rs
@@ -1125,20 +1125,12 @@ impl WorkerProcess {
         self.ipc.get()
     }
 
-    pub(crate) fn write_stdin_payload(
-        &mut self,
-        payload: Vec<u8>,
-        timeout: Duration,
-    ) -> Result<(), WorkerError> {
-        self.send_stdin_payload(Some(payload), timeout)
-    }
-
     pub(crate) fn note_accepted_input_starting(&self) {
         self.live_output.note_accepted_input_starting();
     }
 
     fn close_stdin(&mut self, timeout: Duration) -> Result<(), WorkerError> {
-        self.send_stdin_payload(None, timeout)
+        send_stdin_command(&self.stdin_tx, None, timeout)
     }
 
     fn request_ipc_shutdown(&self) {
@@ -1148,14 +1140,6 @@ impl WorkerProcess {
                 Duration::from_millis(200),
             );
         }
-    }
-
-    fn send_stdin_payload(
-        &mut self,
-        payload: Option<Vec<u8>>,
-        timeout: Duration,
-    ) -> Result<(), WorkerError> {
-        send_stdin_command(&self.stdin_tx, payload, timeout)
     }
 
     pub(crate) fn send_interrupt(&mut self) -> Result<(), WorkerError> {


### PR DESCRIPTION
## Summary

Remove the stale server-side request stdin payload path left after worker input moved to IPC `input_batch` messages. This keeps the request lifecycle aligned with protocol v6 and avoids carrying a fallback branch that no supported backend can use.

## User Facing Changes

No user-facing behavior changes. The public `repl` and `repl_reset` contracts remain unchanged.

## Internal Changes

- Removed request-time raw stdin payload hooks from the backend driver abstraction and request lifecycle.
- Kept stdin close as a bounded shutdown fallback.
- Updated follow-up docs so they describe the current control-prefix flow, public API runner next step, and Windows suite mutex status.
