### PR TITLE
Bump version to 0.3.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-repl"
-version = "0.2.0"
+version = "0.3.0-dev"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
   name        = "mcp-repl"
-  version     = "0.2.0"
+  version     = "0.3.0-dev"
   edition     = "2024"
   publish     = false
   description = "MCP server exposing a long-lived interactive REPL runtime (R or Python backend) over stdio."


### PR DESCRIPTION
## Summary

Move the package metadata back onto a development version after the v0.2.0 release. This keeps `main` identifying the next development cycle instead of continuing to report the released stable version.

## User-facing changes

- Builds from `main` now report `0.3.0-dev`.
- No runtime behavior changes.

## Internal changes

- Updates `Cargo.toml` package version to `0.3.0-dev`.
- Updates the matching package entry in `Cargo.lock`.
