### PR TITLE
Remove review loop guidance from AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,25 +75,6 @@ Keep this file short. It is a table of contents, not the full manual.
 - Do not delete `tests/snapshots/*.snap.new` manually. Use `cargo insta reject`.
 
 
-## Review Loop
-
-- Run `codex review` against the actual PR base, not just `main`.
-- Capture stdout and stderr separately: findings go to stdout; progress logs go to stderr.
-- Run review as one blocking command:
-  - `codex review --base <base> > /tmp/<name>.stdout 2> /tmp/<name>.stderr`
-- Give that command a timeout of at least 30 minutes and let it run to completion.
-- Only poll if the execution tool times out before the process exits. If polling is necessary, poll no more than once every 5-10 minutes.
-- Treat review findings as implementation, test-isolation, or docs-clarity work.
-- If fixing a finding would change the intended contract, rather than implement it, stop and ask the user.
-- If fixing a finding would broaden the PR beyond its intended scope, stop and ask the user unless it is clearly critical.
-- Fix real findings one at a time. Add or adjust the regression test first when practical, keep the branch scope contained, then rerun the required Rust checks. In the commit message for each fix, include the full verbatim finding, as well as the response to how the finding was addressed.
-- After each set of review-fix commits, rerun `codex review` against the same base until stdout reports no actionable findings.
-- If the diff meaning or composition changed during the review loop, update the PR body so it still matches the branch.
-- For large PRs, generate the `Diff composition` section with:
-  - `python3 scripts/diff_composition.py --base <base> --head HEAD --format markdown`
-- Paste that summary into the PR body so reviewers can see how much of the PR is behavior change versus coverage or documentation.
-
-
 ## Planning Rule
 
 - For multi-phase refactors, redesigns, or other work that spans discovery, iteration, and implementation, keep a living plan under `docs/plans/active/` until the initiative is complete.

--- a/tests/docs_contracts.rs
+++ b/tests/docs_contracts.rs
@@ -42,7 +42,6 @@ fn agents_is_short_and_points_to_main_docs() {
         "docs/debugging.md",
         "docs/sandbox.md",
         "docs/plans/AGENTS.md",
-        "scripts/diff_composition.py",
         "cargo test --quiet",
         "python3 tests/run_integration_tests.py --binary target/debug/mcp-repl",
         "cargo insta test --check",


### PR DESCRIPTION
## Summary
- Remove the `Review Loop` section from `AGENTS.md` so the top-level agent guidance stays short and focused on durable repository rules.
- Update the docs contract test to match the shortened AGENTS contents by dropping the removed `scripts/diff_composition.py` reference.
- No public behavior changes; this is an internal documentation cleanup.

## Testing
- Not run (not requested)