### PR TITLE
Rework Linux sandbox around permission profiles

### DIFF
--- a/docs/futurework/claude-sandbox-inherit.md
+++ b/docs/futurework/claude-sandbox-inherit.md
@@ -21,7 +21,8 @@ Minimal task:
 - Claude install currently writes `.claude.json` MCP server entries and updates
   `.claude/settings.json` permissions so Claude can call the generated tools.
 - Claude install uses an explicit `mcp-repl` sandbox mode because Claude does
-  not send Codex-style per-tool-call sandbox metadata to MCP servers.
+  not send `_meta["codex/sandbox-state-meta"]` per-tool-call sandbox metadata to
+  MCP servers.
 - Claude's public settings shape is JSON, not TOML. Project settings live under
   `.claude/settings.json` and `.claude/settings.local.json`, and sandbox options
   are nested under `sandbox`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ checked-in execution plans without relying on stale notes.
   contract.
 - `docs/plans/AGENTS.md`: when to write a checked-in execution plan and where it lives.
 - `docs/plans/completed/codex-sandbox-state-meta-migration.md`: completed plan for migrating Codex `--sandbox inherit` from async updates to per-tool-call sandbox metadata.
+- `docs/plans/completed/linux-permission-profile-sandbox.md`: completed plan for replacing Linux sandbox internals with permission-profile metadata and helper-backed enforcement.
 
 ## Normative Docs
 

--- a/docs/plans/completed/linux-permission-profile-sandbox.md
+++ b/docs/plans/completed/linux-permission-profile-sandbox.md
@@ -1,0 +1,66 @@
+# Linux Permission-Profile Sandbox
+
+## Summary
+
+- Rework `mcp-repl` sandbox internals so Linux behavior uses permission-profile metadata and a helper-backed enforcement path.
+- Preserve the CLI arguments `mcp-repl` already accepts (`--sandbox`, `--add-writable-root`, `--add-allowed-domain`, and supported `--config` keys), but treat old `read-only`, `workspace-write`, and `danger-full-access` modes as inputs that compile into permission profiles.
+- Optimize for Linux first. macOS and Windows compatibility shims may remain behind existing cfg boundaries, but they should not constrain the Linux design.
+
+## Status
+
+- State: completed
+- Last updated: 2026-06-23
+- Current phase: complete
+
+## Current Direction
+
+- Replace the internal Linux authority model with `PermissionProfile`, `FileSystemSandboxPolicy`, `FileSystemSandboxEntry`, `FileSystemPath`, and `NetworkSandboxPolicy`.
+- Parse current per-tool-call sandbox metadata by accepting `permissionProfile` as canonical. Legacy `sandboxPolicy` may remain only as a minimal compatibility input and should immediately compile into a permission profile.
+- Launch Linux workers through a `codex-linux-sandbox` arg0-compatible helper surface that accepts `--permission-profile`, applies bubblewrap by default, applies seccomp after bubblewrap, and keeps legacy Landlock only as an explicit fallback knob.
+
+## Long-Term Direction
+
+- The durable sandbox contract should be permission-profile based across CLI, MCP metadata, tests, and docs.
+- The legacy `SandboxPolicy` enum should become a thin CLI/config compatibility adapter, not the shape used for Linux enforcement or inherited metadata.
+- Claude Code support should map Claude sandbox settings into the same permission-profile model rather than adding another runtime policy representation.
+
+## Phase Status
+
+- Phase 0: completed - inspected the existing `mcp-repl` sandbox implementation.
+- Phase 1: completed - introduced permission-profile policy types and updated Linux launch/metadata translation.
+- Phase 2: completed - revised focused tests and docs around the new policy shape.
+- Phase 3: completed - ran required checks and fixed fallout.
+
+## Locked Decisions
+
+- `permissionProfile` is the canonical inherited metadata field.
+- Missing inherited metadata remains fail-closed for `--sandbox inherit`.
+- `mcp-repl` keeps its existing CLI arguments, but backwards compatibility for older internal JSON/log/snapshot shapes is not a goal.
+- Linux filesystem isolation should prefer bubblewrap; Landlock-only filesystem enforcement is legacy fallback behavior.
+- The session temp directory remains server-owned and is added to the effective writable set for worker runtime needs.
+- `useLegacyLandlock=false` from inherited metadata is not a local bubblewrap override; only `true` forces the legacy path.
+- Restricted-read profiles require the bubblewrap backend for exact read enforcement. Legacy Landlock fallback broadens reads while still enforcing writable roots.
+- When running inside a restricted parent sandbox environment, default Linux startup avoids spawning a trial `bwrap` probe and starts with the legacy fallback path unless `MCP_REPL_USE_LINUX_BWRAP=1` explicitly requests bubblewrap.
+
+## Open Questions
+
+- How much Claude sandbox configuration should be mapped in this change versus documented as follow-up after this Linux sandbox change lands.
+- Whether `mcp-repl` should later adopt protected-create handling for missing `.git`, `.codex`, and `.agents` paths under bubblewrap writable roots.
+
+## Completion Notes
+
+- Implemented the Linux permission-profile runtime model and helper launch path.
+- Updated sandbox metadata tests, docs, and verification coverage.
+- Completed the repository verification required by `AGENTS.md`.
+
+## Stop Conditions
+
+- Stop and ask before broadening the task into non-Linux sandbox behavior changes.
+- Stop if an inherited metadata or helper semantic cannot be represented without changing the public `repl`/`repl_reset` MCP API.
+
+## Decision Log
+
+- 2026-06-23: Chose permission profiles as the internal policy model because current metadata and Linux helper code both use that shape directly.
+- 2026-06-23: Chose a Linux-first implementation because the user explicitly scoped behavior to Linux for this task.
+- 2026-06-23: Kept the existing CLI argument surface as a compatibility adapter and made `permissionProfile` the Linux enforcement shape.
+- 2026-06-23: Kept a legacy Landlock fallback for hosts where bubblewrap cannot start, including restricted test sandboxes that cannot create nested user namespaces.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -17,10 +17,11 @@ it is missing or malformed, `mcp-repl` fails closed with `--sandbox inherit
 requested but no client sandbox state was provided`.
 
 Current Codex builds send this metadata as a `permissionProfile` plus a
-`sandboxCwd` file URI. `mcp-repl` translates the supported managed profile
-shapes into its local `read-only`, `workspace-write`, `external-sandbox`, or
-`danger-full-access` policies, and rejects narrower direct filesystem profiles
-that cannot be represented faithfully.
+`sandboxCwd` file URI. `mcp-repl` treats `permissionProfile` as the canonical
+sandbox shape and keeps the older local sandbox modes as CLI/config adapters
+that compile into permission profiles. Legacy `sandboxPolicy` metadata is still
+accepted as a minimal compatibility input and is immediately converted into a
+permission profile.
 
 `--debug-repl` is the one local-only exception. Because there is no MCP client
 metadata channel in that mode, `mcp-repl --debug-repl --sandbox inherit`
@@ -146,24 +147,39 @@ mcp-repl --sandbox workspace-write \
 
 ## Linux behavior
 
-Sandboxing is enforced by a Linux sandbox helper that applies seccomp + Landlock.
+Sandboxing is enforced by an internal Linux sandbox helper. The helper accepts
+`--permission-profile`, prefers a bubblewrap outer sandbox, and applies the
+restricted-network seccomp filter in the final worker process. Legacy Landlock
+filesystem enforcement remains as a fallback for hosts where bubblewrap cannot
+start.
 
 - `workspace-write` always includes the per-session temp directory in writable roots.
 - `read-only` is translated to a minimal writable setup for the session temp directory only.
 - default Linux worker setup disables network unless explicitly enabled.
 - managed domain allowlists are not enforced on Linux yet; configuring allowed
   or denied domains with enabled network access currently fails closed.
-- `mcp-repl` always uses its own internal Linux sandbox launcher; helper
-  executable paths provided by an MCP client are ignored.
-- Codex sandbox metadata does not control `mcp-repl`'s optional internal
-  `bwrap` stage. That remains a local best-effort setting.
+- `codexLinuxSandboxExe` metadata is accepted for compatibility, but
+  `mcp-repl` re-executes its own internal `codex-linux-sandbox`-compatible
+  helper so fallback behavior stays under server control.
+- `useLegacyLandlock=true` metadata requests the legacy Landlock path.
+  `useLegacyLandlock=false` does not force bubblewrap on; the local host
+  default and `MCP_REPL_USE_LINUX_BWRAP` still decide whether bubblewrap is
+  attempted.
+- restricted-read filesystem profiles require the bubblewrap backend for exact
+  read enforcement. Legacy Landlock fallback still enforces the writable roots,
+  but it broadens reads to host-readable paths because Landlock is write-focused
+  in this compatibility path.
 
-Optional `bwrap` stage:
+Bubblewrap defaults and overrides:
 
-- `MCP_REPL_USE_LINUX_BWRAP=1` enables a bubblewrap outer sandbox.
+- when `MCP_REPL_USE_LINUX_BWRAP` is unset, Linux defaults to bubblewrap when
+  `bwrap` is available and `mcp-repl` is not itself already running inside a
+  restricted parent sandbox environment.
+- `MCP_REPL_USE_LINUX_BWRAP=1` forces a bubblewrap attempt.
+- `MCP_REPL_USE_LINUX_BWRAP=0` uses the legacy Landlock path.
 - `MCP_REPL_LINUX_BWRAP_NO_PROC=1` skips `/proc` mounting.
-- if `bwrap` is requested but worker startup dies before backend info arrives,
-  `mcp-repl` retries once without `bwrap` and continues.
+- if `bwrap` is attempted but worker startup dies before backend info arrives,
+  `mcp-repl` retries once with legacy Landlock and emits a fallback notice.
 
 ## Windows behavior (experimental)
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -17,10 +17,9 @@ use serde::{Deserialize, Serialize};
 use tempfile::Builder;
 
 mod codex_policy;
-pub use codex_policy::{
-    FileSystemSandboxPolicy, NetworkSandboxPolicy, PermissionProfile,
-    normalize_permission_profile_paths,
-};
+#[cfg(target_os = "linux")]
+pub use codex_policy::{FileSystemSandboxPolicy, NetworkSandboxPolicy};
+pub use codex_policy::{PermissionProfile, normalize_permission_profile_paths};
 
 pub const SANDBOX_STATE_META_CAPABILITY: &str = "codex/sandbox-state-meta";
 pub const MANAGED_ALLOWED_DOMAINS_ENV_KEY: &str = "MCP_REPL_ALLOWED_DOMAINS";

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -16,6 +16,12 @@ use url::Url;
 use serde::{Deserialize, Serialize};
 use tempfile::Builder;
 
+mod codex_policy;
+pub use codex_policy::{
+    FileSystemSandboxPolicy, NetworkSandboxPolicy, PermissionProfile,
+    normalize_permission_profile_paths,
+};
+
 pub const SANDBOX_STATE_META_CAPABILITY: &str = "codex/sandbox-state-meta";
 pub const MANAGED_ALLOWED_DOMAINS_ENV_KEY: &str = "MCP_REPL_ALLOWED_DOMAINS";
 pub const MANAGED_DENIED_DOMAINS_ENV_KEY: &str = "MCP_REPL_DENIED_DOMAINS";
@@ -128,7 +134,7 @@ pub struct WritableRoot {
 }
 
 impl SandboxPolicy {
-    #[cfg_attr(target_os = "windows", allow(dead_code))]
+    #[cfg_attr(any(target_os = "windows", target_os = "linux"), allow(dead_code))]
     pub fn has_full_disk_write_access(&self) -> bool {
         match self {
             SandboxPolicy::DangerFullAccess => true,
@@ -221,7 +227,7 @@ impl SandboxPolicy {
     }
 }
 
-#[cfg_attr(target_os = "windows", allow(dead_code))]
+#[cfg(target_os = "macos")]
 fn ensure_absolute(path: PathBuf) -> Option<PathBuf> {
     if path.is_absolute() { Some(path) } else { None }
 }
@@ -234,6 +240,7 @@ fn env_var_truthy(key: &str) -> bool {
 }
 
 #[cfg_attr(target_os = "windows", allow(dead_code))]
+#[cfg(target_os = "macos")]
 fn temp_roots_from_system(exclude_tmpdir_env_var: bool, exclude_slash_tmp: bool) -> Vec<PathBuf> {
     let mut roots = Vec::new();
 
@@ -313,35 +320,7 @@ fn compute_read_only_subpaths(root: &Path) -> Vec<PathBuf> {
     subpaths
 }
 
-#[cfg(target_os = "linux")]
-fn compute_linux_read_only_subpaths(root: &Path) -> Vec<PathBuf> {
-    let mut subpaths = Vec::new();
-
-    let dot_git = root.join(".git");
-    if dot_git.is_dir() || dot_git.is_file() {
-        if dot_git.is_file()
-            && let Some(gitdir) = resolve_gitdir_from_file(&dot_git)
-            && !subpaths.iter().any(|path| path == &gitdir)
-        {
-            subpaths.push(gitdir);
-        }
-        subpaths.push(dot_git);
-    }
-
-    let dot_codex = root.join(".codex");
-    if dot_codex.is_dir() {
-        subpaths.push(dot_codex);
-    }
-
-    let dot_agents = root.join(".agents");
-    if dot_agents.is_dir() {
-        subpaths.push(dot_agents);
-    }
-
-    subpaths
-}
-
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(target_os = "macos")]
 fn resolve_gitdir_from_file(dot_git: &Path) -> Option<PathBuf> {
     let contents = std::fs::read_to_string(dot_git).ok()?;
     let trimmed = contents.trim();
@@ -366,8 +345,10 @@ fn resolve_gitdir_from_file(dot_git: &Path) -> Option<PathBuf> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SandboxState {
     pub sandbox_policy: SandboxPolicy,
+    pub permission_profile: PermissionProfile,
     pub sandbox_cwd: PathBuf,
     pub use_linux_sandbox_bwrap: bool,
+    pub use_legacy_landlock: bool,
     pub managed_network_policy: ManagedNetworkPolicy,
     pub session_temp_dir: PathBuf,
 }
@@ -430,6 +411,8 @@ pub fn log_sandbox_state_meta(meta: &serde_json::Value) {
 pub struct SandboxStateUpdate {
     pub sandbox_policy: SandboxPolicy,
     #[serde(default)]
+    pub permission_profile: Option<PermissionProfile>,
+    #[serde(default)]
     pub sandbox_cwd: Option<PathBuf>,
     #[serde(default)]
     pub use_linux_sandbox_bwrap: Option<bool>,
@@ -443,77 +426,13 @@ struct CodexSandboxStateMeta {
     #[serde(default)]
     sandbox_policy: Option<SandboxPolicy>,
     #[serde(default)]
-    permission_profile: Option<CodexPermissionProfile>,
+    permission_profile: Option<PermissionProfile>,
     #[serde(default)]
-    codex_linux_sandbox_exe: Option<serde_json::Value>,
+    codex_linux_sandbox_exe: Option<PathBuf>,
     sandbox_cwd: String,
     #[serde(default)]
     use_legacy_landlock: bool,
 }
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum CodexPermissionProfile {
-    Managed {
-        file_system: CodexManagedFileSystemPermissions,
-        network: NetworkAccess,
-    },
-    Disabled,
-    External {
-        network: NetworkAccess,
-    },
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum CodexManagedFileSystemPermissions {
-    Restricted {
-        #[serde(default)]
-        entries: Vec<CodexFileSystemSandboxEntry>,
-        #[serde(default)]
-        glob_scan_max_depth: Option<usize>,
-    },
-    Unrestricted,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct CodexFileSystemSandboxEntry {
-    path: CodexFileSystemPath,
-    access: CodexFileSystemAccessMode,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "lowercase")]
-enum CodexFileSystemAccessMode {
-    Read,
-    Write,
-    #[serde(alias = "none")]
-    Deny,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum CodexFileSystemPath {
-    Path { path: String },
-    GlobPattern { pattern: String },
-    Special { value: CodexFileSystemSpecialPath },
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-enum CodexFileSystemSpecialPath {
-    Root,
-    Minimal,
-    ProjectRoots {
-        #[serde(default)]
-        subpath: Option<PathBuf>,
-    },
-    Tmpdir,
-    SlashTmp,
-}
-
-const CODEX_FULL_WRITE_RESTRICTED_NETWORK_ERROR: &str =
-    "Codex permissionProfile full write access with restricted network access is not supported";
 
 pub fn sandbox_state_update_from_codex_meta(
     meta: &serde_json::Value,
@@ -522,10 +441,19 @@ pub fn sandbox_state_update_from_codex_meta(
         .map_err(|err| format!("failed to parse Codex sandbox state metadata: {err}"))?;
     let sandbox_cwd = parse_codex_path_uri(&parsed.sandbox_cwd, "sandboxCwd")?;
 
-    let sandbox_policy = match (parsed.sandbox_policy, parsed.permission_profile) {
-        (Some(policy), _) => validate_codex_sandbox_policy(policy)?,
+    let (sandbox_policy, permission_profile) = match (
+        parsed.sandbox_policy,
+        parsed.permission_profile,
+    ) {
+        (Some(policy), _) => {
+            let policy = validate_codex_sandbox_policy(policy)?;
+            let profile = PermissionProfile::from_legacy_sandbox_policy(&policy, &sandbox_cwd);
+            (policy, Some(profile))
+        }
         (None, Some(permission_profile)) => {
-            sandbox_policy_from_codex_permission_profile(permission_profile, &sandbox_cwd)?
+            let permission_profile = normalize_permission_profile_paths(permission_profile)?;
+            let sandbox_policy = permission_profile.to_legacy_sandbox_policy(&sandbox_cwd);
+            (sandbox_policy, Some(permission_profile))
         }
         (None, None) => {
             return Err("failed to parse Codex sandbox state metadata: missing field `sandboxPolicy` or `permissionProfile`"
@@ -533,15 +461,13 @@ pub fn sandbox_state_update_from_codex_meta(
         }
     };
     let _ = parsed.codex_linux_sandbox_exe;
-    let _ = parsed.use_legacy_landlock;
 
     Ok(SandboxStateUpdate {
         sandbox_policy,
+        permission_profile,
         sandbox_cwd: Some(sandbox_cwd),
-        // Codex reports how its own Linux helper is configured, but mcp-repl's
-        // optional bwrap stage is a separate local best-effort knob.
-        use_linux_sandbox_bwrap: None,
-        use_legacy_landlock: None,
+        use_linux_sandbox_bwrap: parsed.use_legacy_landlock.then_some(false),
+        use_legacy_landlock: parsed.use_legacy_landlock.then_some(true),
     })
 }
 
@@ -592,301 +518,6 @@ fn validate_codex_sandbox_policy(policy: SandboxPolicy) -> Result<SandboxPolicy,
     Ok(policy)
 }
 
-fn sandbox_policy_from_codex_permission_profile(
-    permission_profile: CodexPermissionProfile,
-    sandbox_cwd: &Path,
-) -> Result<SandboxPolicy, String> {
-    match permission_profile {
-        CodexPermissionProfile::Disabled => Ok(SandboxPolicy::DangerFullAccess),
-        CodexPermissionProfile::External { network } => Ok(SandboxPolicy::ExternalSandbox {
-            network_access: network,
-        }),
-        CodexPermissionProfile::Managed {
-            file_system,
-            network,
-        } => sandbox_policy_from_codex_managed_profile(file_system, network, sandbox_cwd),
-    }
-}
-
-fn sandbox_policy_from_codex_managed_profile(
-    file_system: CodexManagedFileSystemPermissions,
-    network: NetworkAccess,
-    sandbox_cwd: &Path,
-) -> Result<SandboxPolicy, String> {
-    let network_access = network.is_enabled();
-    match file_system {
-        CodexManagedFileSystemPermissions::Unrestricted => {
-            if network_access {
-                Ok(SandboxPolicy::DangerFullAccess)
-            } else {
-                Err(CODEX_FULL_WRITE_RESTRICTED_NETWORK_ERROR.to_string())
-            }
-        }
-        CodexManagedFileSystemPermissions::Restricted {
-            entries,
-            glob_scan_max_depth,
-        } => {
-            if glob_scan_max_depth.is_some() {
-                return Err(
-                    "Codex permissionProfile.file_system.glob_scan_max_depth is not supported"
-                        .to_string(),
-                );
-            }
-            sandbox_policy_from_codex_restricted_entries(entries, network_access, sandbox_cwd)
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-struct RestrictedProfileProjection {
-    root_read: bool,
-    root_write: bool,
-    workspace_root_writable: bool,
-    writable_roots: Vec<PathBuf>,
-    tmpdir_writable: bool,
-    slash_tmp_writable: bool,
-    read_entries: Vec<CodexFileSystemPath>,
-}
-
-fn sandbox_policy_from_codex_restricted_entries(
-    entries: Vec<CodexFileSystemSandboxEntry>,
-    network_access: bool,
-    sandbox_cwd: &Path,
-) -> Result<SandboxPolicy, String> {
-    let mut projection = RestrictedProfileProjection::default();
-
-    for entry in entries {
-        match entry.access {
-            CodexFileSystemAccessMode::Deny => {
-                return Err(
-                    "Codex permissionProfile.file_system deny entries are not supported"
-                        .to_string(),
-                );
-            }
-            CodexFileSystemAccessMode::Read => {
-                if matches!(
-                    &entry.path,
-                    CodexFileSystemPath::Special {
-                        value: CodexFileSystemSpecialPath::Root
-                    }
-                ) {
-                    projection.root_read = true;
-                }
-                projection.read_entries.push(entry.path);
-            }
-            CodexFileSystemAccessMode::Write => {
-                project_codex_write_entry(entry.path, sandbox_cwd, &mut projection)?
-            }
-        }
-    }
-
-    if projection.root_write {
-        validate_root_write_projection(&projection)?;
-        if !network_access {
-            return Err(CODEX_FULL_WRITE_RESTRICTED_NETWORK_ERROR.to_string());
-        }
-        return Ok(SandboxPolicy::DangerFullAccess);
-    }
-
-    projection.writable_roots.sort();
-    projection.writable_roots.dedup();
-
-    if projection.workspace_root_writable {
-        validate_workspace_write_read_entries(&projection, sandbox_cwd)?;
-        return Ok(SandboxPolicy::WorkspaceWrite {
-            writable_roots: projection.writable_roots,
-            network_access,
-            exclude_tmpdir_env_var: !projection.tmpdir_writable,
-            exclude_slash_tmp: !projection.slash_tmp_writable,
-        });
-    }
-
-    if !projection.writable_roots.is_empty()
-        || projection.tmpdir_writable
-        || projection.slash_tmp_writable
-    {
-        return Err(
-            "Codex permissionProfile requests writes outside the workspace root, which mcp-repl cannot represent"
-                .to_string(),
-        );
-    }
-
-    if !projection.root_read {
-        return Err(
-            "Codex permissionProfile read-only policy without root read access is not supported"
-                .to_string(),
-        );
-    }
-
-    Ok(SandboxPolicy::ReadOnly { network_access })
-}
-
-fn project_codex_write_entry(
-    path: CodexFileSystemPath,
-    sandbox_cwd: &Path,
-    projection: &mut RestrictedProfileProjection,
-) -> Result<(), String> {
-    match path {
-        CodexFileSystemPath::Path { path } => {
-            let path = parse_codex_path_uri(&path, "permissionProfile.file_system.entries.path")?;
-            if path == sandbox_cwd {
-                projection.workspace_root_writable = true;
-            } else {
-                projection.writable_roots.push(path);
-            }
-        }
-        CodexFileSystemPath::Special { value } => match value {
-            CodexFileSystemSpecialPath::Root => {
-                projection.root_write = true;
-            }
-            CodexFileSystemSpecialPath::ProjectRoots { subpath: None } => {
-                projection.workspace_root_writable = true;
-            }
-            CodexFileSystemSpecialPath::ProjectRoots {
-                subpath: Some(subpath),
-            } => {
-                projection
-                    .writable_roots
-                    .push(resolve_codex_project_root_subpath(sandbox_cwd, &subpath));
-            }
-            CodexFileSystemSpecialPath::Tmpdir => {
-                projection.tmpdir_writable = true;
-            }
-            CodexFileSystemSpecialPath::SlashTmp => {
-                projection.slash_tmp_writable = true;
-            }
-            CodexFileSystemSpecialPath::Minimal => {
-                return Err(
-                    "Codex permissionProfile.file_system minimal write access is not supported"
-                        .to_string(),
-                );
-            }
-        },
-        CodexFileSystemPath::GlobPattern { pattern } => {
-            let _ = pattern;
-            return Err(
-                "Codex permissionProfile.file_system glob pattern writes are not supported"
-                    .to_string(),
-            );
-        }
-    }
-    Ok(())
-}
-
-fn resolve_codex_project_root_subpath(sandbox_cwd: &Path, subpath: &Path) -> PathBuf {
-    if subpath.is_absolute() {
-        subpath.to_path_buf()
-    } else {
-        sandbox_cwd.join(subpath)
-    }
-}
-
-fn validate_root_write_projection(projection: &RestrictedProfileProjection) -> Result<(), String> {
-    for read_entry in &projection.read_entries {
-        if !matches!(
-            read_entry,
-            CodexFileSystemPath::Special {
-                value: CodexFileSystemSpecialPath::Root
-            }
-        ) {
-            return Err(
-                "Codex permissionProfile root write policy with read carveouts is not supported"
-                    .to_string(),
-            );
-        }
-    }
-    Ok(())
-}
-
-fn validate_workspace_write_read_entries(
-    projection: &RestrictedProfileProjection,
-    sandbox_cwd: &Path,
-) -> Result<(), String> {
-    for read_entry in &projection.read_entries {
-        if workspace_write_read_entry_is_representable(
-            read_entry,
-            sandbox_cwd,
-            &projection.writable_roots,
-            projection.root_read,
-        )? {
-            continue;
-        }
-        return Err(
-            "Codex permissionProfile.file_system read entry cannot be represented by mcp-repl workspace-write"
-                .to_string(),
-        );
-    }
-    Ok(())
-}
-
-fn workspace_write_read_entry_is_representable(
-    read_entry: &CodexFileSystemPath,
-    sandbox_cwd: &Path,
-    writable_roots: &[PathBuf],
-    root_read: bool,
-) -> Result<bool, String> {
-    match read_entry {
-        CodexFileSystemPath::Special {
-            value: CodexFileSystemSpecialPath::Root,
-        } => Ok(true),
-        CodexFileSystemPath::Special {
-            value: CodexFileSystemSpecialPath::ProjectRoots { subpath },
-        } => Ok(subpath
-            .as_ref()
-            .is_some_and(|subpath| is_protected_metadata_subpath(subpath))),
-        CodexFileSystemPath::Special {
-            value:
-                CodexFileSystemSpecialPath::Tmpdir
-                | CodexFileSystemSpecialPath::SlashTmp
-                | CodexFileSystemSpecialPath::Minimal,
-        } => Ok(root_read),
-        CodexFileSystemPath::Path { path } => {
-            let path = parse_codex_path_uri(path, "permissionProfile.file_system.entries.path")?;
-            if is_protected_metadata_path_under_roots(&path, sandbox_cwd, writable_roots) {
-                return Ok(true);
-            }
-            Ok(root_read && !is_under_any_root(&path, sandbox_cwd, writable_roots))
-        }
-        CodexFileSystemPath::GlobPattern { pattern } => {
-            let _ = pattern;
-            Ok(false)
-        }
-    }
-}
-
-fn is_protected_metadata_path_under_roots(
-    path: &Path,
-    sandbox_cwd: &Path,
-    writable_roots: &[PathBuf],
-) -> bool {
-    is_protected_metadata_path_under_root(path, sandbox_cwd)
-        || writable_roots
-            .iter()
-            .any(|root| is_protected_metadata_path_under_root(path, root))
-}
-
-fn is_protected_metadata_path_under_root(path: &Path, root: &Path) -> bool {
-    let Ok(suffix) = path.strip_prefix(root) else {
-        return false;
-    };
-    is_protected_metadata_subpath(suffix)
-}
-
-fn is_under_any_root(path: &Path, sandbox_cwd: &Path, writable_roots: &[PathBuf]) -> bool {
-    path.starts_with(sandbox_cwd) || writable_roots.iter().any(|root| path.starts_with(root))
-}
-
-fn is_protected_metadata_subpath(path: &Path) -> bool {
-    let mut components = path.components();
-    let Some(first) = components.next() else {
-        return false;
-    };
-    matches!(
-        first.as_os_str().to_str(),
-        Some(".git" | ".agents" | ".codex")
-    )
-}
-
 impl SandboxState {
     pub fn apply_update(&mut self, update: SandboxStateUpdate) -> bool {
         let mut next = self.clone();
@@ -894,14 +525,25 @@ impl SandboxState {
         if let Some(cwd) = update.sandbox_cwd {
             next.sandbox_cwd = cwd;
         }
+        next.permission_profile = update.permission_profile.unwrap_or_else(|| {
+            PermissionProfile::from_legacy_sandbox_policy(&next.sandbox_policy, &next.sandbox_cwd)
+        });
         if let Some(use_bwrap) = update.use_linux_sandbox_bwrap {
             next.use_linux_sandbox_bwrap = use_bwrap;
-        } else if let Some(use_legacy_landlock) = update.use_legacy_landlock {
-            next.use_linux_sandbox_bwrap = !use_legacy_landlock;
+            next.use_legacy_landlock = !use_bwrap;
+        } else if update.use_legacy_landlock == Some(true) {
+            next.use_linux_sandbox_bwrap = false;
+            next.use_legacy_landlock = true;
         }
         let changed = next != *self;
         *self = next;
         changed
+    }
+
+    pub fn set_sandbox_policy(&mut self, policy: SandboxPolicy) {
+        self.sandbox_policy = policy;
+        self.permission_profile =
+            PermissionProfile::from_legacy_sandbox_policy(&self.sandbox_policy, &self.sandbox_cwd);
     }
 }
 
@@ -916,8 +558,10 @@ impl Default for SandboxState {
                 exclude_tmpdir_env_var: false,
                 exclude_slash_tmp: false,
             },
+            permission_profile: PermissionProfile::workspace_write(),
             sandbox_cwd,
-            use_linux_sandbox_bwrap: false,
+            use_linux_sandbox_bwrap: cfg!(target_os = "linux"),
+            use_legacy_landlock: false,
             managed_network_policy: ManagedNetworkPolicy::default(),
             session_temp_dir,
         }
@@ -1001,7 +645,7 @@ pub fn prepare_worker_command_with_managed_network(
     managed_network_proxy: Option<&crate::managed_network::ManagedNetworkProxy>,
 ) -> Result<PreparedCommand, SandboxError> {
     let mut env = HashMap::new();
-    if !state.sandbox_policy.has_full_network_access() {
+    if !state.permission_profile.has_full_network_access() {
         env.insert(
             CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR.to_string(),
             "1".to_string(),
@@ -1058,7 +702,19 @@ pub fn prepare_worker_command_with_managed_network(
     #[cfg(target_family = "unix")]
     configure_embedded_r_runtime_env(&mut env);
 
+    #[cfg(not(target_os = "linux"))]
     if !state.sandbox_policy.requires_sandbox() {
+        return Ok(PreparedCommand {
+            program: program.to_path_buf(),
+            args,
+            env,
+            arg0: None,
+            #[cfg(target_os = "macos")]
+            denial_logger: None,
+        });
+    }
+    #[cfg(target_os = "linux")]
+    if !state.permission_profile.requires_managed_sandbox() {
         return Ok(PreparedCommand {
             program: program.to_path_buf(),
             args,
@@ -1117,43 +773,16 @@ pub fn prepare_worker_command_with_managed_network(
 
     #[cfg(target_os = "linux")]
     {
-        let mut policy = state.sandbox_policy.clone();
-        let mut policy_cwd = state.sandbox_cwd.clone();
-        match &mut policy {
-            SandboxPolicy::ReadOnly { network_access } => {
-                let temp_root = state.session_temp_dir.clone();
-                policy = SandboxPolicy::WorkspaceWrite {
-                    writable_roots: vec![temp_root.clone()],
-                    network_access: *network_access,
-                    exclude_tmpdir_env_var: true,
-                    exclude_slash_tmp: true,
-                };
-                policy_cwd = temp_root;
-            }
-            SandboxPolicy::WorkspaceWrite {
-                writable_roots,
-                exclude_tmpdir_env_var,
-                exclude_slash_tmp,
-                network_access: _,
-            } => {
-                if !writable_roots
-                    .iter()
-                    .any(|root| root == &state.session_temp_dir)
-                {
-                    writable_roots.push(state.session_temp_dir.clone());
-                }
-                *exclude_tmpdir_env_var = true;
-                *exclude_slash_tmp = true;
-            }
-            _ => {}
-        }
-        let policy = sanitize_linux_sandbox_policy(&policy);
+        let permission_profile = state
+            .permission_profile
+            .clone()
+            .with_additional_writable_root(state.session_temp_dir.clone());
         let command = build_command_vec(program, &args);
         let sandbox_args = create_linux_sandbox_command_args(
             command,
-            &policy,
-            &policy_cwd,
-            state.use_linux_sandbox_bwrap,
+            &permission_profile,
+            &state.sandbox_cwd,
+            state.use_legacy_landlock || !state.use_linux_sandbox_bwrap,
             env_var_truthy(LINUX_BWRAP_NO_PROC_ENV),
         );
         let sandbox_program =
@@ -1204,23 +833,22 @@ fn build_command_vec(program: &Path, args: &[String]) -> Vec<String> {
 #[cfg(target_os = "linux")]
 fn create_linux_sandbox_command_args(
     command: Vec<String>,
-    sandbox_policy: &SandboxPolicy,
+    permission_profile: &PermissionProfile,
     sandbox_policy_cwd: &Path,
-    use_bwrap_sandbox: bool,
+    use_legacy_landlock: bool,
     no_proc: bool,
 ) -> Vec<String> {
     let sandbox_policy_cwd = sandbox_policy_cwd.to_string_lossy().to_string();
-    let sanitized_policy = sanitize_linux_sandbox_policy(sandbox_policy);
-    let sandbox_policy_json =
-        serde_json::to_string(&sanitized_policy).expect("failed to serialize Linux sandbox policy");
+    let permission_profile_json =
+        serde_json::to_string(permission_profile).expect("failed to serialize permission profile");
     let mut linux_cmd: Vec<String> = vec![
         "--sandbox-policy-cwd".to_string(),
         sandbox_policy_cwd,
-        "--sandbox-policy".to_string(),
-        sandbox_policy_json,
+        "--permission-profile".to_string(),
+        permission_profile_json,
     ];
-    if use_bwrap_sandbox {
-        linux_cmd.push("--use-bwrap-sandbox".to_string());
+    if use_legacy_landlock {
+        linux_cmd.push("--use-legacy-landlock".to_string());
     }
     if no_proc {
         linux_cmd.push("--no-proc".to_string());
@@ -1249,36 +877,6 @@ fn create_windows_sandbox_command_args(
     ];
     windows_cmd.extend(command);
     Ok(windows_cmd)
-}
-
-#[cfg(target_os = "linux")]
-fn sanitize_linux_sandbox_policy(policy: &SandboxPolicy) -> SandboxPolicy {
-    match policy {
-        SandboxPolicy::WorkspaceWrite {
-            writable_roots,
-            network_access,
-            exclude_tmpdir_env_var,
-            exclude_slash_tmp,
-        } => {
-            let writable_roots = writable_roots
-                .iter()
-                .filter_map(|root| ensure_absolute(root.clone()))
-                .collect();
-            SandboxPolicy::WorkspaceWrite {
-                writable_roots,
-                network_access: *network_access,
-                exclude_tmpdir_env_var: *exclude_tmpdir_env_var,
-                exclude_slash_tmp: *exclude_slash_tmp,
-            }
-        }
-        SandboxPolicy::ExternalSandbox { network_access } => SandboxPolicy::ExternalSandbox {
-            network_access: *network_access,
-        },
-        SandboxPolicy::DangerFullAccess => SandboxPolicy::DangerFullAccess,
-        SandboxPolicy::ReadOnly { network_access } => SandboxPolicy::ReadOnly {
-            network_access: *network_access,
-        },
-    }
 }
 
 // Allocate the server-owned session temp root. Today SandboxState keeps this
@@ -1388,9 +986,40 @@ pub fn sandbox_state_defaults_with_environment() -> SandboxState {
         env_var_truthy(ALLOW_LOCAL_BINDING_ENV_KEY);
     #[cfg(target_os = "linux")]
     {
-        defaults.use_linux_sandbox_bwrap = env_var_truthy(LINUX_BWRAP_ENABLED_ENV);
+        if let Some(value) = std::env::var_os(LINUX_BWRAP_ENABLED_ENV) {
+            defaults.use_linux_sandbox_bwrap = env_var_truthy(LINUX_BWRAP_ENABLED_ENV);
+            defaults.use_legacy_landlock = !defaults.use_linux_sandbox_bwrap;
+            crate::event_log::log(
+                "linux_bwrap_default",
+                serde_json::json!({
+                    "source": "env",
+                    "env_value": value.to_string_lossy(),
+                    "use_linux_sandbox_bwrap": defaults.use_linux_sandbox_bwrap,
+                }),
+            );
+        } else {
+            defaults.use_linux_sandbox_bwrap = linux_bwrap_usable_on_current_host();
+            defaults.use_legacy_landlock = !defaults.use_linux_sandbox_bwrap;
+            crate::event_log::log(
+                "linux_bwrap_default",
+                serde_json::json!({
+                    "source": "host",
+                    "use_linux_sandbox_bwrap": defaults.use_linux_sandbox_bwrap,
+                }),
+            );
+        }
     }
     defaults
+}
+
+#[cfg(target_os = "linux")]
+fn linux_bwrap_usable_on_current_host() -> bool {
+    if std::env::var_os(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_some()
+        || std::env::var_os("CODEX_SANDBOX").is_some()
+    {
+        return false;
+    }
+    linux_find_bwrap_program().is_some()
 }
 
 #[cfg(target_os = "macos")]
@@ -1679,9 +1308,9 @@ pub fn run_linux_sandbox_main() -> ! {
 #[cfg(target_os = "linux")]
 struct LinuxSandboxArgs {
     sandbox_policy_cwd: PathBuf,
-    sandbox_policy: SandboxPolicy,
+    permission_profile: PermissionProfile,
     command: Vec<std::ffi::OsString>,
-    use_bwrap_sandbox: bool,
+    use_legacy_landlock: bool,
     apply_seccomp_then_exec: bool,
     no_proc: bool,
 }
@@ -1690,18 +1319,23 @@ struct LinuxSandboxArgs {
 fn linux_sandbox_main_impl() -> Result<(), String> {
     let args = linux_sandbox_parse_args()?;
     if args.apply_seccomp_then_exec {
-        linux_apply_sandbox_policy_to_current_thread(
-            &args.sandbox_policy,
+        linux_apply_permission_profile_to_current_thread(
+            &args.permission_profile,
             &args.sandbox_policy_cwd,
+            false,
         )?;
         linux_execvp(args.command)?;
         return Ok(());
     }
-    if args.use_bwrap_sandbox {
+    if !args.use_legacy_landlock && !args.permission_profile.has_full_disk_write_access() {
         linux_exec_bwrap_sandbox(args)?;
         return Ok(());
     }
-    linux_apply_sandbox_policy_to_current_thread(&args.sandbox_policy, &args.sandbox_policy_cwd)?;
+    linux_apply_permission_profile_to_current_thread(
+        &args.permission_profile,
+        &args.sandbox_policy_cwd,
+        args.use_legacy_landlock,
+    )?;
     linux_execvp(args.command)?;
     Ok(())
 }
@@ -1709,16 +1343,16 @@ fn linux_sandbox_main_impl() -> Result<(), String> {
 #[cfg(target_os = "linux")]
 fn linux_sandbox_parse_args() -> Result<LinuxSandboxArgs, String> {
     let mut sandbox_policy_cwd: Option<PathBuf> = None;
-    let mut sandbox_policy: Option<SandboxPolicy> = None;
+    let mut permission_profile: Option<PermissionProfile> = None;
     let mut command: Vec<std::ffi::OsString> = Vec::new();
-    let mut use_bwrap_sandbox = false;
+    let mut use_legacy_landlock = false;
     let mut apply_seccomp_then_exec = false;
     let mut no_proc = false;
 
     let mut args = std::env::args_os().skip(1).peekable();
     while let Some(arg) = args.next() {
-        if arg == "--use-bwrap-sandbox" {
-            use_bwrap_sandbox = true;
+        if arg == "--use-legacy-landlock" {
+            use_legacy_landlock = true;
             continue;
         }
         if arg == "--apply-seccomp-then-exec" {
@@ -1736,6 +1370,19 @@ fn linux_sandbox_parse_args() -> Result<LinuxSandboxArgs, String> {
             sandbox_policy_cwd = Some(PathBuf::from(value));
             continue;
         }
+        if arg == "--permission-profile" {
+            let value = args
+                .next()
+                .ok_or_else(|| "missing value for --permission-profile".to_string())?;
+            let value = value
+                .into_string()
+                .map_err(|_| "--permission-profile must be valid UTF-8".to_string())?;
+            permission_profile = Some(
+                serde_json::from_str(&value)
+                    .map_err(|err| format!("failed to parse --permission-profile: {err}"))?,
+            );
+            continue;
+        }
         if arg == "--sandbox-policy" {
             let value = args
                 .next()
@@ -1743,10 +1390,14 @@ fn linux_sandbox_parse_args() -> Result<LinuxSandboxArgs, String> {
             let value = value
                 .into_string()
                 .map_err(|_| "--sandbox-policy must be valid UTF-8".to_string())?;
-            sandbox_policy = Some(
-                serde_json::from_str(&value)
-                    .map_err(|err| format!("failed to parse --sandbox-policy: {err}"))?,
-            );
+            let sandbox_policy: SandboxPolicy = serde_json::from_str(&value)
+                .map_err(|err| format!("failed to parse --sandbox-policy: {err}"))?;
+            permission_profile = Some(PermissionProfile::from_legacy_sandbox_policy(
+                &sandbox_policy,
+                sandbox_policy_cwd
+                    .as_deref()
+                    .unwrap_or_else(|| Path::new("/")),
+            ));
             continue;
         }
         if arg == "--" {
@@ -1758,16 +1409,17 @@ fn linux_sandbox_parse_args() -> Result<LinuxSandboxArgs, String> {
 
     let sandbox_policy_cwd =
         sandbox_policy_cwd.ok_or_else(|| "missing --sandbox-policy-cwd".to_string())?;
-    let sandbox_policy = sandbox_policy.ok_or_else(|| "missing --sandbox-policy".to_string())?;
+    let permission_profile =
+        permission_profile.ok_or_else(|| "missing --permission-profile".to_string())?;
     if command.is_empty() {
         return Err("no command specified to execute".to_string());
     }
 
     Ok(LinuxSandboxArgs {
         sandbox_policy_cwd,
-        sandbox_policy,
+        permission_profile,
         command,
-        use_bwrap_sandbox,
+        use_legacy_landlock,
         apply_seccomp_then_exec,
         no_proc,
     })
@@ -1793,14 +1445,14 @@ fn linux_find_bwrap_program() -> Option<PathBuf> {
 #[cfg(target_os = "linux")]
 fn linux_build_inner_seccomp_command(args: &LinuxSandboxArgs) -> Result<Vec<String>, String> {
     let current_exe = std::env::current_exe().map_err(|err| err.to_string())?;
-    let policy = sanitize_linux_sandbox_policy(&args.sandbox_policy);
-    let policy_json = serde_json::to_string(&policy).map_err(|err| err.to_string())?;
+    let permission_profile_json =
+        serde_json::to_string(&args.permission_profile).map_err(|err| err.to_string())?;
     let mut inner = vec![
         current_exe.to_string_lossy().to_string(),
         "--sandbox-policy-cwd".to_string(),
         args.sandbox_policy_cwd.to_string_lossy().to_string(),
-        "--sandbox-policy".to_string(),
-        policy_json,
+        "--permission-profile".to_string(),
+        permission_profile_json,
         "--apply-seccomp-then-exec".to_string(),
         "--".to_string(),
     ];
@@ -1817,15 +1469,18 @@ fn linux_exec_bwrap_sandbox(args: LinuxSandboxArgs) -> Result<(), String> {
     let bwrap_program = linux_find_bwrap_program()
         .ok_or_else(|| "bwrap executable not found (tried /usr/bin/bwrap and PATH)".to_string())?;
     let inner = linux_build_inner_seccomp_command(&args)?;
+    let (file_system_policy, network_policy) = args.permission_profile.to_runtime_permissions();
     let mount_proc = !args.no_proc
         && linux_bwrap_supports_proc_mount(
             bwrap_program.as_path(),
-            &args.sandbox_policy,
+            &file_system_policy,
+            network_policy,
             &args.sandbox_policy_cwd,
         );
     let bwrap_args = create_linux_bwrap_command_args(
         inner,
-        &args.sandbox_policy,
+        &file_system_policy,
+        network_policy,
         &args.sandbox_policy_cwd,
         mount_proc,
     )?;
@@ -1839,7 +1494,8 @@ fn linux_exec_bwrap_sandbox(args: LinuxSandboxArgs) -> Result<(), String> {
 #[cfg(target_os = "linux")]
 fn linux_bwrap_supports_proc_mount(
     bwrap_program: &Path,
-    sandbox_policy: &SandboxPolicy,
+    file_system_policy: &FileSystemSandboxPolicy,
+    network_policy: NetworkSandboxPolicy,
     sandbox_policy_cwd: &Path,
 ) -> bool {
     let true_path = if Path::new("/usr/bin/true").is_file() {
@@ -1851,7 +1507,8 @@ fn linux_bwrap_supports_proc_mount(
     };
     let args = match create_linux_bwrap_command_args(
         vec![true_path.to_string()],
-        sandbox_policy,
+        file_system_policy,
+        network_policy,
         sandbox_policy_cwd,
         true,
     ) {
@@ -1878,159 +1535,109 @@ fn linux_bwrap_supports_proc_mount(
 #[cfg(target_os = "linux")]
 fn create_linux_bwrap_command_args(
     command: Vec<String>,
-    sandbox_policy: &SandboxPolicy,
+    file_system_policy: &FileSystemSandboxPolicy,
+    network_policy: NetworkSandboxPolicy,
     sandbox_policy_cwd: &Path,
     mount_proc: bool,
 ) -> Result<Vec<String>, String> {
-    let sandbox_policy = sanitize_linux_sandbox_policy(sandbox_policy);
-    let writable_roots = linux_writable_roots(&sandbox_policy, sandbox_policy_cwd);
-    linux_ensure_bwrap_mount_targets_exist(&writable_roots)?;
-
+    let writable_roots = file_system_policy.get_writable_roots_with_cwd(sandbox_policy_cwd);
     let mut bwrap_args = vec![
         "--die-with-parent".to_string(),
         "--new-session".to_string(),
+        "--unshare-user".to_string(),
         "--unshare-pid".to_string(),
     ];
-    if !sandbox_policy.has_full_network_access() {
+    if !network_policy.is_enabled() {
         bwrap_args.push("--unshare-net".to_string());
     }
     if mount_proc {
         bwrap_args.push("--proc".to_string());
         bwrap_args.push("/proc".to_string());
     }
-    bwrap_args.extend(["--ro-bind".to_string(), "/".to_string(), "/".to_string()]);
+    if file_system_policy.has_full_disk_read_access() {
+        bwrap_args.extend(["--ro-bind".to_string(), "/".to_string(), "/".to_string()]);
+        bwrap_args.extend(["--dev".to_string(), "/dev".to_string()]);
+    } else {
+        bwrap_args.extend(["--tmpfs".to_string(), "/".to_string()]);
+        bwrap_args.extend(["--dev".to_string(), "/dev".to_string()]);
+        for root in file_system_policy.get_readable_roots_with_cwd(sandbox_policy_cwd) {
+            if root.exists() {
+                let root_str = root.to_string_lossy().to_string();
+                bwrap_args.extend(["--ro-bind".to_string(), root_str.clone(), root_str]);
+            }
+        }
+        if file_system_policy.include_platform_defaults() {
+            for root in linux_platform_default_read_roots() {
+                if root.exists() {
+                    let root_str = root.to_string_lossy().to_string();
+                    bwrap_args.extend(["--ro-bind".to_string(), root_str.clone(), root_str]);
+                }
+            }
+        }
+    }
 
-    for root in &writable_roots {
-        let root_str = root.to_string_lossy().to_string();
+    for writable_root in &writable_roots {
+        if !writable_root.root.exists() {
+            continue;
+        }
+        let root_str = writable_root.root.to_string_lossy().to_string();
         bwrap_args.extend(["--bind".to_string(), root_str.clone(), root_str]);
     }
 
-    let read_only_subpaths = collect_linux_read_only_subpaths(&writable_roots);
-    for subpath in read_only_subpaths {
-        if let Some(symlink_path) = find_symlink_in_path(&subpath, &writable_roots) {
-            let target = symlink_path.to_string_lossy().to_string();
-            bwrap_args.extend(["--ro-bind".to_string(), "/dev/null".to_string(), target]);
-            continue;
-        }
-
-        if !subpath.exists() {
-            if let Some(first_missing) = find_first_non_existent_component(&subpath)
-                && is_within_allowed_write_paths(&first_missing, &writable_roots)
-            {
-                let target = first_missing.to_string_lossy().to_string();
-                bwrap_args.extend(["--ro-bind".to_string(), "/dev/null".to_string(), target]);
-            }
-            continue;
-        }
-
-        if is_within_allowed_write_paths(&subpath, &writable_roots) {
-            let target = subpath.to_string_lossy().to_string();
-            bwrap_args.extend(["--ro-bind".to_string(), target.clone(), target]);
+    for writable_root in &writable_roots {
+        for subpath in &writable_root.read_only_subpaths {
+            append_linux_bwrap_read_only_mask(&mut bwrap_args, subpath, &writable_root.root);
         }
     }
 
-    bwrap_args.extend([
-        "--dev-bind".to_string(),
-        "/dev/null".to_string(),
-        "/dev/null".to_string(),
-    ]);
+    for unreadable in file_system_policy.get_unreadable_roots_with_cwd(sandbox_policy_cwd) {
+        append_linux_bwrap_unreadable_mask(&mut bwrap_args, &unreadable);
+    }
 
-    let command_index = bwrap_args.len();
+    bwrap_args.push("--argv0".to_string());
+    bwrap_args.push("codex-linux-sandbox".to_string());
     bwrap_args.push("--".to_string());
     bwrap_args.extend(command);
-    bwrap_args.splice(
-        command_index..command_index,
-        ["--argv0".to_string(), "codex-linux-sandbox".to_string()],
-    );
     Ok(bwrap_args)
 }
 
 #[cfg(target_os = "linux")]
-fn linux_ensure_bwrap_mount_targets_exist(writable_roots: &[PathBuf]) -> Result<(), String> {
-    for root in writable_roots {
-        if !root.exists() {
-            return Err(format!(
-                "sandbox expected writable root {}, but it does not exist",
-                root.display()
-            ));
-        }
+fn append_linux_bwrap_read_only_mask(bwrap_args: &mut Vec<String>, subpath: &Path, root: &Path) {
+    if !subpath.starts_with(root) {
+        return;
     }
-    Ok(())
+    if subpath.exists() {
+        let target = subpath.to_string_lossy().to_string();
+        bwrap_args.extend(["--ro-bind".to_string(), target.clone(), target]);
+    }
 }
 
 #[cfg(target_os = "linux")]
-fn collect_linux_read_only_subpaths(writable_roots: &[PathBuf]) -> Vec<PathBuf> {
-    let mut subpaths = std::collections::BTreeSet::<PathBuf>::new();
-    for root in writable_roots {
-        for subpath in compute_linux_read_only_subpaths(root) {
-            subpaths.insert(subpath);
-        }
+fn append_linux_bwrap_unreadable_mask(bwrap_args: &mut Vec<String>, path: &Path) {
+    if path.is_dir() {
+        let target = path.to_string_lossy().to_string();
+        bwrap_args.extend(["--tmpfs".to_string(), target]);
+    } else if path.exists() {
+        let target = path.to_string_lossy().to_string();
+        bwrap_args.extend(["--ro-bind".to_string(), "/dev/null".to_string(), target]);
     }
-    subpaths.into_iter().collect()
 }
 
 #[cfg(target_os = "linux")]
-fn is_within_allowed_write_paths(path: &Path, allowed_write_paths: &[PathBuf]) -> bool {
-    allowed_write_paths
-        .iter()
-        .any(|root| path.starts_with(root.as_path()))
-}
-
-#[cfg(target_os = "linux")]
-fn find_symlink_in_path(target_path: &Path, allowed_write_paths: &[PathBuf]) -> Option<PathBuf> {
-    let mut current = PathBuf::new();
-    for component in target_path.components() {
-        use std::path::Component;
-        match component {
-            Component::RootDir => {
-                current.push(Path::new("/"));
-                continue;
-            }
-            Component::CurDir => continue,
-            Component::ParentDir => {
-                current.pop();
-                continue;
-            }
-            Component::Normal(part) => current.push(part),
-            Component::Prefix(_) => continue,
-        }
-
-        let metadata = match std::fs::symlink_metadata(&current) {
-            Ok(metadata) => metadata,
-            Err(_) => break,
-        };
-        if metadata.file_type().is_symlink()
-            && is_within_allowed_write_paths(&current, allowed_write_paths)
-        {
-            return Some(current);
-        }
-    }
-    None
-}
-
-#[cfg(target_os = "linux")]
-fn find_first_non_existent_component(target_path: &Path) -> Option<PathBuf> {
-    let mut current = PathBuf::new();
-    for component in target_path.components() {
-        use std::path::Component;
-        match component {
-            Component::RootDir => {
-                current.push(Path::new("/"));
-                continue;
-            }
-            Component::CurDir => continue,
-            Component::ParentDir => {
-                current.pop();
-                continue;
-            }
-            Component::Normal(part) => current.push(part),
-            Component::Prefix(_) => continue,
-        }
-        if !current.exists() {
-            return Some(current);
-        }
-    }
-    None
+fn linux_platform_default_read_roots() -> Vec<PathBuf> {
+    [
+        "/bin",
+        "/sbin",
+        "/usr",
+        "/etc",
+        "/lib",
+        "/lib64",
+        "/nix/store",
+        "/run/current-system/sw",
+    ]
+    .into_iter()
+    .map(PathBuf::from)
+    .collect()
 }
 
 #[cfg(target_os = "linux")]
@@ -2039,20 +1646,28 @@ fn is_proc_mount_failure(stderr: &str) -> bool {
 }
 
 #[cfg(target_os = "linux")]
-fn linux_apply_sandbox_policy_to_current_thread(
-    sandbox_policy: &SandboxPolicy,
+fn linux_apply_permission_profile_to_current_thread(
+    permission_profile: &PermissionProfile,
     cwd: &Path,
+    apply_landlock_fs: bool,
 ) -> Result<(), String> {
-    if !sandbox_policy.has_full_disk_write_access() || !sandbox_policy.has_full_network_access() {
+    let (file_system_policy, network_policy) = permission_profile.to_runtime_permissions();
+    if !network_policy.is_enabled()
+        || (apply_landlock_fs && !file_system_policy.has_full_disk_write_access())
+    {
         linux_set_no_new_privs()?;
     }
 
-    if !sandbox_policy.has_full_network_access() {
+    if !network_policy.is_enabled() {
         linux_install_network_seccomp_filter_on_current_thread()?;
     }
 
-    if !sandbox_policy.has_full_disk_write_access() {
-        let writable_roots = linux_writable_roots(sandbox_policy, cwd);
+    if apply_landlock_fs && !file_system_policy.has_full_disk_write_access() {
+        let writable_roots = file_system_policy
+            .get_writable_roots_with_cwd(cwd)
+            .into_iter()
+            .map(|root| root.root)
+            .collect();
         linux_install_filesystem_landlock_rules_on_current_thread(writable_roots)?;
     }
 
@@ -2066,33 +1681,6 @@ fn linux_set_no_new_privs() -> Result<(), String> {
         return Err(std::io::Error::last_os_error().to_string());
     }
     Ok(())
-}
-
-#[cfg(target_os = "linux")]
-fn linux_writable_roots(policy: &SandboxPolicy, cwd: &Path) -> Vec<PathBuf> {
-    let mut roots: Vec<PathBuf> = Vec::new();
-    let Some(cwd) = ensure_absolute(cwd.to_path_buf()) else {
-        return roots;
-    };
-
-    if let SandboxPolicy::WorkspaceWrite {
-        writable_roots,
-        exclude_tmpdir_env_var,
-        exclude_slash_tmp,
-        network_access: _,
-    } = policy
-    {
-        roots.extend(writable_roots.iter().cloned().filter_map(ensure_absolute));
-        roots.push(cwd);
-        roots.extend(temp_roots_from_system(
-            *exclude_tmpdir_env_var,
-            *exclude_slash_tmp,
-        ));
-    }
-
-    roots.sort();
-    roots.dedup();
-    roots
 }
 
 #[cfg(target_os = "linux")]

--- a/src/sandbox/codex_policy.rs
+++ b/src/sandbox/codex_policy.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "linux")]
 use std::cmp::Ordering;
 use std::path::{Path, PathBuf};
 
@@ -32,6 +33,7 @@ pub enum FileSystemAccessMode {
 }
 
 impl FileSystemAccessMode {
+    #[cfg(target_os = "linux")]
     fn can_read(self) -> bool {
         !matches!(self, FileSystemAccessMode::Deny)
     }
@@ -98,12 +100,14 @@ pub struct FileSystemSandboxPolicy {
     pub entries: Vec<FileSystemSandboxEntry>,
 }
 
+#[cfg(target_os = "linux")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WritableRoot {
     pub root: PathBuf,
     pub read_only_subpaths: Vec<PathBuf>,
 }
 
+#[cfg(target_os = "linux")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ResolvedEntry {
     path: PathBuf,
@@ -213,6 +217,7 @@ impl FileSystemSandboxPolicy {
         Self::restricted(entries)
     }
 
+    #[cfg(target_os = "linux")]
     pub fn has_full_disk_read_access(&self) -> bool {
         match self.kind {
             FileSystemSandboxKind::Unrestricted | FileSystemSandboxKind::ExternalSandbox => true,
@@ -233,6 +238,7 @@ impl FileSystemSandboxPolicy {
         }
     }
 
+    #[cfg(target_os = "linux")]
     pub fn include_platform_defaults(&self) -> bool {
         !self.has_full_disk_read_access()
             && matches!(self.kind, FileSystemSandboxKind::Restricted)
@@ -246,6 +252,7 @@ impl FileSystemSandboxPolicy {
             })
     }
 
+    #[cfg(target_os = "linux")]
     pub fn get_readable_roots_with_cwd(&self, cwd: &Path) -> Vec<PathBuf> {
         if self.has_full_disk_read_access() {
             return Vec::new();
@@ -261,6 +268,7 @@ impl FileSystemSandboxPolicy {
         )
     }
 
+    #[cfg(target_os = "linux")]
     pub fn get_writable_roots_with_cwd(&self, cwd: &Path) -> Vec<WritableRoot> {
         if self.has_full_disk_write_access() {
             return Vec::new();
@@ -296,6 +304,7 @@ impl FileSystemSandboxPolicy {
             .collect()
     }
 
+    #[cfg(target_os = "linux")]
     pub fn get_unreadable_roots_with_cwd(&self, cwd: &Path) -> Vec<PathBuf> {
         if !matches!(self.kind, FileSystemSandboxKind::Restricted) {
             return Vec::new();
@@ -310,10 +319,12 @@ impl FileSystemSandboxPolicy {
         )
     }
 
+    #[cfg(target_os = "linux")]
     pub fn can_read_path_with_cwd(&self, path: &Path, cwd: &Path) -> bool {
         self.resolve_access_with_cwd(path, cwd).can_read()
     }
 
+    #[cfg(target_os = "linux")]
     pub fn can_write_path_with_cwd(&self, path: &Path, cwd: &Path) -> bool {
         if !self.resolve_access_with_cwd(path, cwd).can_write() {
             return false;
@@ -324,6 +335,7 @@ impl FileSystemSandboxPolicy {
         !self.metadata_write_denied(path, cwd)
     }
 
+    #[cfg(target_os = "linux")]
     pub fn with_additional_writable_root(mut self, root: PathBuf) -> Self {
         if !matches!(self.kind, FileSystemSandboxKind::Restricted) {
             return self;
@@ -407,6 +419,7 @@ impl FileSystemSandboxPolicy {
         }
     }
 
+    #[cfg(target_os = "linux")]
     fn resolve_access_with_cwd(&self, path: &Path, cwd: &Path) -> FileSystemAccessMode {
         match self.kind {
             FileSystemSandboxKind::Unrestricted | FileSystemSandboxKind::ExternalSandbox => {
@@ -424,6 +437,7 @@ impl FileSystemSandboxPolicy {
             .unwrap_or(FileSystemAccessMode::Deny)
     }
 
+    #[cfg(target_os = "linux")]
     fn resolved_entries_with_cwd(&self, cwd: &Path) -> Vec<ResolvedEntry> {
         self.entries
             .iter()
@@ -448,6 +462,7 @@ impl FileSystemSandboxPolicy {
             })
     }
 
+    #[cfg(target_os = "linux")]
     fn has_denied_read_restrictions(&self) -> bool {
         matches!(self.kind, FileSystemSandboxKind::Restricted)
             && self
@@ -471,6 +486,7 @@ impl FileSystemSandboxPolicy {
             })
     }
 
+    #[cfg(target_os = "linux")]
     fn metadata_write_denied(&self, path: &Path, cwd: &Path) -> bool {
         let target = resolve_path_against_cwd(path, cwd);
         self.resolved_entries_with_cwd(cwd)
@@ -584,6 +600,7 @@ impl PermissionProfile {
         }
     }
 
+    #[cfg(target_os = "linux")]
     pub fn to_runtime_permissions(&self) -> (FileSystemSandboxPolicy, NetworkSandboxPolicy) {
         (
             self.file_system_sandbox_policy(),
@@ -610,11 +627,13 @@ impl PermissionProfile {
         self.network_sandbox_policy().is_enabled()
     }
 
+    #[cfg(target_os = "linux")]
     pub fn has_full_disk_write_access(&self) -> bool {
         self.file_system_sandbox_policy()
             .has_full_disk_write_access()
     }
 
+    #[cfg(target_os = "linux")]
     pub fn requires_managed_sandbox(&self) -> bool {
         match self {
             Self::Disabled => false,
@@ -625,6 +644,7 @@ impl PermissionProfile {
         }
     }
 
+    #[cfg(target_os = "linux")]
     pub fn with_additional_writable_root(self, root: PathBuf) -> Self {
         match self {
             Self::Managed {
@@ -690,6 +710,7 @@ impl From<NetworkAccess> for NetworkSandboxPolicy {
     }
 }
 
+#[cfg(target_os = "linux")]
 fn resolve_entry_path(path: &FileSystemPath, cwd: &Path) -> Option<PathBuf> {
     match path {
         FileSystemPath::Special {
@@ -739,6 +760,7 @@ fn default_read_only_subpaths_for_writable_root(root: &Path) -> Vec<PathBuf> {
         .collect()
 }
 
+#[cfg(target_os = "linux")]
 fn resolved_entry_precedence(left: &ResolvedEntry, right: &ResolvedEntry) -> Ordering {
     left.path
         .components()

--- a/src/sandbox/codex_policy.rs
+++ b/src/sandbox/codex_policy.rs
@@ -1,0 +1,825 @@
+use std::cmp::Ordering;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use super::{NetworkAccess, SandboxPolicy};
+
+const PROTECTED_METADATA_NAMES: &[&str] = &[".git", ".agents", ".codex"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum NetworkSandboxPolicy {
+    #[default]
+    Restricted,
+    Enabled,
+}
+
+impl NetworkSandboxPolicy {
+    pub fn is_enabled(self) -> bool {
+        matches!(self, NetworkSandboxPolicy::Enabled)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FileSystemAccessMode {
+    Read,
+    Write,
+    #[serde(alias = "none")]
+    Deny,
+}
+
+impl FileSystemAccessMode {
+    fn can_read(self) -> bool {
+        !matches!(self, FileSystemAccessMode::Deny)
+    }
+
+    fn can_write(self) -> bool {
+        matches!(self, FileSystemAccessMode::Write)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FileSystemSpecialPath {
+    Root,
+    Minimal,
+    #[serde(alias = "current_working_directory")]
+    ProjectRoots {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        subpath: Option<PathBuf>,
+    },
+    Tmpdir,
+    SlashTmp,
+    Unknown {
+        path: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        subpath: Option<PathBuf>,
+    },
+}
+
+impl FileSystemSpecialPath {
+    fn project_roots(subpath: Option<PathBuf>) -> Self {
+        Self::ProjectRoots { subpath }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum FileSystemPath {
+    Path { path: PathBuf },
+    GlobPattern { pattern: String },
+    Special { value: FileSystemSpecialPath },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileSystemSandboxEntry {
+    pub path: FileSystemPath,
+    pub access: FileSystemAccessMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum FileSystemSandboxKind {
+    #[default]
+    Restricted,
+    Unrestricted,
+    ExternalSandbox,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileSystemSandboxPolicy {
+    pub kind: FileSystemSandboxKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub glob_scan_max_depth: Option<usize>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entries: Vec<FileSystemSandboxEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WritableRoot {
+    pub root: PathBuf,
+    pub read_only_subpaths: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedEntry {
+    path: PathBuf,
+    access: FileSystemAccessMode,
+}
+
+impl Default for FileSystemSandboxPolicy {
+    fn default() -> Self {
+        Self::read_only()
+    }
+}
+
+impl FileSystemSandboxPolicy {
+    pub fn read_only() -> Self {
+        Self::restricted(vec![FileSystemSandboxEntry {
+            path: FileSystemPath::Special {
+                value: FileSystemSpecialPath::Root,
+            },
+            access: FileSystemAccessMode::Read,
+        }])
+    }
+
+    pub fn unrestricted() -> Self {
+        Self {
+            kind: FileSystemSandboxKind::Unrestricted,
+            glob_scan_max_depth: None,
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn external_sandbox() -> Self {
+        Self {
+            kind: FileSystemSandboxKind::ExternalSandbox,
+            glob_scan_max_depth: None,
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn restricted(entries: Vec<FileSystemSandboxEntry>) -> Self {
+        Self {
+            kind: FileSystemSandboxKind::Restricted,
+            glob_scan_max_depth: None,
+            entries,
+        }
+    }
+
+    pub fn workspace_write(
+        writable_roots: &[PathBuf],
+        exclude_tmpdir_env_var: bool,
+        exclude_slash_tmp: bool,
+    ) -> Self {
+        let mut entries = vec![
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::Root,
+                },
+                access: FileSystemAccessMode::Read,
+            },
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::project_roots(None),
+                },
+                access: FileSystemAccessMode::Write,
+            },
+        ];
+        if !exclude_slash_tmp {
+            entries.push(FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::SlashTmp,
+                },
+                access: FileSystemAccessMode::Write,
+            });
+        }
+        if !exclude_tmpdir_env_var {
+            entries.push(FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::Tmpdir,
+                },
+                access: FileSystemAccessMode::Write,
+            });
+        }
+        entries.extend(
+            writable_roots
+                .iter()
+                .cloned()
+                .map(|path| FileSystemSandboxEntry {
+                    path: FileSystemPath::Path { path },
+                    access: FileSystemAccessMode::Write,
+                }),
+        );
+        for name in PROTECTED_METADATA_NAMES {
+            entries.push(FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::project_roots(Some(PathBuf::from(name))),
+                },
+                access: FileSystemAccessMode::Read,
+            });
+        }
+        for root in writable_roots {
+            for path in default_read_only_subpaths_for_writable_root(root) {
+                entries.push(FileSystemSandboxEntry {
+                    path: FileSystemPath::Path { path },
+                    access: FileSystemAccessMode::Read,
+                });
+            }
+        }
+        Self::restricted(entries)
+    }
+
+    pub fn has_full_disk_read_access(&self) -> bool {
+        match self.kind {
+            FileSystemSandboxKind::Unrestricted | FileSystemSandboxKind::ExternalSandbox => true,
+            FileSystemSandboxKind::Restricted => {
+                self.has_root_access(FileSystemAccessMode::can_read)
+                    && !self.has_denied_read_restrictions()
+            }
+        }
+    }
+
+    pub fn has_full_disk_write_access(&self) -> bool {
+        match self.kind {
+            FileSystemSandboxKind::Unrestricted | FileSystemSandboxKind::ExternalSandbox => true,
+            FileSystemSandboxKind::Restricted => {
+                self.has_root_access(FileSystemAccessMode::can_write)
+                    && !self.has_write_narrowing_entries()
+            }
+        }
+    }
+
+    pub fn include_platform_defaults(&self) -> bool {
+        !self.has_full_disk_read_access()
+            && matches!(self.kind, FileSystemSandboxKind::Restricted)
+            && self.entries.iter().any(|entry| {
+                matches!(
+                    &entry.path,
+                    FileSystemPath::Special {
+                        value: FileSystemSpecialPath::Minimal
+                    } if entry.access.can_read()
+                )
+            })
+    }
+
+    pub fn get_readable_roots_with_cwd(&self, cwd: &Path) -> Vec<PathBuf> {
+        if self.has_full_disk_read_access() {
+            return Vec::new();
+        }
+        let entries = self.resolved_entries_with_cwd(cwd);
+        dedup_paths(
+            entries
+                .iter()
+                .filter(|entry| entry.access.can_read())
+                .filter(|entry| self.can_read_path_with_cwd(&entry.path, cwd))
+                .map(|entry| entry.path.clone())
+                .collect(),
+        )
+    }
+
+    pub fn get_writable_roots_with_cwd(&self, cwd: &Path) -> Vec<WritableRoot> {
+        if self.has_full_disk_write_access() {
+            return Vec::new();
+        }
+
+        let entries = self.resolved_entries_with_cwd(cwd);
+        let writable_roots = dedup_paths(
+            entries
+                .iter()
+                .filter(|entry| entry.access.can_write())
+                .filter(|entry| self.can_write_path_with_cwd(&entry.path, cwd))
+                .map(|entry| entry.path.clone())
+                .collect(),
+        );
+
+        writable_roots
+            .into_iter()
+            .map(|root| {
+                let mut read_only_subpaths = default_read_only_subpaths_for_writable_root(&root);
+                read_only_subpaths.extend(
+                    entries
+                        .iter()
+                        .filter(|entry| !entry.access.can_write())
+                        .filter(|entry| entry.path.starts_with(&root))
+                        .filter(|entry| !self.can_write_path_with_cwd(&entry.path, cwd))
+                        .map(|entry| entry.path.clone()),
+                );
+                WritableRoot {
+                    root,
+                    read_only_subpaths: dedup_paths(read_only_subpaths),
+                }
+            })
+            .collect()
+    }
+
+    pub fn get_unreadable_roots_with_cwd(&self, cwd: &Path) -> Vec<PathBuf> {
+        if !matches!(self.kind, FileSystemSandboxKind::Restricted) {
+            return Vec::new();
+        }
+        dedup_paths(
+            self.resolved_entries_with_cwd(cwd)
+                .into_iter()
+                .filter(|entry| entry.access == FileSystemAccessMode::Deny)
+                .filter(|entry| !self.can_read_path_with_cwd(&entry.path, cwd))
+                .map(|entry| entry.path)
+                .collect(),
+        )
+    }
+
+    pub fn can_read_path_with_cwd(&self, path: &Path, cwd: &Path) -> bool {
+        self.resolve_access_with_cwd(path, cwd).can_read()
+    }
+
+    pub fn can_write_path_with_cwd(&self, path: &Path, cwd: &Path) -> bool {
+        if !self.resolve_access_with_cwd(path, cwd).can_write() {
+            return false;
+        }
+        if self.has_full_disk_write_access() {
+            return true;
+        }
+        !self.metadata_write_denied(path, cwd)
+    }
+
+    pub fn with_additional_writable_root(mut self, root: PathBuf) -> Self {
+        if !matches!(self.kind, FileSystemSandboxKind::Restricted) {
+            return self;
+        }
+        self.entries.push(FileSystemSandboxEntry {
+            path: FileSystemPath::Path { path: root },
+            access: FileSystemAccessMode::Write,
+        });
+        self
+    }
+
+    pub fn to_legacy_sandbox_policy(
+        &self,
+        network: NetworkSandboxPolicy,
+        cwd: &Path,
+    ) -> SandboxPolicy {
+        match self.kind {
+            FileSystemSandboxKind::ExternalSandbox => SandboxPolicy::ExternalSandbox {
+                network_access: network.into(),
+            },
+            FileSystemSandboxKind::Unrestricted => {
+                if network.is_enabled() {
+                    SandboxPolicy::DangerFullAccess
+                } else {
+                    SandboxPolicy::ExternalSandbox {
+                        network_access: NetworkAccess::Restricted,
+                    }
+                }
+            }
+            FileSystemSandboxKind::Restricted => {
+                if self.has_full_disk_write_access() {
+                    return if network.is_enabled() {
+                        SandboxPolicy::DangerFullAccess
+                    } else {
+                        SandboxPolicy::ExternalSandbox {
+                            network_access: NetworkAccess::Restricted,
+                        }
+                    };
+                }
+
+                let mut workspace_writable = false;
+                let mut writable_roots = Vec::new();
+                let mut tmpdir_writable = false;
+                let mut slash_tmp_writable = false;
+                for entry in &self.entries {
+                    if !entry.access.can_write() {
+                        continue;
+                    }
+                    match &entry.path {
+                        FileSystemPath::Special {
+                            value: FileSystemSpecialPath::ProjectRoots { subpath: None },
+                        } => workspace_writable = true,
+                        FileSystemPath::Special {
+                            value: FileSystemSpecialPath::Tmpdir,
+                        } => tmpdir_writable = true,
+                        FileSystemPath::Special {
+                            value: FileSystemSpecialPath::SlashTmp,
+                        } => slash_tmp_writable = true,
+                        _ => match resolve_file_system_path(&entry.path, cwd) {
+                            Some(path) if path == cwd => workspace_writable = true,
+                            Some(path) => writable_roots.push(path),
+                            None => {}
+                        },
+                    }
+                }
+
+                if workspace_writable {
+                    writable_roots.retain(|root| root != cwd);
+                    SandboxPolicy::WorkspaceWrite {
+                        writable_roots: dedup_paths(writable_roots),
+                        network_access: network.is_enabled(),
+                        exclude_tmpdir_env_var: !tmpdir_writable,
+                        exclude_slash_tmp: !slash_tmp_writable,
+                    }
+                } else {
+                    SandboxPolicy::ReadOnly {
+                        network_access: network.is_enabled(),
+                    }
+                }
+            }
+        }
+    }
+
+    fn resolve_access_with_cwd(&self, path: &Path, cwd: &Path) -> FileSystemAccessMode {
+        match self.kind {
+            FileSystemSandboxKind::Unrestricted | FileSystemSandboxKind::ExternalSandbox => {
+                return FileSystemAccessMode::Write;
+            }
+            FileSystemSandboxKind::Restricted => {}
+        }
+
+        let path = resolve_path_against_cwd(path, cwd);
+        self.resolved_entries_with_cwd(cwd)
+            .into_iter()
+            .filter(|entry| path.starts_with(&entry.path))
+            .max_by(resolved_entry_precedence)
+            .map(|entry| entry.access)
+            .unwrap_or(FileSystemAccessMode::Deny)
+    }
+
+    fn resolved_entries_with_cwd(&self, cwd: &Path) -> Vec<ResolvedEntry> {
+        self.entries
+            .iter()
+            .filter_map(|entry| {
+                resolve_entry_path(&entry.path, cwd).map(|path| ResolvedEntry {
+                    path,
+                    access: entry.access,
+                })
+            })
+            .collect()
+    }
+
+    fn has_root_access(&self, predicate: impl Fn(FileSystemAccessMode) -> bool) -> bool {
+        matches!(self.kind, FileSystemSandboxKind::Restricted)
+            && self.entries.iter().any(|entry| {
+                matches!(
+                    &entry.path,
+                    FileSystemPath::Special {
+                        value: FileSystemSpecialPath::Root
+                    } if predicate(entry.access)
+                )
+            })
+    }
+
+    fn has_denied_read_restrictions(&self) -> bool {
+        matches!(self.kind, FileSystemSandboxKind::Restricted)
+            && self
+                .entries
+                .iter()
+                .any(|entry| entry.access == FileSystemAccessMode::Deny)
+    }
+
+    fn has_write_narrowing_entries(&self) -> bool {
+        matches!(self.kind, FileSystemSandboxKind::Restricted)
+            && self.entries.iter().any(|entry| {
+                if entry.access.can_write() {
+                    return false;
+                }
+                !matches!(
+                    &entry.path,
+                    FileSystemPath::Special {
+                        value: FileSystemSpecialPath::Root
+                    } if entry.access == FileSystemAccessMode::Read
+                )
+            })
+    }
+
+    fn metadata_write_denied(&self, path: &Path, cwd: &Path) -> bool {
+        let target = resolve_path_against_cwd(path, cwd);
+        self.resolved_entries_with_cwd(cwd)
+            .into_iter()
+            .filter(|entry| !entry.access.can_write())
+            .any(|entry| {
+                target.starts_with(&entry.path)
+                    && entry
+                        .path
+                        .file_name()
+                        .and_then(|file_name| file_name.to_str())
+                        .is_some_and(|file_name| PROTECTED_METADATA_NAMES.contains(&file_name))
+            })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ManagedFileSystemPermissions {
+    Restricted {
+        #[serde(default)]
+        entries: Vec<FileSystemSandboxEntry>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        glob_scan_max_depth: Option<usize>,
+    },
+    Unrestricted,
+}
+
+impl ManagedFileSystemPermissions {
+    fn from_sandbox_policy(policy: &FileSystemSandboxPolicy) -> Self {
+        match policy.kind {
+            FileSystemSandboxKind::Restricted => Self::Restricted {
+                entries: policy.entries.clone(),
+                glob_scan_max_depth: policy.glob_scan_max_depth,
+            },
+            FileSystemSandboxKind::Unrestricted => Self::Unrestricted,
+            FileSystemSandboxKind::ExternalSandbox => {
+                unreachable!(
+                    "external filesystem policy is represented by PermissionProfile::External"
+                )
+            }
+        }
+    }
+
+    pub fn to_sandbox_policy(&self) -> FileSystemSandboxPolicy {
+        match self {
+            Self::Restricted {
+                entries,
+                glob_scan_max_depth,
+            } => FileSystemSandboxPolicy {
+                kind: FileSystemSandboxKind::Restricted,
+                glob_scan_max_depth: *glob_scan_max_depth,
+                entries: entries.clone(),
+            },
+            Self::Unrestricted => FileSystemSandboxPolicy::unrestricted(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PermissionProfile {
+    Managed {
+        file_system: ManagedFileSystemPermissions,
+        network: NetworkSandboxPolicy,
+    },
+    Disabled,
+    External {
+        network: NetworkSandboxPolicy,
+    },
+}
+
+impl PermissionProfile {
+    pub fn workspace_write() -> Self {
+        let file_system = FileSystemSandboxPolicy::workspace_write(&[], false, false);
+        Self::Managed {
+            file_system: ManagedFileSystemPermissions::from_sandbox_policy(&file_system),
+            network: NetworkSandboxPolicy::Restricted,
+        }
+    }
+
+    pub fn from_legacy_sandbox_policy(policy: &SandboxPolicy, cwd: &Path) -> Self {
+        match policy {
+            SandboxPolicy::DangerFullAccess => Self::Disabled,
+            SandboxPolicy::ExternalSandbox { network_access } => Self::External {
+                network: (*network_access).into(),
+            },
+            SandboxPolicy::ReadOnly { network_access } => Self::Managed {
+                file_system: ManagedFileSystemPermissions::from_sandbox_policy(
+                    &FileSystemSandboxPolicy::read_only(),
+                ),
+                network: NetworkSandboxPolicy::from_bool(*network_access),
+            },
+            SandboxPolicy::WorkspaceWrite {
+                writable_roots,
+                network_access,
+                exclude_tmpdir_env_var,
+                exclude_slash_tmp,
+            } => {
+                let _ = cwd;
+                let file_system = FileSystemSandboxPolicy::workspace_write(
+                    writable_roots,
+                    *exclude_tmpdir_env_var,
+                    *exclude_slash_tmp,
+                );
+                Self::Managed {
+                    file_system: ManagedFileSystemPermissions::from_sandbox_policy(&file_system),
+                    network: NetworkSandboxPolicy::from_bool(*network_access),
+                }
+            }
+        }
+    }
+
+    pub fn to_runtime_permissions(&self) -> (FileSystemSandboxPolicy, NetworkSandboxPolicy) {
+        (
+            self.file_system_sandbox_policy(),
+            self.network_sandbox_policy(),
+        )
+    }
+
+    pub fn file_system_sandbox_policy(&self) -> FileSystemSandboxPolicy {
+        match self {
+            Self::Managed { file_system, .. } => file_system.to_sandbox_policy(),
+            Self::Disabled => FileSystemSandboxPolicy::unrestricted(),
+            Self::External { .. } => FileSystemSandboxPolicy::external_sandbox(),
+        }
+    }
+
+    pub fn network_sandbox_policy(&self) -> NetworkSandboxPolicy {
+        match self {
+            Self::Managed { network, .. } | Self::External { network } => *network,
+            Self::Disabled => NetworkSandboxPolicy::Enabled,
+        }
+    }
+
+    pub fn has_full_network_access(&self) -> bool {
+        self.network_sandbox_policy().is_enabled()
+    }
+
+    pub fn has_full_disk_write_access(&self) -> bool {
+        self.file_system_sandbox_policy()
+            .has_full_disk_write_access()
+    }
+
+    pub fn requires_managed_sandbox(&self) -> bool {
+        match self {
+            Self::Disabled => false,
+            Self::External { network } => !network.is_enabled(),
+            Self::Managed { .. } => {
+                !self.has_full_disk_write_access() || !self.has_full_network_access()
+            }
+        }
+    }
+
+    pub fn with_additional_writable_root(self, root: PathBuf) -> Self {
+        match self {
+            Self::Managed {
+                file_system,
+                network,
+            } => {
+                let file_system = file_system
+                    .to_sandbox_policy()
+                    .with_additional_writable_root(root);
+                Self::Managed {
+                    file_system: ManagedFileSystemPermissions::from_sandbox_policy(&file_system),
+                    network,
+                }
+            }
+            Self::Disabled => Self::Disabled,
+            Self::External { network } => Self::External { network },
+        }
+    }
+
+    pub fn to_legacy_sandbox_policy(&self, cwd: &Path) -> SandboxPolicy {
+        match self {
+            Self::Disabled => SandboxPolicy::DangerFullAccess,
+            Self::External { network } => SandboxPolicy::ExternalSandbox {
+                network_access: (*network).into(),
+            },
+            Self::Managed {
+                file_system,
+                network,
+            } => file_system
+                .to_sandbox_policy()
+                .to_legacy_sandbox_policy(*network, cwd),
+        }
+    }
+}
+
+impl NetworkSandboxPolicy {
+    fn from_bool(value: bool) -> Self {
+        if value {
+            Self::Enabled
+        } else {
+            Self::Restricted
+        }
+    }
+}
+
+impl From<NetworkSandboxPolicy> for NetworkAccess {
+    fn from(value: NetworkSandboxPolicy) -> Self {
+        if value.is_enabled() {
+            NetworkAccess::Enabled
+        } else {
+            NetworkAccess::Restricted
+        }
+    }
+}
+
+impl From<NetworkAccess> for NetworkSandboxPolicy {
+    fn from(value: NetworkAccess) -> Self {
+        if value.is_enabled() {
+            NetworkSandboxPolicy::Enabled
+        } else {
+            NetworkSandboxPolicy::Restricted
+        }
+    }
+}
+
+fn resolve_entry_path(path: &FileSystemPath, cwd: &Path) -> Option<PathBuf> {
+    match path {
+        FileSystemPath::Special {
+            value: FileSystemSpecialPath::Root,
+        } => Some(PathBuf::from("/")),
+        _ => resolve_file_system_path(path, cwd),
+    }
+}
+
+fn resolve_file_system_path(path: &FileSystemPath, cwd: &Path) -> Option<PathBuf> {
+    match path {
+        FileSystemPath::Path { path } => Some(resolve_path_against_cwd(path, cwd)),
+        FileSystemPath::GlobPattern { .. } => None,
+        FileSystemPath::Special { value } => resolve_file_system_special_path(value, cwd),
+    }
+}
+
+fn resolve_file_system_special_path(value: &FileSystemSpecialPath, cwd: &Path) -> Option<PathBuf> {
+    match value {
+        FileSystemSpecialPath::Root => Some(PathBuf::from("/")),
+        FileSystemSpecialPath::Minimal => None,
+        FileSystemSpecialPath::ProjectRoots { subpath: None } => Some(cwd.to_path_buf()),
+        FileSystemSpecialPath::ProjectRoots {
+            subpath: Some(subpath),
+        } => Some(resolve_path_against_cwd(subpath, cwd)),
+        FileSystemSpecialPath::Tmpdir => std::env::var_os("TMPDIR")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .filter(|path| path.is_absolute()),
+        FileSystemSpecialPath::SlashTmp => Some(PathBuf::from("/tmp")),
+        FileSystemSpecialPath::Unknown { .. } => None,
+    }
+}
+
+fn resolve_path_against_cwd(path: &Path, cwd: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
+fn default_read_only_subpaths_for_writable_root(root: &Path) -> Vec<PathBuf> {
+    PROTECTED_METADATA_NAMES
+        .iter()
+        .map(|name| root.join(name))
+        .collect()
+}
+
+fn resolved_entry_precedence(left: &ResolvedEntry, right: &ResolvedEntry) -> Ordering {
+    left.path
+        .components()
+        .count()
+        .cmp(&right.path.components().count())
+        .then_with(|| left.access.cmp(&right.access))
+}
+
+fn dedup_paths(mut paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+pub fn normalize_permission_profile_paths(
+    mut profile: PermissionProfile,
+) -> Result<PermissionProfile, String> {
+    match &mut profile {
+        PermissionProfile::Managed { file_system, .. } => {
+            if let ManagedFileSystemPermissions::Restricted { entries, .. } = file_system {
+                for entry in entries {
+                    normalize_file_system_path(&mut entry.path)?;
+                }
+            }
+        }
+        PermissionProfile::Disabled | PermissionProfile::External { .. } => {}
+    }
+    validate_permission_profile(&profile)?;
+    Ok(profile)
+}
+
+pub fn validate_permission_profile(profile: &PermissionProfile) -> Result<(), String> {
+    let file_system = profile.file_system_sandbox_policy();
+    for entry in &file_system.entries {
+        validate_file_system_path(&entry.path)?;
+    }
+    Ok(())
+}
+
+fn normalize_file_system_path(path: &mut FileSystemPath) -> Result<(), String> {
+    let FileSystemPath::Path { path } = path else {
+        return Ok(());
+    };
+    let raw = path.to_string_lossy();
+    if !raw.starts_with("file:") {
+        return Ok(());
+    }
+    let url = Url::parse(&raw).map_err(|err| {
+        format!("Codex permissionProfile.file_system.entries.path has invalid file URI: {err}")
+    })?;
+    *path = url.to_file_path().map_err(|_| {
+        format!("Codex permissionProfile.file_system.entries.path must be a local file URI: {raw}")
+    })?;
+    Ok(())
+}
+
+fn validate_file_system_path(path: &FileSystemPath) -> Result<(), String> {
+    match path {
+        FileSystemPath::Path { path } => {
+            if !path.is_absolute() {
+                return Err(format!(
+                    "Codex permissionProfile.file_system.entries.path requires absolute paths, got: {}",
+                    path.display()
+                ));
+            }
+        }
+        FileSystemPath::GlobPattern { .. } => {}
+        FileSystemPath::Special {
+            value:
+                FileSystemSpecialPath::ProjectRoots {
+                    subpath: Some(subpath),
+                },
+        } => {
+            if subpath.is_absolute() {
+                return Err(format!(
+                    "Codex permissionProfile.file_system project_roots subpath must be relative, got: {}",
+                    subpath.display()
+                ));
+            }
+        }
+        FileSystemPath::Special { .. } => {}
+    }
+    Ok(())
+}

--- a/src/sandbox_cli.rs
+++ b/src/sandbox_cli.rs
@@ -231,9 +231,8 @@ pub fn resolve_effective_sandbox_state_with_defaults(
                 apply_mode(&mut state, *mode, inherited, defaults)?
             }
             SandboxCliOperation::AddWritableRoot(path) => {
-                let SandboxPolicy::WorkspaceWrite { writable_roots, .. } =
-                    &mut state.sandbox_policy
-                else {
+                let mut policy = state.sandbox_policy.clone();
+                let SandboxPolicy::WorkspaceWrite { writable_roots, .. } = &mut policy else {
                     return Err(
                         "--add-writable-root can only be used while sandbox mode is workspace-write"
                             .to_string(),
@@ -242,6 +241,7 @@ pub fn resolve_effective_sandbox_state_with_defaults(
                 if !writable_roots.iter().any(|root| root == path) {
                     writable_roots.push(path.clone());
                 }
+                state.set_sandbox_policy(policy);
             }
             SandboxCliOperation::AddAllowedDomain(domain) => {
                 let domain = domain.trim();
@@ -383,22 +383,22 @@ fn apply_mode(
         }
         SandboxModeArg::ReadOnly => {
             *state = defaults.clone();
-            state.sandbox_policy = SandboxPolicy::ReadOnly {
+            state.set_sandbox_policy(SandboxPolicy::ReadOnly {
                 network_access: false,
-            };
+            });
         }
         SandboxModeArg::WorkspaceWrite => {
             *state = defaults.clone();
-            state.sandbox_policy = SandboxPolicy::WorkspaceWrite {
+            state.set_sandbox_policy(SandboxPolicy::WorkspaceWrite {
                 writable_roots: Vec::new(),
                 network_access: false,
                 exclude_tmpdir_env_var: false,
                 exclude_slash_tmp: false,
-            };
+            });
         }
         SandboxModeArg::DangerFullAccess => {
             *state = defaults.clone();
-            state.sandbox_policy = SandboxPolicy::DangerFullAccess;
+            state.set_sandbox_policy(SandboxPolicy::DangerFullAccess);
         }
     }
     Ok(())
@@ -413,10 +413,11 @@ fn apply_config_op(
     match op {
         SandboxConfigOperation::SetMode(mode) => apply_mode(state, *mode, inherited, defaults),
         SandboxConfigOperation::SetWorkspaceNetworkAccess(network_access) => {
+            let mut policy = state.sandbox_policy.clone();
             let SandboxPolicy::WorkspaceWrite {
                 network_access: current,
                 ..
-            } = &mut state.sandbox_policy
+            } = &mut policy
             else {
                 return Err(
                     "sandbox_workspace_write.network_access requires workspace-write mode"
@@ -424,13 +425,15 @@ fn apply_config_op(
                 );
             };
             *current = *network_access;
+            state.set_sandbox_policy(policy);
             Ok(())
         }
         SandboxConfigOperation::SetWorkspaceWritableRoots(roots) => {
+            let mut policy = state.sandbox_policy.clone();
             let SandboxPolicy::WorkspaceWrite {
                 writable_roots: current,
                 ..
-            } = &mut state.sandbox_policy
+            } = &mut policy
             else {
                 return Err(
                     "sandbox_workspace_write.writable_roots requires workspace-write mode"
@@ -438,13 +441,15 @@ fn apply_config_op(
                 );
             };
             *current = roots.clone();
+            state.set_sandbox_policy(policy);
             Ok(())
         }
         SandboxConfigOperation::SetWorkspaceExcludeTmpdirEnvVar(value) => {
+            let mut policy = state.sandbox_policy.clone();
             let SandboxPolicy::WorkspaceWrite {
                 exclude_tmpdir_env_var,
                 ..
-            } = &mut state.sandbox_policy
+            } = &mut policy
             else {
                 return Err(
                     "sandbox_workspace_write.exclude_tmpdir_env_var requires workspace-write mode"
@@ -452,12 +457,14 @@ fn apply_config_op(
                 );
             };
             *exclude_tmpdir_env_var = *value;
+            state.set_sandbox_policy(policy);
             Ok(())
         }
         SandboxConfigOperation::SetWorkspaceExcludeSlashTmp(value) => {
+            let mut policy = state.sandbox_policy.clone();
             let SandboxPolicy::WorkspaceWrite {
                 exclude_slash_tmp, ..
-            } = &mut state.sandbox_policy
+            } = &mut policy
             else {
                 return Err(
                     "sandbox_workspace_write.exclude_slash_tmp requires workspace-write mode"
@@ -465,6 +472,7 @@ fn apply_config_op(
                 );
             };
             *exclude_slash_tmp = *value;
+            state.set_sandbox_policy(policy);
             Ok(())
         }
         SandboxConfigOperation::SetAllowedDomains(values) => {
@@ -481,6 +489,7 @@ fn apply_config_op(
         }
         SandboxConfigOperation::SetUseLinuxSandboxBwrap(value) => {
             state.use_linux_sandbox_bwrap = *value;
+            state.use_legacy_landlock = !*value;
             Ok(())
         }
     }

--- a/src/worker_process.rs
+++ b/src/worker_process.rs
@@ -101,14 +101,18 @@ pub(crate) fn worker_context_event_payload(
 ) -> serde_json::Value {
     let sandbox_policy = serde_json::to_value(&sandbox_state.sandbox_policy)
         .unwrap_or_else(|err| serde_json::json!({ "serialize_error": err.to_string() }));
+    let permission_profile = serde_json::to_value(&sandbox_state.permission_profile)
+        .unwrap_or_else(|err| serde_json::json!({ "serialize_error": err.to_string() }));
     serde_json::json!({
         "backend": format!("{backend:?}"),
         "worker_launch": worker_launch.label(),
         "stdin_transport": worker_launch.stdin_transport().as_str(),
         "sandbox_policy": sandbox_policy,
+        "permission_profile": permission_profile,
         "sandbox_cwd": sandbox_state.sandbox_cwd.to_string_lossy().to_string(),
         "session_temp_dir": sandbox_state.session_temp_dir.to_string_lossy().to_string(),
         "use_linux_sandbox_bwrap": sandbox_state.use_linux_sandbox_bwrap,
+        "use_legacy_landlock": sandbox_state.use_legacy_landlock,
         "managed_network_policy": {
             "allowed_domains": sandbox_state.managed_network_policy.allowed_domains.clone(),
             "denied_domains": sandbox_state.managed_network_policy.denied_domains.clone(),

--- a/src/worker_process/sandbox_state.rs
+++ b/src/worker_process/sandbox_state.rs
@@ -73,6 +73,7 @@ impl WorkerManager {
 
         let update = SandboxStateUpdate {
             sandbox_policy: self.sandbox_defaults.sandbox_policy.clone(),
+            permission_profile: Some(self.sandbox_defaults.permission_profile.clone()),
             sandbox_cwd: Some(self.sandbox_defaults.sandbox_cwd.clone()),
             use_linux_sandbox_bwrap: Some(self.sandbox_defaults.use_linux_sandbox_bwrap),
             use_legacy_landlock: None,
@@ -156,6 +157,7 @@ impl WorkerManager {
     fn apply_linux_bwrap_fallback_override(&self, state: &mut SandboxState) {
         if self.linux_bwrap_fallback_disabled {
             state.use_linux_sandbox_bwrap = false;
+            state.use_legacy_landlock = true;
         }
     }
 
@@ -289,6 +291,7 @@ mod tests {
                     exclude_tmpdir_env_var: false,
                     exclude_slash_tmp: false,
                 },
+                permission_profile: None,
                 sandbox_cwd: Some(writable_root.clone()),
                 use_linux_sandbox_bwrap: None,
                 use_legacy_landlock: None,
@@ -337,6 +340,7 @@ mod tests {
                 exclude_tmpdir_env_var: false,
                 exclude_slash_tmp: false,
             },
+            permission_profile: None,
             sandbox_cwd: None,
             use_linux_sandbox_bwrap: None,
             use_legacy_landlock: None,
@@ -353,6 +357,7 @@ mod tests {
             .update_sandbox_state(
                 SandboxStateUpdate {
                     sandbox_policy: SandboxPolicy::DangerFullAccess,
+                    permission_profile: None,
                     sandbox_cwd: None,
                     use_linux_sandbox_bwrap: None,
                     use_legacy_landlock: None,

--- a/src/worker_process/worker_launch.rs
+++ b/src/worker_process/worker_launch.rs
@@ -130,9 +130,12 @@ impl WorkerManager {
 
         self.linux_bwrap_fallback_disabled = true;
         self.sandbox_state.use_linux_sandbox_bwrap = false;
+        self.sandbox_state.use_legacy_landlock = true;
         self.sandbox_defaults.use_linux_sandbox_bwrap = false;
+        self.sandbox_defaults.use_legacy_landlock = true;
         if let Some(inherited_state) = self.inherited_sandbox_state.as_mut() {
             inherited_state.use_linux_sandbox_bwrap = false;
+            inherited_state.use_legacy_landlock = true;
         }
 
         match self.oversized_output {
@@ -243,8 +246,6 @@ mod tests {
     use crate::sandbox_cli::resolve_effective_sandbox_state_with_defaults;
     #[cfg(target_os = "linux")]
     use crate::worker_process::test_support::contents_text;
-    #[cfg(target_os = "linux")]
-    use std::time::Duration;
 
     #[test]
     fn python_backend_prepares_windows_sandbox_launch() {
@@ -324,6 +325,7 @@ mod tests {
                 exclude_tmpdir_env_var: false,
                 exclude_slash_tmp: false,
             },
+            permission_profile: None,
             sandbox_cwd: Some(std::env::temp_dir()),
             use_linux_sandbox_bwrap: Some(true),
             use_legacy_landlock: None,
@@ -394,7 +396,7 @@ mod tests {
         }))
         .expect("Codex sandbox metadata");
         manager
-            .update_sandbox_state(update, Duration::from_millis(1))
+            .stage_sandbox_state_update(update)
             .expect("follow-up sandbox state");
 
         assert!(
@@ -429,6 +431,7 @@ mod tests {
                 exclude_tmpdir_env_var: false,
                 exclude_slash_tmp: false,
             },
+            permission_profile: None,
             sandbox_cwd: Some(std::env::temp_dir()),
             use_linux_sandbox_bwrap: None,
             use_legacy_landlock: None,
@@ -499,7 +502,7 @@ mod tests {
         }))
         .expect("Codex sandbox metadata");
         manager
-            .update_sandbox_state(update, Duration::from_millis(1))
+            .stage_sandbox_state_update(update)
             .expect("follow-up sandbox state");
 
         assert!(

--- a/src/worker_process/write_flow.rs
+++ b/src/worker_process/write_flow.rs
@@ -598,6 +598,7 @@ mod tests {
                 sandbox_policy: SandboxPolicy::ReadOnly {
                     network_access: false,
                 },
+                permission_profile: None,
                 sandbox_cwd: None,
                 use_linux_sandbox_bwrap: None,
                 use_legacy_landlock: None,
@@ -639,6 +640,7 @@ mod tests {
                 sandbox_policy: SandboxPolicy::ReadOnly {
                     network_access: false,
                 },
+                permission_profile: None,
                 sandbox_cwd: None,
                 use_linux_sandbox_bwrap: None,
                 use_legacy_landlock: None,
@@ -687,6 +689,7 @@ mod tests {
                 sandbox_policy: SandboxPolicy::ReadOnly {
                     network_access: false,
                 },
+                permission_profile: None,
                 sandbox_cwd: Some(sandbox_cwd.clone()),
                 use_linux_sandbox_bwrap: None,
                 use_legacy_landlock: None,
@@ -711,6 +714,7 @@ mod tests {
                         exclude_tmpdir_env_var: false,
                         exclude_slash_tmp: false,
                     },
+                    permission_profile: None,
                     sandbox_cwd: Some(sandbox_cwd.clone()),
                     use_linux_sandbox_bwrap: None,
                     use_legacy_landlock: None,

--- a/tests/codex_integration.rs
+++ b/tests/codex_integration.rs
@@ -359,7 +359,12 @@ mod unix_impl {
             .into());
         }
 
-        assert_exec_output_contains_tool_call(&stdout, "r", "repl", MOCK_TOOL_INPUT)?;
+        if let Err(err) =
+            assert_exec_output_contains_tool_call(&stdout, "r", "repl", MOCK_TOOL_INPUT)
+        {
+            let last_request = mock_server.last_request().await;
+            return Err(format!("{err}\nlast_request: {last_request:?}").into());
+        }
         if !outputs.iter().any(|out| out.contains("CODEX_MOCK_MCP_OK")) {
             let request_paths = mock_server.request_paths().await;
             let last_request = mock_server.last_request().await;
@@ -2607,6 +2612,8 @@ tryCatch({
         next_call_ordinal: usize,
         pending_call_id: Option<String>,
         pending_call_ordinal: Option<usize>,
+        pending_tool_search_call_id: Option<String>,
+        pending_tool_search_tool_args: Option<String>,
     }
 
     impl MockResponsesServer {
@@ -2655,6 +2662,8 @@ tryCatch({
                 next_call_ordinal: 1,
                 pending_call_id: None,
                 pending_call_ordinal: None,
+                pending_tool_search_call_id: None,
+                pending_tool_search_tool_args: None,
             }));
             let state_clone = Arc::clone(&state);
             tokio::spawn(async move {
@@ -2866,19 +2875,30 @@ tryCatch({
             );
         }
 
+        if let Some(call_id) = state.pending_tool_search_call_id.as_deref()
+            && has_tool_search_output(body, call_id)
+        {
+            let tool_args = state
+                .pending_tool_search_tool_args
+                .take()
+                .expect("pending tool search must keep scripted tool arguments");
+            state.pending_tool_search_call_id = None;
+            return queue_deferred_tool_call(state, tool_args);
+        }
+
         if has_user_message(body)
             && let Some(tool_args) = state.first_user_turn_tool_args.take()
         {
-            return queue_tool_call(body, state, tool_args);
+            return queue_tool_call_or_search(body, state, tool_args);
         }
 
         if has_user_marker(body, WORKSPACE_WRITE_MARKER) {
-            return queue_tool_call(body, state, state.workspace_write_tool_args.clone());
+            return queue_tool_call_or_search(body, state, state.workspace_write_tool_args.clone());
         }
         if has_user_marker(body, FULL_ACCESS_MARKER)
             && let Some(tool_args) = state.full_access_tool_args.clone()
         {
-            return queue_tool_call(body, state, tool_args);
+            return queue_tool_call_or_search(body, state, tool_args);
         }
         response_body_with_items(vec![message_item("ready")], "resp-ready")
     }
@@ -2889,20 +2909,68 @@ tryCatch({
         namespace: Option<String>,
     }
 
+    fn queue_tool_call_or_search(
+        request: &Value,
+        state: &mut MockState,
+        tool_args: String,
+    ) -> String {
+        if resolve_visible_tool_call_spec(request, &state.tool_name).is_some() {
+            return queue_tool_call(request, state, tool_args);
+        }
+        if request_has_tool_search(request) {
+            return queue_tool_search_call(state, tool_args);
+        }
+        queue_tool_call(request, state, tool_args)
+    }
+
     fn queue_tool_call(request: &Value, state: &mut MockState, tool_args: String) -> String {
+        let tool_call =
+            resolve_visible_tool_call_spec(request, &state.tool_name).unwrap_or_else(|| {
+                MockToolCallSpec {
+                    name: state.tool_name.clone(),
+                    namespace: None,
+                }
+            });
+        queue_tool_call_with_spec(state, tool_args, tool_call)
+    }
+
+    fn queue_deferred_tool_call(state: &mut MockState, tool_args: String) -> String {
+        let tool_call = split_legacy_tool_name(&state.tool_name).map_or_else(
+            || MockToolCallSpec {
+                name: state.tool_name.clone(),
+                namespace: None,
+            },
+            |(namespace, name)| MockToolCallSpec {
+                name: name.to_string(),
+                namespace: Some(namespace.to_string()),
+            },
+        );
+        queue_tool_call_with_spec(state, tool_args, tool_call)
+    }
+
+    fn queue_tool_call_with_spec(
+        state: &mut MockState,
+        tool_args: String,
+        tool_call: MockToolCallSpec,
+    ) -> String {
         let ordinal = state.next_call_ordinal;
         state.next_call_ordinal += 1;
         let call_id = format!("call-{ordinal}");
         state.pending_call_id = Some(call_id.clone());
         state.pending_call_ordinal = Some(ordinal);
-        let tool_call =
-            resolve_tool_call_spec(request, &state.tool_name).unwrap_or_else(|| MockToolCallSpec {
-                name: state.tool_name.clone(),
-                namespace: None,
-            });
         response_body_with_items(
             vec![function_call_item(&tool_call, &call_id, &tool_args)],
             &format!("resp-call-{ordinal}"),
+        )
+    }
+
+    fn queue_tool_search_call(state: &mut MockState, tool_args: String) -> String {
+        let call_id = format!("tool-search-{}", state.next_call_ordinal);
+        state.pending_tool_search_call_id = Some(call_id.clone());
+        state.pending_tool_search_tool_args = Some(tool_args);
+        response_body_with_items(
+            vec![tool_search_call_item(&call_id, &state.tool_name)],
+            &format!("resp-search-{}", state.next_call_ordinal),
         )
     }
 
@@ -2936,6 +3004,26 @@ tryCatch({
         item
     }
 
+    fn tool_search_call_item(call_id: &str, tool_name: &str) -> Value {
+        serde_json::json!({
+            "type": "tool_search_call",
+            "call_id": call_id,
+            "execution": "client",
+            "arguments": {
+                "query": tool_name.replace("__", " "),
+                "limit": 8,
+            },
+        })
+    }
+
+    fn resolve_visible_tool_call_spec(
+        request: &Value,
+        legacy_tool_name: &str,
+    ) -> Option<MockToolCallSpec> {
+        resolve_tool_call_spec(request, legacy_tool_name)
+            .or_else(|| resolve_legacy_function_tool_call_spec(request, legacy_tool_name))
+    }
+
     fn resolve_tool_call_spec(request: &Value, legacy_tool_name: &str) -> Option<MockToolCallSpec> {
         let (namespace, name) = split_legacy_tool_name(legacy_tool_name)?;
         let tools = request.get("tools")?.as_array()?;
@@ -2956,6 +3044,23 @@ tryCatch({
             name: name.to_string(),
             namespace: Some(namespace.to_string()),
         })
+    }
+
+    fn resolve_legacy_function_tool_call_spec(
+        request: &Value,
+        legacy_tool_name: &str,
+    ) -> Option<MockToolCallSpec> {
+        let tools = request.get("tools")?.as_array()?;
+        tools
+            .iter()
+            .any(|tool| {
+                tool.get("type").and_then(Value::as_str) == Some("function")
+                    && tool.get("name").and_then(Value::as_str) == Some(legacy_tool_name)
+            })
+            .then(|| MockToolCallSpec {
+                name: legacy_tool_name.to_string(),
+                namespace: None,
+            })
     }
 
     fn split_legacy_tool_name(legacy_tool_name: &str) -> Option<(&str, &str)> {
@@ -3001,6 +3106,15 @@ tryCatch({
             .unwrap_or(false)
     }
 
+    fn request_has_tool_search(body: &Value) -> bool {
+        let Some(tools) = body.get("tools").and_then(Value::as_array) else {
+            return false;
+        };
+        tools
+            .iter()
+            .any(|tool| tool.get("type").and_then(Value::as_str) == Some("tool_search"))
+    }
+
     fn has_user_message(body: &Value) -> bool {
         let Some(items) = body.get("input").and_then(Value::as_array) else {
             return false;
@@ -3017,6 +3131,16 @@ tryCatch({
         };
         items.iter().any(|item| {
             item.get("type").and_then(Value::as_str) == Some("function_call_output")
+                && item.get("call_id").and_then(Value::as_str) == Some(call_id)
+        })
+    }
+
+    fn has_tool_search_output(body: &Value, call_id: &str) -> bool {
+        let Some(items) = body.get("input").and_then(Value::as_array) else {
+            return false;
+        };
+        items.iter().any(|item| {
+            item.get("type").and_then(Value::as_str) == Some("tool_search_output")
                 && item.get("call_id").and_then(Value::as_str) == Some(call_id)
         })
     }

--- a/tests/sandbox_state_meta.rs
+++ b/tests/sandbox_state_meta.rs
@@ -226,7 +226,7 @@ fn read_only_meta(sandbox_cwd: &Path) -> Value {
 
 fn read_only_restricted_access_meta(sandbox_cwd: &Path) -> Value {
     codex_sandbox_state_meta(
-        managed_profile(Vec::new(), "restricted"),
+        managed_profile(vec![special_entry("minimal", "read")], "restricted"),
         sandbox_cwd,
         false,
     )
@@ -2559,7 +2559,7 @@ async fn sandbox_inherit_workspace_write_meta_allows_write_in_cwd() -> TestResul
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn sandbox_inherit_rejects_restricted_read_workspace_write_meta() -> TestResult<()> {
+async fn sandbox_inherit_accepts_restricted_read_workspace_write_meta() -> TestResult<()> {
     let _guard = test_guard();
     let temp = tempdir()?;
     let session = spawn_inherit_server(temp.path()).await?;
@@ -2577,24 +2577,20 @@ async fn sandbox_inherit_rejects_restricted_read_workspace_write_meta() -> TestR
         eprintln!("sandbox_state_meta backend unavailable in this environment; skipping");
         return Ok(());
     }
-    assert_eq!(
-        result.is_error,
-        Some(true),
-        "expected restricted read metadata to be reported as an MCP tool error"
+    assert!(
+        result.is_error != Some(true),
+        "did not expect restricted read workspace-write metadata to be rejected, got: {text}"
     );
     assert!(
-        text.contains("read entry cannot be represented"),
-        "expected restricted read metadata rejection, got: {text}"
-    );
-    assert!(
-        !text.contains("[1] 2"),
-        "did not expect input to run after unsupported restricted read metadata, got: {text}"
+        text.contains("[1] 2"),
+        "expected input to run after restricted read workspace-write metadata, got: {text}"
     );
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn sandbox_inherit_rejects_restricted_read_only_meta() -> TestResult<()> {
+async fn sandbox_inherit_accepts_restricted_read_only_meta_when_backend_supports_it()
+-> TestResult<()> {
     let _guard = test_guard();
     let temp = tempdir()?;
     let session = spawn_inherit_server(temp.path()).await?;
@@ -2612,24 +2608,35 @@ async fn sandbox_inherit_rejects_restricted_read_only_meta() -> TestResult<()> {
         eprintln!("sandbox_state_meta backend unavailable in this environment; skipping");
         return Ok(());
     }
-    assert_eq!(
-        result.is_error,
-        Some(true),
-        "expected restricted read-only metadata to be reported as an MCP tool error"
+    assert!(
+        !text.contains("failed to parse Codex sandbox state metadata"),
+        "restricted read-only metadata should parse, got: {text}"
+    );
+    if text.contains("legacy Linux Landlock filesystem backend") {
+        eprintln!(
+            "restricted read-only metadata requires the bwrap backend in this environment; skipping"
+        );
+        return Ok(());
+    }
+    if text.contains("worker protocol error: ipc disconnected while waiting for worker_ready") {
+        eprintln!(
+            "restricted read-only metadata could not start under this Linux sandbox backend; skipping"
+        );
+        return Ok(());
+    }
+    assert!(
+        result.is_error != Some(true),
+        "did not expect restricted read-only metadata to be rejected when backend supports it, got: {text}"
     );
     assert!(
-        text.contains("without root read access"),
-        "expected restricted read-only metadata rejection, got: {text}"
-    );
-    assert!(
-        !text.contains("[1] 2"),
-        "did not expect input to run after unsupported restricted read-only metadata, got: {text}"
+        text.contains("[1] 2"),
+        "expected input to run after restricted read-only metadata, got: {text}"
     );
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn sandbox_inherit_rejects_full_write_network_restricted_meta() -> TestResult<()> {
+async fn sandbox_inherit_accepts_full_write_network_restricted_meta() -> TestResult<()> {
     let _guard = test_guard();
     let temp = tempdir()?;
     let session = spawn_inherit_server(temp.path()).await?;
@@ -2643,24 +2650,19 @@ async fn sandbox_inherit_rejects_full_write_network_restricted_meta() -> TestRes
     let text = collect_text(&result);
     session.cancel().await?;
 
-    assert_eq!(
-        result.is_error,
-        Some(true),
-        "expected full-write restricted-network metadata to be reported as an MCP tool error"
+    assert!(
+        result.is_error != Some(true),
+        "did not expect full-write restricted-network metadata to be rejected, got: {text}"
     );
     assert!(
-        text.contains("full write access with restricted network access is not supported"),
-        "expected full-write restricted-network metadata rejection, got: {text}"
-    );
-    assert!(
-        !text.contains("[1] 2"),
-        "did not expect input to run after unsupported full-write restricted-network metadata, got: {text}"
+        text.contains("[1] 2"),
+        "expected input to run after full-write restricted-network metadata, got: {text}"
     );
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn sandbox_inherit_rejects_root_write_network_restricted_meta() -> TestResult<()> {
+async fn sandbox_inherit_accepts_root_write_network_restricted_meta() -> TestResult<()> {
     let _guard = test_guard();
     let temp = tempdir()?;
     let session = spawn_inherit_server(temp.path()).await?;
@@ -2674,18 +2676,13 @@ async fn sandbox_inherit_rejects_root_write_network_restricted_meta() -> TestRes
     let text = collect_text(&result);
     session.cancel().await?;
 
-    assert_eq!(
-        result.is_error,
-        Some(true),
-        "expected root-write restricted-network metadata to be reported as an MCP tool error"
+    assert!(
+        result.is_error != Some(true),
+        "did not expect root-write restricted-network metadata to be rejected, got: {text}"
     );
     assert!(
-        text.contains("full write access with restricted network access is not supported"),
-        "expected root-write restricted-network metadata rejection, got: {text}"
-    );
-    assert!(
-        !text.contains("[1] 2"),
-        "did not expect input to run after unsupported root-write restricted-network metadata, got: {text}"
+        text.contains("[1] 2"),
+        "expected input to run after root-write restricted-network metadata, got: {text}"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

This replaces the Linux sandbox internals with a permission-profile runtime model so `mcp-repl` can represent current per-tool-call sandbox metadata directly while keeping the existing public CLI arguments stable. The change is Linux-focused and keeps older local sandbox modes as adapters into the new policy shape.

## User-Facing Changes

- Existing CLI arguments remain supported, including `--sandbox`, `--add-writable-root`, `--add-allowed-domain`, and the current sandbox-related `--config` keys.
- `permissionProfile` is now the canonical inherited sandbox metadata shape; legacy `sandboxPolicy` metadata is still accepted as a minimal compatibility input and converted immediately.
- Linux workers now prefer bubblewrap when available, with legacy Landlock as a fallback when bubblewrap cannot start.
- `MCP_REPL_USE_LINUX_BWRAP=1` forces a bubblewrap attempt; `MCP_REPL_USE_LINUX_BWRAP=0` uses the legacy Landlock path.
- Restricted-read profiles are accepted. Exact read enforcement requires bubblewrap; the legacy Landlock fallback still enforces writable roots but broadens reads to host-readable paths.

## Internal Changes

- Adds `src/sandbox/codex_policy.rs` with `PermissionProfile`, filesystem policy, network policy, path resolution, and legacy policy conversion.
- Changes `SandboxState` to track both the compatibility `SandboxPolicy` and the effective permission profile.
- Updates Linux helper launch to consume `--permission-profile`, build bubblewrap mounts from the new policy model, and apply restricted-network seccomp in the final worker process.
- Keeps `codexLinuxSandboxExe` accepted as incoming metadata but does not expose it as worker runtime state.
- Extends worker context logging with `permission_profile` and `use_legacy_landlock`.
- Updates sandbox docs, the completed implementation plan, and focused sandbox metadata coverage.
