### PR TITLE
Expose REPL tools in code mode installs

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -479,6 +479,16 @@ fn normalize_codex_code_mode_item(doc: &mut DocumentMut) -> Result<(), Box<dyn s
     if doc.get("features").is_none() {
         doc["features"] = Item::Table(Table::new());
     }
+    let inline_features = doc["features"].as_inline_table().map(|inline| {
+        let mut table = Table::new();
+        for (key, value) in inline.iter() {
+            table.insert(key, Item::Value(value.clone()));
+        }
+        table
+    });
+    if let Some(table) = inline_features {
+        doc["features"] = Item::Table(table);
+    }
     if !doc["features"].is_table() {
         return Err("`features` must be a TOML table".into());
     }

--- a/src/install.rs
+++ b/src/install.rs
@@ -14,6 +14,7 @@ const CODEX_TOOL_TIMEOUT_COMMENT: &str =
 const CODEX_SANDBOX_INHERIT_COMMENT: &str = "\n# --sandbox inherit: use sandbox policy metadata sent by Codex on each tool call.\n# mcp-repl fails closed if the tool call omits or malforms that metadata.\n";
 pub const DEFAULT_R_SERVER_NAME: &str = "r";
 pub const DEFAULT_PYTHON_SERVER_NAME: &str = "python";
+const MCP_REPL_TOOL_NAMES: &[&str] = &["repl", "repl_reset"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InstallInterpreter {
@@ -103,6 +104,7 @@ pub fn run(options: InstallOptions) -> Result<(), Box<dyn std::error::Error>> {
                     upsert_codex_mcp_server(&path, server_name, &command, &server_args)?;
                 }
                 println!("Updated codex MCP config: {}", path.display());
+                println!("Start a new Codex session to load the updated MCP tools.");
             }
             InstallTarget::Claude => {
                 let config_path = root.join(".claude.json");
@@ -408,6 +410,9 @@ fn upsert_codex_mcp_server(
 
     doc["mcp_servers"][server_name]["command"] = value(command);
     doc["mcp_servers"][server_name]["tool_timeout_sec"] = value(CODEX_TOOL_TIMEOUT_SECS);
+    doc["mcp_servers"][server_name]["enabled"] = value(true);
+    ensure_codex_mcp_server_tools_unfiltered(&mut doc, server_name)?;
+    upsert_codex_code_mode_direct_namespace(&mut doc, server_name)?;
 
     let mut toml_args = Array::default();
     for arg in args {
@@ -435,6 +440,157 @@ fn upsert_codex_mcp_server(
 
     atomic_write(config_path, &doc.to_string())?;
     Ok(())
+}
+
+fn ensure_codex_mcp_server_tools_unfiltered(
+    doc: &mut DocumentMut,
+    server_name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    add_values_to_existing_toml_string_array(
+        &mut doc["mcp_servers"][server_name]["enabled_tools"],
+        MCP_REPL_TOOL_NAMES,
+        &format!("mcp_servers.{server_name}.enabled_tools"),
+    )?;
+    remove_values_from_existing_toml_string_array(
+        &mut doc["mcp_servers"][server_name]["disabled_tools"],
+        MCP_REPL_TOOL_NAMES,
+        &format!("mcp_servers.{server_name}.disabled_tools"),
+    )
+}
+
+fn upsert_codex_code_mode_direct_namespace(
+    doc: &mut DocumentMut,
+    server_name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    normalize_codex_code_mode_item(doc)?;
+    let namespace = codex_namespace_for_server_name(server_name);
+    let item = &mut doc["features"]["code_mode"]["direct_only_tool_namespaces"];
+    let mut namespaces = if item.is_none() {
+        Vec::new()
+    } else {
+        toml_string_array_values(item, "features.code_mode.direct_only_tool_namespaces")?
+    };
+    push_missing_string(&mut namespaces, &namespace);
+    set_toml_string_array(item, &namespaces);
+    Ok(())
+}
+
+fn normalize_codex_code_mode_item(doc: &mut DocumentMut) -> Result<(), Box<dyn std::error::Error>> {
+    if doc.get("features").is_none() {
+        doc["features"] = Item::Table(Table::new());
+    }
+    if !doc["features"].is_table() {
+        return Err("`features` must be a TOML table".into());
+    }
+
+    let code_mode_item = &mut doc["features"]["code_mode"];
+    if code_mode_item.is_none() {
+        *code_mode_item = Item::Table(Table::new());
+        return Ok(());
+    }
+    if code_mode_item.is_table() {
+        return Ok(());
+    }
+    if let Some(enabled) = code_mode_item.as_bool() {
+        let mut table = Table::new();
+        table.insert("enabled", value(enabled));
+        *code_mode_item = Item::Table(table);
+        return Ok(());
+    }
+
+    let Some(inline) = code_mode_item.as_inline_table() else {
+        return Err("`features.code_mode` must be a TOML boolean, table, or inline table".into());
+    };
+    let mut table = Table::new();
+    for (key, value) in inline.iter() {
+        table.insert(key, Item::Value(value.clone()));
+    }
+    *code_mode_item = Item::Table(table);
+    Ok(())
+}
+
+fn codex_namespace_for_server_name(server_name: &str) -> String {
+    format!("mcp__{}", sanitize_codex_tool_name(server_name))
+}
+
+fn sanitize_codex_tool_name(raw: &str) -> String {
+    let mut sanitized = String::with_capacity(raw.len());
+    for c in raw.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' {
+            sanitized.push(c);
+        } else {
+            sanitized.push('_');
+        }
+    }
+    if sanitized.is_empty() {
+        "_".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn add_values_to_existing_toml_string_array(
+    item: &mut Item,
+    values: &[&str],
+    path: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if item.is_none() {
+        return Ok(());
+    }
+    let mut existing = toml_string_array_values(item, path)?;
+    for value in values {
+        push_missing_string(&mut existing, value);
+    }
+    set_toml_string_array(item, &existing);
+    Ok(())
+}
+
+fn remove_values_from_existing_toml_string_array(
+    item: &mut Item,
+    values: &[&str],
+    path: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if item.is_none() {
+        return Ok(());
+    }
+    let existing = toml_string_array_values(item, path)?;
+    let filtered = existing
+        .into_iter()
+        .filter(|existing| !values.contains(&existing.as_str()))
+        .collect::<Vec<_>>();
+    set_toml_string_array(item, &filtered);
+    Ok(())
+}
+
+fn toml_string_array_values(
+    item: &Item,
+    path: &str,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let Some(array) = item.as_array() else {
+        return Err(format!("`{path}` must be a TOML string array").into());
+    };
+    let mut values = Vec::new();
+    for value in array.iter() {
+        let Some(value) = value.as_str() else {
+            return Err(format!("`{path}` must contain only strings").into());
+        };
+        push_missing_string(&mut values, value);
+    }
+    Ok(values)
+}
+
+fn set_toml_string_array(item: &mut Item, values: &[String]) {
+    let mut array = Array::default();
+    for value in values {
+        array.push(value.as_str());
+    }
+    *item = Item::Value(array.into());
+}
+
+fn push_missing_string(values: &mut Vec<String>, value: &str) {
+    if !values.iter().any(|existing| existing == value) {
+        values.push(value.to_string());
+    }
 }
 
 fn format_toml_array_multiline(array: &mut Array) {

--- a/tests/client_config_dual_backend.rs
+++ b/tests/client_config_dual_backend.rs
@@ -327,6 +327,59 @@ command = "/usr/local/bin/notes"
 }
 
 #[test]
+fn install_codex_target_merges_inline_features_table() -> TestResult<()> {
+    let temp = tempfile::tempdir()?;
+    let codex_home = temp.path().join("codex-home");
+    std::fs::create_dir_all(&codex_home)?;
+    std::fs::write(
+        codex_home.join("config.toml"),
+        r#"features = { code_mode = false, use_linux_sandbox_bwrap = false }
+
+[mcp_servers.r]
+command = "/usr/local/bin/old-mcp-repl"
+"#,
+    )?;
+    let exe = resolve_exe()?;
+
+    assert_command_success(
+        Command::new(&exe)
+            .arg("install")
+            .arg("--client")
+            .arg("codex")
+            .arg("--interpreter")
+            .arg("r")
+            .env("CODEX_HOME", &codex_home),
+    )?;
+
+    let text = std::fs::read_to_string(codex_home.join("config.toml"))?;
+    let doc = text.parse::<DocumentMut>()?;
+    assert_eq!(
+        doc["features"]["code_mode"]["enabled"].as_bool(),
+        Some(false),
+        "expected existing inline features.code_mode boolean to move to enabled"
+    );
+    assert_eq!(
+        doc["features"]["use_linux_sandbox_bwrap"].as_bool(),
+        Some(false),
+        "expected unrelated inline features to remain"
+    );
+    let direct_only = doc["features"]["code_mode"]["direct_only_tool_namespaces"]
+        .as_array()
+        .expect("expected direct-only namespaces")
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .expect("expected direct-only namespace string")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(direct_only, vec!["mcp__r".to_string()]);
+
+    Ok(())
+}
+
+#[test]
 fn install_codex_target_preserves_existing_direct_only_namespaces() -> TestResult<()> {
     let temp = tempfile::tempdir()?;
     let codex_home = temp.path().join("codex-home");

--- a/tests/client_config_dual_backend.rs
+++ b/tests/client_config_dual_backend.rs
@@ -133,7 +133,7 @@ fn install_codex_target_defaults_to_r_and_python_servers() -> TestResult<()> {
     assert_eq!(
         String::from_utf8(output.stdout)?,
         format!(
-            "Updated codex MCP config: {}\n",
+            "Updated codex MCP config: {}\nStart a new Codex session to load the updated MCP tools.\n",
             codex_home.join("config.toml").display()
         )
     );
@@ -202,6 +202,176 @@ fn install_codex_target_defaults_to_r_and_python_servers() -> TestResult<()> {
     assert!(
         py_has_files_mode,
         "expected python args to include `--oversized-output files`"
+    );
+    let direct_only = doc["features"]["code_mode"]["direct_only_tool_namespaces"]
+        .as_array()
+        .expect("expected features.code_mode.direct_only_tool_namespaces array")
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .expect("expected direct-only namespace string")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        direct_only,
+        vec!["mcp__r".to_string(), "mcp__python".to_string()]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn install_codex_target_merges_code_mode_visibility_and_unfilters_tools() -> TestResult<()> {
+    let temp = tempfile::tempdir()?;
+    let codex_home = temp.path().join("codex-home");
+    std::fs::create_dir_all(&codex_home)?;
+    std::fs::write(
+        codex_home.join("config.toml"),
+        r#"[features]
+code_mode = false
+
+[mcp_servers.r]
+command = "/usr/local/bin/old-mcp-repl"
+enabled = false
+enabled_tools = ["other"]
+disabled_tools = ["repl", "other", "repl_reset"]
+
+[mcp_servers.notes]
+command = "/usr/local/bin/notes"
+"#,
+    )?;
+    let exe = resolve_exe()?;
+
+    let output = assert_command_success(
+        Command::new(&exe)
+            .arg("install")
+            .arg("--client")
+            .arg("codex")
+            .arg("--interpreter")
+            .arg("r")
+            .env("CODEX_HOME", &codex_home),
+    )?;
+    assert_eq!(
+        String::from_utf8(output.stdout)?,
+        format!(
+            "Updated codex MCP config: {}\nStart a new Codex session to load the updated MCP tools.\n",
+            codex_home.join("config.toml").display()
+        )
+    );
+
+    let text = std::fs::read_to_string(codex_home.join("config.toml"))?;
+    let doc = text.parse::<DocumentMut>()?;
+    assert_eq!(
+        doc["features"]["code_mode"]["enabled"].as_bool(),
+        Some(false),
+        "expected existing features.code_mode boolean to move to enabled"
+    );
+    let direct_only = doc["features"]["code_mode"]["direct_only_tool_namespaces"]
+        .as_array()
+        .expect("expected direct-only namespaces")
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .expect("expected direct-only namespace string")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(direct_only, vec!["mcp__r".to_string()]);
+
+    assert_eq!(
+        doc["mcp_servers"]["r"]["enabled"].as_bool(),
+        Some(true),
+        "expected installed Codex MCP server to be enabled"
+    );
+    let enabled_tools = doc["mcp_servers"]["r"]["enabled_tools"]
+        .as_array()
+        .expect("expected enabled_tools array")
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .expect("expected enabled tool string")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        enabled_tools,
+        vec![
+            "other".to_string(),
+            "repl".to_string(),
+            "repl_reset".to_string()
+        ]
+    );
+    let disabled_tools = doc["mcp_servers"]["r"]["disabled_tools"]
+        .as_array()
+        .expect("expected disabled_tools array")
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .expect("expected disabled tool string")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(disabled_tools, vec!["other".to_string()]);
+    assert_eq!(
+        doc["mcp_servers"]["notes"]["command"].as_str(),
+        Some("/usr/local/bin/notes"),
+        "expected unrelated MCP servers to remain"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn install_codex_target_preserves_existing_direct_only_namespaces() -> TestResult<()> {
+    let temp = tempfile::tempdir()?;
+    let codex_home = temp.path().join("codex-home");
+    std::fs::create_dir_all(&codex_home)?;
+    std::fs::write(
+        codex_home.join("config.toml"),
+        r#"[features.code_mode]
+enabled = false
+direct_only_tool_namespaces = ["mcp__notes", "mcp__r"]
+"#,
+    )?;
+    let exe = resolve_exe()?;
+
+    assert_command_success(
+        Command::new(&exe)
+            .arg("install")
+            .arg("--client")
+            .arg("codex")
+            .env("CODEX_HOME", &codex_home),
+    )?;
+
+    let text = std::fs::read_to_string(codex_home.join("config.toml"))?;
+    let doc = text.parse::<DocumentMut>()?;
+    assert_eq!(
+        doc["features"]["code_mode"]["enabled"].as_bool(),
+        Some(false)
+    );
+    let direct_only = doc["features"]["code_mode"]["direct_only_tool_namespaces"]
+        .as_array()
+        .expect("expected direct-only namespaces")
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .expect("expected direct-only namespace string")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        direct_only,
+        vec![
+            "mcp__notes".to_string(),
+            "mcp__r".to_string(),
+            "mcp__python".to_string()
+        ]
     );
 
     Ok(())

--- a/tests/codex_integration.rs
+++ b/tests/codex_integration.rs
@@ -1295,6 +1295,24 @@ mod unix_impl {
             has_sandbox_inherit,
             "expected installed Codex config to include `--sandbox inherit`"
         );
+        let direct_only = doc["features"]["code_mode"]["direct_only_tool_namespaces"]
+            .as_array()
+            .ok_or_else(|| {
+                "expected features.code_mode.direct_only_tool_namespaces array".to_string()
+            })?
+            .iter()
+            .map(|value| {
+                value
+                    .as_str()
+                    .ok_or_else(|| "expected direct-only namespace string".to_string())
+                    .map(ToString::to_string)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            direct_only,
+            vec!["mcp__r".to_string()],
+            "expected installed Codex config to expose the R MCP namespace directly"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
Make the OpenAI CLI install path expose the R and Python REPL MCP namespaces directly in code mode, so installed tools remain visible after setup.

## User-facing changes
- Installer output now reminds users to start a new session after config updates.
- Installed REPL tools stay visible when existing config uses MCP server allowlists or blocklists.

## Internal changes
- Merge installed MCP namespaces into `features.code_mode.direct_only_tool_namespaces` while keeping unrelated entries.
- Convert legacy boolean code-mode config to table form while preserving `enabled`.
- Force installed MCP server entries on and keep `repl` / `repl_reset` available.
- Added CLI and live config coverage for the generated installer config.
