### PR TITLE
Handle sandbox payload metadata consistently across worker launch and writes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,15 +37,13 @@
   tempfile = "3.27.0"
   tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
   toml_edit = "0.25.5"
+  url = "2.5.8"
 [target.'cfg(target_os = "linux")'.dependencies]
   landlock    = "0.4.4"
   seccompiler = "0.5.0"
 
 [target.'cfg(unix)'.dependencies]
   portable-pty = "0.9.0"
-
-[target.'cfg(target_os = "macos")'.dependencies]
-  url = "2.5.8"
 
 [target.'cfg(target_os = "windows")'.dependencies]
   windows-sys = { version = "0.61.2", features = [

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -16,6 +16,12 @@ That metadata is the source of truth for the tool call that is about to run. If
 it is missing or malformed, `mcp-repl` fails closed with `--sandbox inherit
 requested but no client sandbox state was provided`.
 
+Current Codex builds send this metadata as a `permissionProfile` plus a
+`sandboxCwd` file URI. `mcp-repl` translates the supported managed profile
+shapes into its local `read-only`, `workspace-write`, `external-sandbox`, or
+`danger-full-access` policies, and rejects narrower direct filesystem profiles
+that cannot be represented faithfully.
+
 `--debug-repl` is the one local-only exception. Because there is no MCP client
 metadata channel in that mode, `mcp-repl --debug-repl --sandbox inherit`
 bootstraps one local inherited snapshot from the current default sandbox state

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -11,7 +11,6 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 #[cfg(target_os = "linux")]
 use std::process;
-#[cfg(target_os = "macos")]
 use url::Url;
 
 use serde::{Deserialize, Serialize};
@@ -99,7 +98,10 @@ pub enum SandboxPolicy {
     #[serde(rename = "danger-full-access")]
     DangerFullAccess,
     #[serde(rename = "read-only")]
-    ReadOnly,
+    ReadOnly {
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        network_access: bool,
+    },
     #[serde(rename = "external-sandbox")]
     ExternalSandbox {
         #[serde(default)]
@@ -131,7 +133,7 @@ impl SandboxPolicy {
         match self {
             SandboxPolicy::DangerFullAccess => true,
             SandboxPolicy::ExternalSandbox { .. } => true,
-            SandboxPolicy::ReadOnly => false,
+            SandboxPolicy::ReadOnly { .. } => false,
             SandboxPolicy::WorkspaceWrite { .. } => false,
         }
     }
@@ -141,7 +143,7 @@ impl SandboxPolicy {
         match self {
             SandboxPolicy::DangerFullAccess => true,
             SandboxPolicy::ExternalSandbox { .. } => true,
-            SandboxPolicy::ReadOnly => true,
+            SandboxPolicy::ReadOnly { .. } => true,
             SandboxPolicy::WorkspaceWrite { .. } => true,
         }
     }
@@ -150,7 +152,7 @@ impl SandboxPolicy {
         match self {
             SandboxPolicy::DangerFullAccess => true,
             SandboxPolicy::ExternalSandbox { network_access } => network_access.is_enabled(),
-            SandboxPolicy::ReadOnly => false,
+            SandboxPolicy::ReadOnly { network_access } => *network_access,
             SandboxPolicy::WorkspaceWrite { network_access, .. } => *network_access,
         }
     }
@@ -169,7 +171,7 @@ impl SandboxPolicy {
         session_temp_dir: Option<&Path>,
     ) -> Vec<WritableRoot> {
         match self {
-            SandboxPolicy::ReadOnly => {
+            SandboxPolicy::ReadOnly { .. } => {
                 let roots = temp_writable_roots(false, false, session_temp_dir);
                 roots
                     .into_iter()
@@ -435,46 +437,93 @@ pub struct SandboxStateUpdate {
     pub use_legacy_landlock: Option<bool>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CodexSandboxStateMeta {
-    pub sandbox_policy: SandboxPolicy,
+struct CodexSandboxStateMeta {
+    permission_profile: CodexPermissionProfile,
     #[serde(default)]
-    pub codex_linux_sandbox_exe: Option<PathBuf>,
-    pub sandbox_cwd: PathBuf,
+    codex_linux_sandbox_exe: Option<serde_json::Value>,
+    sandbox_cwd: String,
     #[serde(default)]
-    pub use_legacy_landlock: bool,
+    use_legacy_landlock: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum CodexPermissionProfile {
+    Managed {
+        file_system: CodexManagedFileSystemPermissions,
+        network: NetworkAccess,
+    },
+    Disabled,
+    External {
+        network: NetworkAccess,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum CodexManagedFileSystemPermissions {
+    Restricted {
+        #[serde(default)]
+        entries: Vec<CodexFileSystemSandboxEntry>,
+        #[serde(default)]
+        glob_scan_max_depth: Option<usize>,
+    },
+    Unrestricted,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CodexFileSystemSandboxEntry {
+    path: CodexFileSystemPath,
+    access: CodexFileSystemAccessMode,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum CodexFileSystemAccessMode {
+    Read,
+    Write,
+    #[serde(alias = "none")]
+    Deny,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum CodexFileSystemPath {
+    Path { path: String },
+    GlobPattern { pattern: String },
+    Special { value: CodexFileSystemSpecialPath },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum CodexFileSystemSpecialPath {
+    Root,
+    Minimal,
+    ProjectRoots {
+        #[serde(default)]
+        subpath: Option<PathBuf>,
+    },
+    Tmpdir,
+    SlashTmp,
 }
 
 pub fn sandbox_state_update_from_codex_meta(
     meta: &serde_json::Value,
 ) -> Result<SandboxStateUpdate, String> {
-    if let Some(field) = codex_unsupported_sandbox_policy_field(meta) {
-        return Err(format!(
-            "Codex sandbox metadata with {field} is not supported"
-        ));
-    }
     let parsed = serde_json::from_value::<CodexSandboxStateMeta>(meta.clone())
         .map_err(|err| format!("failed to parse Codex sandbox state metadata: {err}"))?;
+    let sandbox_cwd = parse_codex_path_uri(&parsed.sandbox_cwd, "sandboxCwd")?;
 
-    if !parsed.sandbox_cwd.is_absolute() {
-        return Err(format!(
-            "Codex sandbox metadata requires an absolute sandboxCwd, got: {}",
-            parsed.sandbox_cwd.display()
-        ));
-    }
-    if let SandboxPolicy::WorkspaceWrite { writable_roots, .. } = &parsed.sandbox_policy
-        && let Some(root) = writable_roots.iter().find(|root| !root.is_absolute())
-    {
-        return Err(format!(
-            "Codex sandbox metadata requires absolute sandboxPolicy.writable_roots entries, got: {}",
-            root.display()
-        ));
-    }
+    let sandbox_policy =
+        sandbox_policy_from_codex_permission_profile(parsed.permission_profile, &sandbox_cwd)?;
+    let _ = parsed.codex_linux_sandbox_exe;
+    let _ = parsed.use_legacy_landlock;
 
     Ok(SandboxStateUpdate {
-        sandbox_policy: parsed.sandbox_policy,
-        sandbox_cwd: Some(parsed.sandbox_cwd),
+        sandbox_policy,
+        sandbox_cwd: Some(sandbox_cwd),
         // Codex reports how its own Linux helper is configured, but mcp-repl's
         // optional bwrap stage is a separate local best-effort knob.
         use_linux_sandbox_bwrap: None,
@@ -482,20 +531,339 @@ pub fn sandbox_state_update_from_codex_meta(
     })
 }
 
-fn codex_unsupported_sandbox_policy_field(meta: &serde_json::Value) -> Option<String> {
-    let policy = meta
-        .get("sandboxPolicy")
-        .and_then(serde_json::Value::as_object)?;
-    match policy.get("type").and_then(serde_json::Value::as_str) {
-        Some("workspace-write") if policy.contains_key("read_only_access") => {
-            Some("sandboxPolicy.read_only_access".to_string())
+fn parse_codex_path_uri(value: &str, field: &str) -> Result<PathBuf, String> {
+    let path = if value.starts_with("file:") {
+        let url = Url::parse(value)
+            .map_err(|err| format!("Codex sandbox metadata has invalid {field}: {err}"))?;
+        if url.scheme() != "file" {
+            return Err(format!(
+                "Codex sandbox metadata requires {field} to be a file URI, got: {value}"
+            ));
         }
-        Some("read-only") => policy
-            .keys()
-            .find(|key| key.as_str() != "type")
-            .map(|key| format!("sandboxPolicy.{key}")),
-        _ => None,
+        if !url.username().is_empty()
+            || url.password().is_some()
+            || url.port().is_some()
+            || url.query().is_some()
+            || url.fragment().is_some()
+        {
+            return Err(format!(
+                "Codex sandbox metadata {field} file URI has unsupported metadata: {value}"
+            ));
+        }
+        url.to_file_path().map_err(|_| {
+            format!("Codex sandbox metadata requires local file URI {field}, got: {value}")
+        })?
+    } else {
+        PathBuf::from(value)
+    };
+
+    if !path.is_absolute() {
+        return Err(format!(
+            "Codex sandbox metadata requires an absolute {field}, got: {}",
+            path.display()
+        ));
     }
+    Ok(path)
+}
+
+fn sandbox_policy_from_codex_permission_profile(
+    permission_profile: CodexPermissionProfile,
+    sandbox_cwd: &Path,
+) -> Result<SandboxPolicy, String> {
+    match permission_profile {
+        CodexPermissionProfile::Disabled => Ok(SandboxPolicy::DangerFullAccess),
+        CodexPermissionProfile::External { network } => Ok(SandboxPolicy::ExternalSandbox {
+            network_access: network,
+        }),
+        CodexPermissionProfile::Managed {
+            file_system,
+            network,
+        } => sandbox_policy_from_codex_managed_profile(file_system, network, sandbox_cwd),
+    }
+}
+
+fn sandbox_policy_from_codex_managed_profile(
+    file_system: CodexManagedFileSystemPermissions,
+    network: NetworkAccess,
+    sandbox_cwd: &Path,
+) -> Result<SandboxPolicy, String> {
+    let network_access = network.is_enabled();
+    match file_system {
+        CodexManagedFileSystemPermissions::Unrestricted => {
+            if network_access {
+                Ok(SandboxPolicy::DangerFullAccess)
+            } else {
+                Ok(SandboxPolicy::ExternalSandbox {
+                    network_access: NetworkAccess::Restricted,
+                })
+            }
+        }
+        CodexManagedFileSystemPermissions::Restricted {
+            entries,
+            glob_scan_max_depth,
+        } => {
+            if glob_scan_max_depth.is_some() {
+                return Err(
+                    "Codex permissionProfile.file_system.glob_scan_max_depth is not supported"
+                        .to_string(),
+                );
+            }
+            sandbox_policy_from_codex_restricted_entries(entries, network_access, sandbox_cwd)
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct RestrictedProfileProjection {
+    root_read: bool,
+    root_write: bool,
+    workspace_root_writable: bool,
+    writable_roots: Vec<PathBuf>,
+    tmpdir_writable: bool,
+    slash_tmp_writable: bool,
+    read_entries: Vec<CodexFileSystemPath>,
+}
+
+fn sandbox_policy_from_codex_restricted_entries(
+    entries: Vec<CodexFileSystemSandboxEntry>,
+    network_access: bool,
+    sandbox_cwd: &Path,
+) -> Result<SandboxPolicy, String> {
+    let mut projection = RestrictedProfileProjection::default();
+
+    for entry in entries {
+        match entry.access {
+            CodexFileSystemAccessMode::Deny => {
+                return Err(
+                    "Codex permissionProfile.file_system deny entries are not supported"
+                        .to_string(),
+                );
+            }
+            CodexFileSystemAccessMode::Read => {
+                if matches!(
+                    &entry.path,
+                    CodexFileSystemPath::Special {
+                        value: CodexFileSystemSpecialPath::Root
+                    }
+                ) {
+                    projection.root_read = true;
+                }
+                projection.read_entries.push(entry.path);
+            }
+            CodexFileSystemAccessMode::Write => {
+                project_codex_write_entry(entry.path, sandbox_cwd, &mut projection)?
+            }
+        }
+    }
+
+    if projection.root_write {
+        validate_root_write_projection(&projection)?;
+        return Ok(if network_access {
+            SandboxPolicy::DangerFullAccess
+        } else {
+            SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Restricted,
+            }
+        });
+    }
+
+    projection.writable_roots.sort();
+    projection.writable_roots.dedup();
+
+    if projection.workspace_root_writable {
+        validate_workspace_write_read_entries(&projection, sandbox_cwd)?;
+        return Ok(SandboxPolicy::WorkspaceWrite {
+            writable_roots: projection.writable_roots,
+            network_access,
+            exclude_tmpdir_env_var: !projection.tmpdir_writable,
+            exclude_slash_tmp: !projection.slash_tmp_writable,
+        });
+    }
+
+    if !projection.writable_roots.is_empty()
+        || projection.tmpdir_writable
+        || projection.slash_tmp_writable
+    {
+        return Err(
+            "Codex permissionProfile requests writes outside the workspace root, which mcp-repl cannot represent"
+                .to_string(),
+        );
+    }
+
+    if !projection.root_read {
+        return Err(
+            "Codex permissionProfile read-only policy without root read access is not supported"
+                .to_string(),
+        );
+    }
+
+    Ok(SandboxPolicy::ReadOnly { network_access })
+}
+
+fn project_codex_write_entry(
+    path: CodexFileSystemPath,
+    sandbox_cwd: &Path,
+    projection: &mut RestrictedProfileProjection,
+) -> Result<(), String> {
+    match path {
+        CodexFileSystemPath::Path { path } => {
+            let path = parse_codex_path_uri(&path, "permissionProfile.file_system.entries.path")?;
+            if path == sandbox_cwd {
+                projection.workspace_root_writable = true;
+            } else {
+                projection.writable_roots.push(path);
+            }
+        }
+        CodexFileSystemPath::Special { value } => match value {
+            CodexFileSystemSpecialPath::Root => {
+                projection.root_write = true;
+            }
+            CodexFileSystemSpecialPath::ProjectRoots { subpath: None } => {
+                projection.workspace_root_writable = true;
+            }
+            CodexFileSystemSpecialPath::ProjectRoots {
+                subpath: Some(subpath),
+            } => {
+                projection
+                    .writable_roots
+                    .push(resolve_codex_project_root_subpath(sandbox_cwd, &subpath));
+            }
+            CodexFileSystemSpecialPath::Tmpdir => {
+                projection.tmpdir_writable = true;
+            }
+            CodexFileSystemSpecialPath::SlashTmp => {
+                projection.slash_tmp_writable = true;
+            }
+            CodexFileSystemSpecialPath::Minimal => {
+                return Err(
+                    "Codex permissionProfile.file_system minimal write access is not supported"
+                        .to_string(),
+                );
+            }
+        },
+        CodexFileSystemPath::GlobPattern { pattern } => {
+            let _ = pattern;
+            return Err(
+                "Codex permissionProfile.file_system glob pattern writes are not supported"
+                    .to_string(),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn resolve_codex_project_root_subpath(sandbox_cwd: &Path, subpath: &Path) -> PathBuf {
+    if subpath.is_absolute() {
+        subpath.to_path_buf()
+    } else {
+        sandbox_cwd.join(subpath)
+    }
+}
+
+fn validate_root_write_projection(projection: &RestrictedProfileProjection) -> Result<(), String> {
+    for read_entry in &projection.read_entries {
+        if !matches!(
+            read_entry,
+            CodexFileSystemPath::Special {
+                value: CodexFileSystemSpecialPath::Root
+            }
+        ) {
+            return Err(
+                "Codex permissionProfile root write policy with read carveouts is not supported"
+                    .to_string(),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_workspace_write_read_entries(
+    projection: &RestrictedProfileProjection,
+    sandbox_cwd: &Path,
+) -> Result<(), String> {
+    for read_entry in &projection.read_entries {
+        if workspace_write_read_entry_is_representable(
+            read_entry,
+            sandbox_cwd,
+            &projection.writable_roots,
+            projection.root_read,
+        )? {
+            continue;
+        }
+        return Err(
+            "Codex permissionProfile.file_system read entry cannot be represented by mcp-repl workspace-write"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn workspace_write_read_entry_is_representable(
+    read_entry: &CodexFileSystemPath,
+    sandbox_cwd: &Path,
+    writable_roots: &[PathBuf],
+    root_read: bool,
+) -> Result<bool, String> {
+    match read_entry {
+        CodexFileSystemPath::Special {
+            value: CodexFileSystemSpecialPath::Root,
+        } => Ok(true),
+        CodexFileSystemPath::Special {
+            value: CodexFileSystemSpecialPath::ProjectRoots { subpath },
+        } => Ok(subpath
+            .as_ref()
+            .is_some_and(|subpath| is_protected_metadata_subpath(subpath))),
+        CodexFileSystemPath::Special {
+            value:
+                CodexFileSystemSpecialPath::Tmpdir
+                | CodexFileSystemSpecialPath::SlashTmp
+                | CodexFileSystemSpecialPath::Minimal,
+        } => Ok(root_read),
+        CodexFileSystemPath::Path { path } => {
+            let path = parse_codex_path_uri(path, "permissionProfile.file_system.entries.path")?;
+            if is_protected_metadata_path_under_roots(&path, sandbox_cwd, writable_roots) {
+                return Ok(true);
+            }
+            Ok(root_read && !is_under_any_root(&path, sandbox_cwd, writable_roots))
+        }
+        CodexFileSystemPath::GlobPattern { pattern } => {
+            let _ = pattern;
+            Ok(false)
+        }
+    }
+}
+
+fn is_protected_metadata_path_under_roots(
+    path: &Path,
+    sandbox_cwd: &Path,
+    writable_roots: &[PathBuf],
+) -> bool {
+    is_protected_metadata_path_under_root(path, sandbox_cwd)
+        || writable_roots
+            .iter()
+            .any(|root| is_protected_metadata_path_under_root(path, root))
+}
+
+fn is_protected_metadata_path_under_root(path: &Path, root: &Path) -> bool {
+    let Ok(suffix) = path.strip_prefix(root) else {
+        return false;
+    };
+    is_protected_metadata_subpath(suffix)
+}
+
+fn is_under_any_root(path: &Path, sandbox_cwd: &Path, writable_roots: &[PathBuf]) -> bool {
+    path.starts_with(sandbox_cwd) || writable_roots.iter().any(|root| path.starts_with(root))
+}
+
+fn is_protected_metadata_subpath(path: &Path) -> bool {
+    let mut components = path.components();
+    let Some(first) = components.next() else {
+        return false;
+    };
+    matches!(
+        first.as_os_str().to_str(),
+        Some(".git" | ".agents" | ".codex")
+    )
 }
 
 impl SandboxState {
@@ -731,11 +1099,11 @@ pub fn prepare_worker_command_with_managed_network(
         let mut policy = state.sandbox_policy.clone();
         let mut policy_cwd = state.sandbox_cwd.clone();
         match &mut policy {
-            SandboxPolicy::ReadOnly => {
+            SandboxPolicy::ReadOnly { network_access } => {
                 let temp_root = state.session_temp_dir.clone();
                 policy = SandboxPolicy::WorkspaceWrite {
                     writable_roots: vec![temp_root.clone()],
-                    network_access: false,
+                    network_access: *network_access,
                     exclude_tmpdir_env_var: true,
                     exclude_slash_tmp: true,
                 };
@@ -886,7 +1254,9 @@ fn sanitize_linux_sandbox_policy(policy: &SandboxPolicy) -> SandboxPolicy {
             network_access: *network_access,
         },
         SandboxPolicy::DangerFullAccess => SandboxPolicy::DangerFullAccess,
-        SandboxPolicy::ReadOnly => SandboxPolicy::ReadOnly,
+        SandboxPolicy::ReadOnly { network_access } => SandboxPolicy::ReadOnly {
+            network_access: *network_access,
+        },
     }
 }
 
@@ -2828,13 +3198,84 @@ mod tests {
     }
 
     #[test]
+    fn codex_sandbox_state_meta_parses_current_permission_profile_payload() {
+        let sandbox_cwd = std::env::temp_dir().join("mcp-repl-codex-meta-cwd");
+        let sandbox_cwd_uri = url::Url::from_file_path(&sandbox_cwd)
+            .expect("absolute sandbox cwd should convert to file URI")
+            .to_string();
+
+        let update = sandbox_state_update_from_codex_meta(&json!({
+            "permissionProfile": {
+                "type": "managed",
+                "file_system": {
+                    "type": "restricted",
+                    "entries": [
+                        {
+                            "path": {
+                                "type": "special",
+                                "value": { "kind": "root" }
+                            },
+                            "access": "read"
+                        },
+                        {
+                            "path": {
+                                "type": "special",
+                                "value": { "kind": "project_roots" }
+                            },
+                            "access": "write"
+                        },
+                        {
+                            "path": {
+                                "type": "special",
+                                "value": { "kind": "tmpdir" }
+                            },
+                            "access": "write"
+                        },
+                        {
+                            "path": {
+                                "type": "special",
+                                "value": { "kind": "slash_tmp" }
+                            },
+                            "access": "write"
+                        }
+                    ]
+                },
+                "network": "restricted"
+            },
+            "sandboxCwd": sandbox_cwd_uri,
+            "useLegacyLandlock": false,
+            "codexLinuxSandboxExe": if cfg!(target_os = "linux") {
+                serde_json::Value::String("/tmp/codex-linux-sandbox".to_string())
+            } else {
+                serde_json::Value::Null
+            },
+        }))
+        .expect("current Codex sandbox metadata");
+
+        assert_eq!(
+            update.sandbox_policy,
+            SandboxPolicy::WorkspaceWrite {
+                writable_roots: Vec::new(),
+                network_access: false,
+                exclude_tmpdir_env_var: false,
+                exclude_slash_tmp: false,
+            }
+        );
+        assert_eq!(update.sandbox_cwd, Some(sandbox_cwd));
+        assert!(update.use_linux_sandbox_bwrap.is_none());
+    }
+
+    #[test]
     fn codex_sandbox_state_meta_does_not_force_internal_linux_bwrap() {
         let sandbox_cwd = std::env::temp_dir().join("mcp-repl-codex-meta-cwd");
+        let sandbox_cwd_uri = url::Url::from_file_path(&sandbox_cwd)
+            .expect("absolute sandbox cwd should convert to file URI")
+            .to_string();
         let update = sandbox_state_update_from_codex_meta(&json!({
-            "sandboxPolicy": {
-                "type": "danger-full-access"
+            "permissionProfile": {
+                "type": "disabled"
             },
-            "sandboxCwd": sandbox_cwd,
+            "sandboxCwd": sandbox_cwd_uri,
             "useLegacyLandlock": false,
             "codexLinuxSandboxExe": if cfg!(target_os = "linux") {
                 serde_json::Value::String("/tmp/codex-linux-sandbox".to_string())
@@ -2853,15 +3294,41 @@ mod tests {
     #[test]
     fn codex_sandbox_state_meta_rejects_relative_workspace_write_roots() {
         let sandbox_cwd = std::env::temp_dir().join("mcp-repl-codex-meta-cwd");
+        let sandbox_cwd_uri = url::Url::from_file_path(&sandbox_cwd)
+            .expect("absolute sandbox cwd should convert to file URI")
+            .to_string();
         let err = sandbox_state_update_from_codex_meta(&json!({
-            "sandboxPolicy": {
-                "type": "workspace-write",
-                "writable_roots": ["relative-root"],
-                "network_access": false,
-                "exclude_tmpdir_env_var": false,
-                "exclude_slash_tmp": false
+            "permissionProfile": {
+                "type": "managed",
+                "file_system": {
+                    "type": "restricted",
+                    "entries": [
+                        {
+                            "path": {
+                                "type": "special",
+                                "value": { "kind": "root" }
+                            },
+                            "access": "read"
+                        },
+                        {
+                            "path": {
+                                "type": "special",
+                                "value": { "kind": "project_roots" }
+                            },
+                            "access": "write"
+                        },
+                        {
+                            "path": {
+                                "type": "path",
+                                "path": "relative-root"
+                            },
+                            "access": "write"
+                        }
+                    ]
+                },
+                "network": "restricted"
             },
-            "sandboxCwd": sandbox_cwd,
+            "sandboxCwd": sandbox_cwd_uri,
             "useLegacyLandlock": false,
             "codexLinuxSandboxExe": if cfg!(target_os = "linux") {
                 serde_json::Value::String("/tmp/codex-linux-sandbox".to_string())
@@ -2872,8 +3339,8 @@ mod tests {
         .expect_err("relative writable roots should fail closed");
 
         assert!(
-            err.contains("sandboxPolicy.writable_roots"),
-            "expected writable_roots validation error, got: {err}"
+            err.contains("permissionProfile.file_system.entries.path"),
+            "expected path validation error, got: {err}"
         );
         assert!(
             err.contains("relative-root"),

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -509,6 +509,9 @@ enum CodexFileSystemSpecialPath {
     SlashTmp,
 }
 
+const CODEX_FULL_WRITE_RESTRICTED_NETWORK_ERROR: &str =
+    "Codex permissionProfile full write access with restricted network access is not supported";
+
 pub fn sandbox_state_update_from_codex_meta(
     meta: &serde_json::Value,
 ) -> Result<SandboxStateUpdate, String> {
@@ -593,9 +596,7 @@ fn sandbox_policy_from_codex_managed_profile(
             if network_access {
                 Ok(SandboxPolicy::DangerFullAccess)
             } else {
-                Ok(SandboxPolicy::ExternalSandbox {
-                    network_access: NetworkAccess::Restricted,
-                })
+                Err(CODEX_FULL_WRITE_RESTRICTED_NETWORK_ERROR.to_string())
             }
         }
         CodexManagedFileSystemPermissions::Restricted {
@@ -658,13 +659,10 @@ fn sandbox_policy_from_codex_restricted_entries(
 
     if projection.root_write {
         validate_root_write_projection(&projection)?;
-        return Ok(if network_access {
-            SandboxPolicy::DangerFullAccess
-        } else {
-            SandboxPolicy::ExternalSandbox {
-                network_access: NetworkAccess::Restricted,
-            }
-        });
+        if !network_access {
+            return Err(CODEX_FULL_WRITE_RESTRICTED_NETWORK_ERROR.to_string());
+        }
+        return Ok(SandboxPolicy::DangerFullAccess);
     }
 
     projection.writable_roots.sort();

--- a/src/sandbox_cli.rs
+++ b/src/sandbox_cli.rs
@@ -81,7 +81,7 @@ enum SandboxValidationMode {
 impl SandboxValidationMode {
     fn from_policy(policy: &SandboxPolicy) -> Self {
         match policy {
-            SandboxPolicy::ReadOnly => Self::ReadOnly,
+            SandboxPolicy::ReadOnly { .. } => Self::ReadOnly,
             SandboxPolicy::WorkspaceWrite { .. } => Self::WorkspaceWrite,
             SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. } => {
                 Self::DangerFullAccess
@@ -383,7 +383,9 @@ fn apply_mode(
         }
         SandboxModeArg::ReadOnly => {
             *state = defaults.clone();
-            state.sandbox_policy = SandboxPolicy::ReadOnly;
+            state.sandbox_policy = SandboxPolicy::ReadOnly {
+                network_access: false,
+            };
         }
         SandboxModeArg::WorkspaceWrite => {
             *state = defaults.clone();

--- a/src/windows_sandbox.rs
+++ b/src/windows_sandbox.rs
@@ -562,8 +562,9 @@ fn stable_cap_sid_string(policy: &SandboxPolicy, sandbox_policy_cwd: &Path) -> S
     let canonical_cwd = canonicalize_or_identity(sandbox_policy_cwd);
     let stable_cwd = stable_sid_seed_path_buf(canonical_cwd.clone());
     let policy_seed = match policy {
-        SandboxPolicy::ReadOnly => serde_json::json!({
+        SandboxPolicy::ReadOnly { network_access } => serde_json::json!({
             "mode": "read-only",
+            "network_access": network_access,
         }),
         SandboxPolicy::WorkspaceWrite {
             writable_roots,
@@ -748,7 +749,7 @@ fn stable_sid_word(bytes: &[u8], seed: u32) -> u32 {
 
 fn validate_windows_policy(policy: &SandboxPolicy) -> Result<(), String> {
     match policy {
-        SandboxPolicy::ReadOnly | SandboxPolicy::WorkspaceWrite { .. } => Ok(()),
+        SandboxPolicy::ReadOnly { .. } | SandboxPolicy::WorkspaceWrite { .. } => Ok(()),
         SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. } => {
             Err("windows sandbox runner only supports read-only/workspace-write".to_string())
         }
@@ -3734,7 +3735,9 @@ mod tests {
 
     #[test]
     fn applies_network_block_for_read_only() {
-        assert!(should_apply_network_block(&SandboxPolicy::ReadOnly));
+        assert!(should_apply_network_block(&SandboxPolicy::ReadOnly {
+            network_access: false,
+        }));
     }
 
     #[test]
@@ -3973,7 +3976,9 @@ mod tests {
         let mut env_map = HashMap::new();
         env_map.insert("TEMP".to_string(), temp_dir.to_string_lossy().to_string());
         let paths = compute_allow_deny_paths(
-            &SandboxPolicy::ReadOnly,
+            &SandboxPolicy::ReadOnly {
+                network_access: false,
+            },
             &command_cwd,
             &command_cwd,
             Some(&session_temp_dir),
@@ -4067,7 +4072,12 @@ mod tests {
             stable_cap_sid_string(&workspace_policy(Vec::new(), false, false), &cwd_a);
         let workspace_b =
             stable_cap_sid_string(&workspace_policy(Vec::new(), false, false), &cwd_b);
-        let readonly_a = stable_cap_sid_string(&SandboxPolicy::ReadOnly, &cwd_a);
+        let readonly_a = stable_cap_sid_string(
+            &SandboxPolicy::ReadOnly {
+                network_access: false,
+            },
+            &cwd_a,
+        );
 
         assert_ne!(workspace_a, workspace_b);
         assert_ne!(workspace_a, readonly_a);

--- a/src/worker_process/worker_launch.rs
+++ b/src/worker_process/worker_launch.rs
@@ -346,15 +346,49 @@ mod tests {
         );
         assert!(retry, "expected startup failure to disable bwrap");
 
+        let sandbox_cwd = std::env::temp_dir();
+        let sandbox_cwd_uri = url::Url::from_file_path(&sandbox_cwd)
+            .expect("absolute sandbox cwd should convert to file URI")
+            .to_string();
         let update = sandbox_state_update_from_codex_meta(&json!({
-            "sandboxPolicy": {
-                "type": "workspace-write",
-                "writable_roots": [],
-                "network_access": false,
-                "exclude_tmpdir_env_var": false,
-                "exclude_slash_tmp": false
+            "permissionProfile": {
+                "type": "managed",
+                "file_system": {
+                    "type": "restricted",
+                    "entries": [
+                        {
+                            "path": {
+                                "type": "special",
+                                "value": { "kind": "root" }
+                            },
+                            "access": "read"
+                        },
+                        {
+                            "path": {
+                                "type": "special",
+                                "value": { "kind": "project_roots" }
+                            },
+                            "access": "write"
+                        },
+                        {
+                            "path": {
+                                "type": "special",
+                                "value": { "kind": "tmpdir" }
+                            },
+                            "access": "write"
+                        },
+                        {
+                            "path": {
+                                "type": "special",
+                                "value": { "kind": "slash_tmp" }
+                            },
+                            "access": "write"
+                        }
+                    ]
+                },
+                "network": "restricted"
             },
-            "sandboxCwd": std::env::temp_dir(),
+            "sandboxCwd": sandbox_cwd_uri,
             "useLegacyLandlock": false,
             "codexLinuxSandboxExe": "/tmp/codex-linux-sandbox"
         }))
@@ -417,15 +451,49 @@ mod tests {
         );
         assert!(retry, "expected startup failure to disable bwrap");
 
+        let sandbox_cwd = std::env::temp_dir();
+        let sandbox_cwd_uri = url::Url::from_file_path(&sandbox_cwd)
+            .expect("absolute sandbox cwd should convert to file URI")
+            .to_string();
         let update = sandbox_state_update_from_codex_meta(&json!({
-            "sandboxPolicy": {
-                "type": "workspace-write",
-                "writable_roots": [],
-                "network_access": false,
-                "exclude_tmpdir_env_var": false,
-                "exclude_slash_tmp": false
+            "permissionProfile": {
+                "type": "managed",
+                "file_system": {
+                    "type": "restricted",
+                    "entries": [
+                        {
+                            "path": {
+                                "type": "special",
+                                "value": { "kind": "root" }
+                            },
+                            "access": "read"
+                        },
+                        {
+                            "path": {
+                                "type": "special",
+                                "value": { "kind": "project_roots" }
+                            },
+                            "access": "write"
+                        },
+                        {
+                            "path": {
+                                "type": "special",
+                                "value": { "kind": "tmpdir" }
+                            },
+                            "access": "write"
+                        },
+                        {
+                            "path": {
+                                "type": "special",
+                                "value": { "kind": "slash_tmp" }
+                            },
+                            "access": "write"
+                        }
+                    ]
+                },
+                "network": "restricted"
             },
-            "sandboxCwd": std::env::temp_dir(),
+            "sandboxCwd": sandbox_cwd_uri,
             "useLegacyLandlock": false,
             "codexLinuxSandboxExe": "/tmp/codex-linux-sandbox"
         }))

--- a/src/worker_process/write_flow.rs
+++ b/src/worker_process/write_flow.rs
@@ -602,7 +602,9 @@ mod tests {
             .expect("worker manager");
         manager
             .stage_sandbox_state_update(SandboxStateUpdate {
-                sandbox_policy: SandboxPolicy::ReadOnly,
+                sandbox_policy: SandboxPolicy::ReadOnly {
+                    network_access: false,
+                },
                 sandbox_cwd: None,
                 use_linux_sandbox_bwrap: None,
                 use_legacy_landlock: None,
@@ -641,7 +643,9 @@ mod tests {
             .expect("worker manager");
         manager
             .stage_sandbox_state_update(SandboxStateUpdate {
-                sandbox_policy: SandboxPolicy::ReadOnly,
+                sandbox_policy: SandboxPolicy::ReadOnly {
+                    network_access: false,
+                },
                 sandbox_cwd: None,
                 use_linux_sandbox_bwrap: None,
                 use_legacy_landlock: None,
@@ -687,7 +691,9 @@ mod tests {
             .expect("worker manager");
         manager
             .stage_sandbox_state_update(SandboxStateUpdate {
-                sandbox_policy: SandboxPolicy::ReadOnly,
+                sandbox_policy: SandboxPolicy::ReadOnly {
+                    network_access: false,
+                },
                 sandbox_cwd: Some(sandbox_cwd.clone()),
                 use_linux_sandbox_bwrap: None,
                 use_legacy_landlock: None,

--- a/tests/codex_integration.rs
+++ b/tests/codex_integration.rs
@@ -2038,22 +2038,6 @@ tryCatch({
                         path.push(normalized_key.clone());
                         normalize_inner(&mut child, path, workspace, codex_home);
                         path.pop();
-                        if path_matches(path, &["sandboxPolicy"])
-                            && normalized_key == "writable_roots"
-                            && matches!(
-                                &child,
-                                Value::Array(items)
-                                    if items.iter().all(|item| {
-                                        matches!(
-                                            item.as_str(),
-                                            Some("<CODEX_HOME>/memories")
-                                                | Some("<CODEX_HOME>\\memories")
-                                        )
-                                    })
-                            )
-                        {
-                            continue;
-                        }
                         map.insert(normalized_key, child);
                     }
                     if path_matches(path, &["capabilities", "elicitation"]) && map.is_empty() {
@@ -2206,15 +2190,26 @@ tryCatch({
     }
 
     #[test]
-    fn normalize_wire_snapshot_drops_default_codex_memories_writable_root() {
+    fn normalize_wire_snapshot_drops_permission_profile() {
         let workspace = std::env::temp_dir().join("mcp-repl-wire-workspace");
         let codex_home = std::env::temp_dir().join("mcp-repl-wire-codex-home");
         let memories = codex_home.join("memories");
         let mut value = serde_json::json!({
-            "sandboxPolicy": {
-                "type": "workspace-write",
-                "writable_roots": [memories],
-                "network_access": false
+            "permissionProfile": {
+                "type": "managed",
+                "file_system": {
+                    "type": "restricted",
+                    "entries": [
+                        {
+                            "path": {
+                                "type": "path",
+                                "path": memories
+                            },
+                            "access": "write"
+                        }
+                    ]
+                },
+                "network": "restricted"
             }
         });
 
@@ -2222,39 +2217,8 @@ tryCatch({
 
         assert_eq!(
             value,
-            serde_json::json!({
-                "sandboxPolicy": {
-                    "type": "workspace-write",
-                    "network_access": false
-                }
-            }),
-            "wire snapshots should not retain Codex's default memories writable root"
-        );
-    }
-
-    #[test]
-    fn normalize_wire_snapshot_drops_windows_default_codex_memories_writable_root() {
-        let workspace = std::env::temp_dir().join("mcp-repl-wire-workspace");
-        let codex_home = std::env::temp_dir().join("mcp-repl-wire-codex-home");
-        let mut value = serde_json::json!({
-            "sandboxPolicy": {
-                "type": "workspace-write",
-                "writable_roots": ["<CODEX_HOME>\\memories"],
-                "network_access": false
-            }
-        });
-
-        normalize_wire_snapshot_value(&mut value, &workspace, &codex_home);
-
-        assert_eq!(
-            value,
-            serde_json::json!({
-                "sandboxPolicy": {
-                    "type": "workspace-write",
-                    "network_access": false
-                }
-            }),
-            "wire snapshots should not retain Codex's default memories writable root with Windows separators"
+            serde_json::json!({}),
+            "wire snapshots should not retain Codex's full permission profile"
         );
     }
 

--- a/tests/sandbox_state_meta.rs
+++ b/tests/sandbox_state_meta.rs
@@ -150,6 +150,16 @@ fn managed_profile(entries: Vec<Value>, network: &str) -> Value {
     })
 }
 
+fn managed_unrestricted_profile(network: &str) -> Value {
+    json!({
+        "type": "managed",
+        "file_system": {
+            "type": "unrestricted",
+        },
+        "network": network,
+    })
+}
+
 fn workspace_write_profile() -> Value {
     managed_profile(
         vec![
@@ -218,6 +228,25 @@ fn read_only_restricted_access_meta(sandbox_cwd: &Path) -> Value {
 fn read_only_network_access_meta(sandbox_cwd: &Path) -> Value {
     codex_sandbox_state_meta(
         managed_profile(vec![root_read_entry()], "enabled"),
+        sandbox_cwd,
+        false,
+    )
+}
+
+fn full_write_network_restricted_meta(sandbox_cwd: &Path) -> Value {
+    codex_sandbox_state_meta(
+        managed_unrestricted_profile("restricted"),
+        sandbox_cwd,
+        false,
+    )
+}
+
+fn root_write_network_restricted_meta(sandbox_cwd: &Path) -> Value {
+    codex_sandbox_state_meta(
+        managed_profile(
+            vec![root_read_entry(), special_entry("root", "write")],
+            "restricted",
+        ),
         sandbox_cwd,
         false,
     )
@@ -2587,6 +2616,68 @@ async fn sandbox_inherit_rejects_restricted_read_only_meta() -> TestResult<()> {
     assert!(
         !text.contains("[1] 2"),
         "did not expect input to run after unsupported restricted read-only metadata, got: {text}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sandbox_inherit_rejects_full_write_network_restricted_meta() -> TestResult<()> {
+    let _guard = test_guard();
+    let temp = tempdir()?;
+    let session = spawn_inherit_server(temp.path()).await?;
+    let result = session
+        .write_stdin_raw_with_meta(
+            "1+1",
+            Some(2.0),
+            Some(full_write_network_restricted_meta(temp.path())),
+        )
+        .await?;
+    let text = collect_text(&result);
+    session.cancel().await?;
+
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "expected full-write restricted-network metadata to be reported as an MCP tool error"
+    );
+    assert!(
+        text.contains("full write access with restricted network access is not supported"),
+        "expected full-write restricted-network metadata rejection, got: {text}"
+    );
+    assert!(
+        !text.contains("[1] 2"),
+        "did not expect input to run after unsupported full-write restricted-network metadata, got: {text}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sandbox_inherit_rejects_root_write_network_restricted_meta() -> TestResult<()> {
+    let _guard = test_guard();
+    let temp = tempdir()?;
+    let session = spawn_inherit_server(temp.path()).await?;
+    let result = session
+        .write_stdin_raw_with_meta(
+            "1+1",
+            Some(2.0),
+            Some(root_write_network_restricted_meta(temp.path())),
+        )
+        .await?;
+    let text = collect_text(&result);
+    session.cancel().await?;
+
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "expected root-write restricted-network metadata to be reported as an MCP tool error"
+    );
+    assert!(
+        text.contains("full write access with restricted network access is not supported"),
+        "expected root-write restricted-network metadata rejection, got: {text}"
+    );
+    assert!(
+        !text.contains("[1] 2"),
+        "did not expect input to run after unsupported root-write restricted-network metadata, got: {text}"
     );
     Ok(())
 }

--- a/tests/sandbox_state_meta.rs
+++ b/tests/sandbox_state_meta.rs
@@ -84,14 +84,21 @@ fn linux_sandbox_exe_value(use_legacy_landlock: bool) -> Value {
     }
 }
 
+fn sandbox_cwd_uri(sandbox_cwd: &Path) -> String {
+    url::Url::from_file_path(sandbox_cwd)
+        .map(|url| url.to_string())
+        .unwrap_or_else(|_| panic!("failed to convert {} to file URI", sandbox_cwd.display()))
+}
+
 fn codex_sandbox_state_meta(
-    sandbox_policy: Value,
+    permission_profile: Value,
     sandbox_cwd: &Path,
     use_legacy_landlock: bool,
 ) -> Value {
+    let sandbox_cwd = sandbox_cwd_uri(sandbox_cwd);
     json!({
         SANDBOX_STATE_META_CAPABILITY: {
-            "sandboxPolicy": sandbox_policy,
+            "permissionProfile": permission_profile,
             "sandboxCwd": sandbox_cwd,
             "useLegacyLandlock": use_legacy_landlock,
             "codexLinuxSandboxExe": linux_sandbox_exe_value(use_legacy_landlock),
@@ -99,15 +106,68 @@ fn codex_sandbox_state_meta(
     })
 }
 
+fn root_read_entry() -> Value {
+    json!({
+        "path": {
+            "type": "special",
+            "value": { "kind": "root" }
+        },
+        "access": "read"
+    })
+}
+
+fn special_entry(kind: &str, access: &str) -> Value {
+    json!({
+        "path": {
+            "type": "special",
+            "value": { "kind": kind }
+        },
+        "access": access
+    })
+}
+
+fn protected_project_entry(subpath: &str) -> Value {
+    json!({
+        "path": {
+            "type": "special",
+            "value": {
+                "kind": "project_roots",
+                "subpath": subpath
+            }
+        },
+        "access": "read"
+    })
+}
+
+fn managed_profile(entries: Vec<Value>, network: &str) -> Value {
+    json!({
+        "type": "managed",
+        "file_system": {
+            "type": "restricted",
+            "entries": entries,
+        },
+        "network": network,
+    })
+}
+
+fn workspace_write_profile() -> Value {
+    managed_profile(
+        vec![
+            root_read_entry(),
+            special_entry("project_roots", "write"),
+            special_entry("tmpdir", "write"),
+            special_entry("slash_tmp", "write"),
+            protected_project_entry(".git"),
+            protected_project_entry(".agents"),
+            protected_project_entry(".codex"),
+        ],
+        "restricted",
+    )
+}
+
 fn workspace_write_meta(sandbox_cwd: &Path) -> Value {
     codex_sandbox_state_meta(
-        json!({
-            "type": "workspace-write",
-            "writable_roots": [],
-            "network_access": false,
-            "exclude_tmpdir_env_var": false,
-            "exclude_slash_tmp": false,
-        }),
+        workspace_write_profile(),
         sandbox_cwd,
         /*use_legacy_landlock*/ false,
     )
@@ -115,33 +175,41 @@ fn workspace_write_meta(sandbox_cwd: &Path) -> Value {
 
 fn workspace_write_restricted_read_meta(sandbox_cwd: &Path) -> Value {
     codex_sandbox_state_meta(
-        json!({
-            "type": "workspace-write",
-            "writable_roots": [],
-            "network_access": false,
-            "exclude_tmpdir_env_var": false,
-            "exclude_slash_tmp": false,
-            "read_only_access": {
-                "mode": "read-only",
-            },
-        }),
+        managed_profile(
+            vec![
+                root_read_entry(),
+                special_entry("project_roots", "write"),
+                special_entry("tmpdir", "write"),
+                special_entry("slash_tmp", "write"),
+                json!({
+                    "path": {
+                        "type": "special",
+                        "value": {
+                            "kind": "project_roots",
+                            "subpath": "restricted"
+                        }
+                    },
+                    "access": "read"
+                }),
+            ],
+            "restricted",
+        ),
         sandbox_cwd,
         /*use_legacy_landlock*/ false,
     )
 }
 
 fn read_only_meta(sandbox_cwd: &Path) -> Value {
-    codex_sandbox_state_meta(json!({"type": "read-only"}), sandbox_cwd, false)
+    codex_sandbox_state_meta(
+        managed_profile(vec![root_read_entry()], "restricted"),
+        sandbox_cwd,
+        false,
+    )
 }
 
 fn read_only_restricted_access_meta(sandbox_cwd: &Path) -> Value {
     codex_sandbox_state_meta(
-        json!({
-            "type": "read-only",
-            "access": {
-                "mode": "read-only",
-            },
-        }),
+        managed_profile(Vec::new(), "restricted"),
         sandbox_cwd,
         false,
     )
@@ -149,17 +217,14 @@ fn read_only_restricted_access_meta(sandbox_cwd: &Path) -> Value {
 
 fn read_only_network_access_meta(sandbox_cwd: &Path) -> Value {
     codex_sandbox_state_meta(
-        json!({
-            "type": "read-only",
-            "network_access": true,
-        }),
+        managed_profile(vec![root_read_entry()], "enabled"),
         sandbox_cwd,
         false,
     )
 }
 
 fn full_access_meta(sandbox_cwd: &Path) -> Value {
-    codex_sandbox_state_meta(json!({"type": "danger-full-access"}), sandbox_cwd, false)
+    codex_sandbox_state_meta(json!({"type": "disabled"}), sandbox_cwd, false)
 }
 
 fn encode_path(path: &Path) -> TestResult<String> {
@@ -2481,7 +2546,7 @@ async fn sandbox_inherit_rejects_restricted_read_workspace_write_meta() -> TestR
         "expected restricted read metadata to be reported as an MCP tool error"
     );
     assert!(
-        text.contains("read_only_access"),
+        text.contains("read entry cannot be represented"),
         "expected restricted read metadata rejection, got: {text}"
     );
     assert!(
@@ -2516,7 +2581,7 @@ async fn sandbox_inherit_rejects_restricted_read_only_meta() -> TestResult<()> {
         "expected restricted read-only metadata to be reported as an MCP tool error"
     );
     assert!(
-        text.contains("access"),
+        text.contains("without root read access"),
         "expected restricted read-only metadata rejection, got: {text}"
     );
     assert!(
@@ -2527,7 +2592,7 @@ async fn sandbox_inherit_rejects_restricted_read_only_meta() -> TestResult<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn sandbox_inherit_rejects_read_only_network_access_meta() -> TestResult<()> {
+async fn sandbox_inherit_accepts_read_only_network_access_meta() -> TestResult<()> {
     let _guard = test_guard();
     let temp = tempdir()?;
     let session = spawn_inherit_server(temp.path()).await?;
@@ -2547,16 +2612,12 @@ async fn sandbox_inherit_rejects_read_only_network_access_meta() -> TestResult<(
     }
     assert_eq!(
         result.is_error,
-        Some(true),
-        "expected read-only network metadata to be reported as an MCP tool error"
+        Some(false),
+        "expected read-only network metadata to be accepted"
     );
     assert!(
-        text.contains("network_access"),
-        "expected read-only network metadata rejection, got: {text}"
-    );
-    assert!(
-        !text.contains("[1] 2"),
-        "did not expect input to run after unsupported read-only network metadata, got: {text}"
+        text.contains("[1] 2"),
+        "expected input to run after read-only network metadata, got: {text}"
     );
     Ok(())
 }

--- a/tests/snapshots/codex_integration__linux__codex_exec_wire_sandbox_state_meta.snap
+++ b/tests/snapshots/codex_integration__linux__codex_exec_wire_sandbox_state_meta.snap
@@ -34,14 +34,8 @@ expression: snapshot
             "sandbox": "<SANDBOX_BACKEND>"
           },
           "codex/sandbox-state-meta": {
-            "sandboxPolicy": {
-              "type": "workspace-write",
-              "network_access": false,
-              "exclude_tmpdir_env_var": false,
-              "exclude_slash_tmp": false
-            },
             "codexLinuxSandboxExe": "<CODEX_LINUX_SANDBOX_EXE>",
-            "sandboxCwd": "<WORKSPACE>",
+            "sandboxCwd": "file://<WORKSPACE>",
             "useLegacyLandlock": false
           }
         },

--- a/tests/snapshots/codex_integration__macos__codex_exec_wire_sandbox_state_meta.snap
+++ b/tests/snapshots/codex_integration__macos__codex_exec_wire_sandbox_state_meta.snap
@@ -33,14 +33,8 @@ expression: snapshot
             "sandbox": "<SANDBOX_BACKEND>"
           },
           "codex/sandbox-state-meta": {
-            "sandboxPolicy": {
-              "type": "workspace-write",
-              "network_access": false,
-              "exclude_tmpdir_env_var": false,
-              "exclude_slash_tmp": false
-            },
             "codexLinuxSandboxExe": null,
-            "sandboxCwd": "<WORKSPACE>",
+            "sandboxCwd": "file://<WORKSPACE>",
             "useLegacyLandlock": false
           }
         },


### PR DESCRIPTION
## Summary
- Normalizes how sandbox state metadata is carried through worker launch and write flows so the server can apply the intended sandbox policy reliably.
- Updates sandbox documentation and CLI handling to reflect the payload format more clearly and keep platform behavior aligned.
- Adjusts Windows sandbox handling and worker-side plumbing to accept the revised payload shape without special-case drift.
- Refreshes integration and snapshot coverage for sandbox state metadata on Linux and macOS.

## Notes
- The user-facing effect is more consistent sandbox behavior and clearer metadata propagation during REPL startup and subsequent writes.
- Most of the change is internal plumbing; the public surface changes are limited to documentation and the way sandbox state metadata is represented in the wire path.