### PR TITLE
Respect console plot sizing during R drawing

### DIFF
--- a/docs/futurework/repl-tool-description-extras.md
+++ b/docs/futurework/repl-tool-description-extras.md
@@ -137,6 +137,7 @@ It should be treated as source material for:
 ### R plot controls
 
 - `options(console.plot.width = ..., console.plot.height = ...)`
+- `options(console.plot.asp = ...)` (height / width, used when height is unset)
 - `options(console.plot.units = "in" | "cm" | "mm" | "px")`
 - `options(console.plot.dpi = ...)` (alias: `console.plot.res`)
 

--- a/docs/tool-descriptions/repl_tool_r.md
+++ b/docs/tool-descriptions/repl_tool_r.md
@@ -8,7 +8,7 @@ Behavior:
 - Session state (variables, loaded packages) persists across calls. Errors don't crash the session.
 - Uses the user's R installation and library paths.
 
-- Plots (ggplot2 and base R) are captured and returned as images. Adjust sizing with `options(console.plot.width, console.plot.height, console.plot.units, console.plot.dpi)`.
+- Plots (ggplot2 and base R) are captured and returned as images. Adjust the managed console plot device and exported PNG size with `options(console.plot.width, console.plot.height, console.plot.asp, console.plot.units, console.plot.dpi)`. `console.plot.asp` is height / width, matching the shape of knitr `fig.asp` and Quarto `fig-asp`; mcp-repl does not read knitr options or Quarto YAML. Explicit user-opened graphics devices remain user-controlled.
 - Empty `input` polls for more output from a timed-out request or for detached background output while idle.
 - If a request times out, keep polling with empty `input` until the remaining worker output is drained. New non-empty input is discarded while that timed-out request is still active.
 - Large output replies may stay inline when only slightly oversized. Larger overages may be written to a server-owned output bundle directory. The inline reply stays bounded and may show a preview plus the most relevant disclosed path inside that bundle.

--- a/docs/tool-descriptions/repl_tool_r_pager.md
+++ b/docs/tool-descriptions/repl_tool_r_pager.md
@@ -7,7 +7,7 @@ Arguments:
 Behavior:
 - Session state (variables, loaded packages) persists across calls. Errors don't crash the session.
 - Uses the user's R installation and library paths.
-- Plots (ggplot2 and base R) are captured and returned as images. Adjust sizing with `options(console.plot.width, console.plot.height, console.plot.units, console.plot.dpi)`.
+- Plots (ggplot2 and base R) are captured and returned as images. Adjust the managed console plot device and exported PNG size with `options(console.plot.width, console.plot.height, console.plot.asp, console.plot.units, console.plot.dpi)`. `console.plot.asp` is height / width, matching the shape of knitr `fig.asp` and Quarto `fig-asp`; mcp-repl does not read knitr options or Quarto YAML. Explicit user-opened graphics devices remain user-controlled.
 - Empty `input` polls for more output from a timed-out request or for detached background output while idle. While pager mode is active, empty input advances one page.
 - If a request times out, keep polling with empty `input` until the remaining worker output is drained. New non-empty input is discarded while that timed-out request is still active.
 - Oversized text output can enter a modal pager. While pager mode is active, backend input is blocked until you quit the pager or consume the remaining pages.

--- a/r/mcp_repl.R
+++ b/r/mcp_repl.R
@@ -838,6 +838,7 @@ local({
     }
 
     old_dev <- grDevices::dev.cur()
+    old_par <- tryCatch(graphics::par(no.readonly = TRUE), error = function(e) NULL)
     st$managed_device <- NULL
     st$managed_path <- NULL
     st$managed_spec <- NULL
@@ -850,6 +851,9 @@ local({
     }
 
     .mcp_repl_plot_device()
+    if (is.list(old_par)) {
+      try(graphics::par(old_par), silent = TRUE)
+    }
     TRUE
   }
 
@@ -871,7 +875,7 @@ local({
       .mcp_repl_plot_process_changes(reason)
     }
 
-    reopened <- .mcp_repl_plot_reopen_managed_device_if_needed()
+    reopened <- is_new_page && .mcp_repl_plot_reopen_managed_device_if_needed()
 
     if (is_new_page || isTRUE(reopened)) {
       st$current_id <- .mcp_repl_new_plot_id()

--- a/r/mcp_repl.R
+++ b/r/mcp_repl.R
@@ -518,6 +518,9 @@ local({
   .mcp_repl_plot_state$recordings <- new.env(parent = emptyenv())
   .mcp_repl_plot_state$in_render <- FALSE
   .mcp_repl_plot_state$initialized <- FALSE
+  .mcp_repl_plot_state$managed_device <- NULL
+  .mcp_repl_plot_state$managed_path <- NULL
+  .mcp_repl_plot_state$managed_spec <- NULL
   .mcp_repl_plot_default_dpi <- 96
   .mcp_repl_plot_default_width <- 800 / .mcp_repl_plot_default_dpi
   .mcp_repl_plot_default_height <- 600 / .mcp_repl_plot_default_dpi
@@ -545,19 +548,161 @@ local({
     NULL
   }
 
+  .mcp_repl_plot_positive_number <- function(value) {
+    if (
+      !is.numeric(value) ||
+        length(value) != 1L ||
+        !is.finite(value) ||
+        value <= 0
+    ) {
+      return(NULL)
+    }
+
+    as.numeric(value)
+  }
+
+  .mcp_repl_plot_spec <- function() {
+    units <- .mcp_repl_plot_units(
+      getOption("console.plot.units", .mcp_repl_plot_default_units)
+    )
+    if (is.null(units)) {
+      units <- .mcp_repl_plot_default_units
+    }
+
+    dpi <- .mcp_repl_plot_positive_number(getOption("console.plot.dpi"))
+    if (is.null(dpi)) {
+      dpi <- .mcp_repl_plot_positive_number(getOption("console.plot.res"))
+    }
+    if (is.null(dpi)) {
+      dpi <- .mcp_repl_plot_default_dpi
+    }
+
+    width <- .mcp_repl_plot_positive_number(getOption("console.plot.width"))
+    height <- .mcp_repl_plot_positive_number(getOption("console.plot.height"))
+    asp <- .mcp_repl_plot_positive_number(getOption("console.plot.asp"))
+
+    scale <- switch(
+      units,
+      "in" = 1,
+      "cm" = 1 / 2.54,
+      "mm" = 1 / 25.4,
+      "px" = NA_real_
+    )
+
+    if (is.na(scale)) {
+      if (is.null(width)) {
+        width_px <- round(.mcp_repl_plot_default_width * dpi)
+      } else {
+        width_px <- round(width)
+      }
+
+      if (is.null(height)) {
+        if (is.null(asp)) {
+          height_px <- round(.mcp_repl_plot_default_height * dpi)
+        } else {
+          height_px <- round(width_px * asp)
+        }
+      } else {
+        height_px <- round(height)
+      }
+    } else {
+      if (is.null(width)) {
+        width_px <- round(.mcp_repl_plot_default_width * dpi)
+      } else {
+        width_px <- round(width * scale * dpi)
+      }
+
+      if (is.null(height)) {
+        if (is.null(asp)) {
+          height_px <- round(.mcp_repl_plot_default_height * dpi)
+        } else {
+          height_px <- round(width_px * asp)
+        }
+      } else {
+        height_px <- round(height * scale * dpi)
+      }
+    }
+
+    if (!is.finite(width_px) || width_px <= 0) {
+      width_px <- round(.mcp_repl_plot_default_width * dpi)
+    }
+    if (!is.finite(height_px) || height_px <= 0) {
+      height_px <- round(.mcp_repl_plot_default_height * dpi)
+    }
+
+    list(
+      width = width_px,
+      height = height_px,
+      res = dpi,
+      key = paste(width_px, height_px, dpi, sep = ":")
+    )
+  }
+
+  .mcp_repl_plot_current_is_managed <- function() {
+    st <- .mcp_repl_plot_state
+    current <- grDevices::dev.cur()
+    path <- .mcp_repl_plot_device_path(current)
+
+    is.numeric(st$managed_device) &&
+      length(st$managed_device) == 1L &&
+      is.character(st$managed_path) &&
+      length(st$managed_path) == 1L &&
+      current > 1L &&
+      as.integer(current) == as.integer(st$managed_device) &&
+      identical(path, st$managed_path)
+  }
+
+  .mcp_repl_plot_device_path <- function(device) {
+    device <- as.integer(device)
+    devices <- get(".Devices", envir = baseenv())
+    if (!is.list(devices) || length(devices) < device) {
+      return(NULL)
+    }
+
+    path <- attr(devices[[device]], "filepath", exact = TRUE)
+    if (!is.character(path) || length(path) != 1L || !nzchar(path)) {
+      return(NULL)
+    }
+
+    path
+  }
+
+  .mcp_repl_plot_render_spec <- function() {
+    st <- .mcp_repl_plot_state
+    if (.mcp_repl_plot_current_is_managed() && is.list(st$managed_spec)) {
+      return(st$managed_spec)
+    }
+
+    .mcp_repl_plot_spec()
+  }
+
   .mcp_repl_plot_device <- function(...) {
+    st <- .mcp_repl_plot_state
+    spec <- .mcp_repl_plot_spec()
     path <- tempfile("mcp-repl-plot-", fileext = ".png")
     ok <- FALSE
     tryCatch({
-      grDevices::png(filename = path, ...)
+      grDevices::png(
+        filename = path,
+        width = spec$width,
+        height = spec$height,
+        res = spec$res
+      )
       ok <- TRUE
     }, error = function(e) NULL)
 
     if (!ok) {
       path <- tempfile("mcp-repl-plot-", fileext = ".pdf")
-      grDevices::pdf(file = path, ...)
+      grDevices::pdf(
+        file = path,
+        width = spec$width / spec$res,
+        height = spec$height / spec$res
+      )
     }
 
+    st$managed_device <- grDevices::dev.cur()
+    st$managed_path <- .mcp_repl_plot_device_path(st$managed_device)
+    st$managed_spec <- spec
     try(grDevices::dev.control(displaylist = "enable"), silent = TRUE)
     invisible(NULL)
   }
@@ -656,65 +801,13 @@ local({
 
     st$recordings[[id]] <- raw_recording
 
-    width <- getOption("console.plot.width")
-    if (is.null(width)) {
-      width <- .mcp_repl_plot_default_width
-    }
-
-    height <- getOption("console.plot.height")
-    if (is.null(height)) {
-      height <- .mcp_repl_plot_default_height
-    }
-
-    units <- .mcp_repl_plot_units(
-      getOption("console.plot.units", .mcp_repl_plot_default_units)
-    )
-    if (is.null(units)) {
-      units <- .mcp_repl_plot_default_units
-    }
-
-    dpi <- getOption("console.plot.dpi")
-    if (is.null(dpi)) {
-      dpi <- getOption("console.plot.res", .mcp_repl_plot_default_dpi)
-    }
-
-    if (!is.numeric(width) || !is.finite(width) || width <= 0) {
-      width <- .mcp_repl_plot_default_width
-    }
-    if (!is.numeric(height) || !is.finite(height) || height <= 0) {
-      height <- .mcp_repl_plot_default_height
-    }
-    if (!is.numeric(dpi) || !is.finite(dpi) || dpi <= 0) {
-      dpi <- .mcp_repl_plot_default_dpi
-    }
-
-    scale <- switch(
-      units,
-      "in" = 1,
-      "cm" = 1 / 2.54,
-      "mm" = 1 / 25.4,
-      "px" = NA_real_
-    )
-    if (is.na(scale)) {
-      width <- round(width)
-      height <- round(height)
-    } else {
-      width <- round(width * scale * dpi)
-      height <- round(height * scale * dpi)
-    }
-
-    if (!is.finite(width) || width <= 0) {
-      width <- round(.mcp_repl_plot_default_width * .mcp_repl_plot_default_dpi)
-    }
-    if (!is.finite(height) || height <= 0) {
-      height <- round(.mcp_repl_plot_default_height * .mcp_repl_plot_default_dpi)
-    }
+    spec <- .mcp_repl_plot_render_spec()
 
     png_raw <- .mcp_repl_plot_render_recording(
       recording,
-      width = width,
-      height = height,
-      res = dpi
+      width = spec$width,
+      height = spec$height,
+      res = spec$res
     )
     if (!is.raw(png_raw)) {
       return(invisible(NULL))
@@ -731,6 +824,33 @@ local({
 
   .mcp_repl_plot_flush <<- function(reason = "") {
     .mcp_repl_plot_process_changes(reason)
+  }
+
+  .mcp_repl_plot_reopen_managed_device_if_needed <- function() {
+    st <- .mcp_repl_plot_state
+    if (!.mcp_repl_plot_current_is_managed()) {
+      return(FALSE)
+    }
+
+    spec <- .mcp_repl_plot_spec()
+    if (is.list(st$managed_spec) && identical(spec$key, st$managed_spec$key)) {
+      return(FALSE)
+    }
+
+    old_dev <- grDevices::dev.cur()
+    st$managed_device <- NULL
+    st$managed_path <- NULL
+    st$managed_spec <- NULL
+    closed <- tryCatch({
+      grDevices::dev.off(which = old_dev)
+      TRUE
+    }, error = function(e) FALSE)
+    if (!closed) {
+      return(FALSE)
+    }
+
+    .mcp_repl_plot_device()
+    TRUE
   }
 
   .mcp_repl_plot_before_new_page <- function(reason = "") {
@@ -751,7 +871,9 @@ local({
       .mcp_repl_plot_process_changes(reason)
     }
 
-    if (is_new_page) {
+    reopened <- .mcp_repl_plot_reopen_managed_device_if_needed()
+
+    if (is_new_page || isTRUE(reopened)) {
       st$current_id <- .mcp_repl_new_plot_id()
       st$next_is_new <- TRUE
       st$page_open_seen <- TRUE

--- a/tests/plot_images.rs
+++ b/tests/plot_images.rs
@@ -845,6 +845,181 @@ async fn plots_respect_numeric_size_options() -> TestResult<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn plot_size_options_set_live_device_geometry() -> TestResult<()> {
+    let session = spawn_server_with_files().await?;
+
+    let input = r#"options(console.plot.width = 13.5, console.plot.height = 6, console.plot.units = "in", console.plot.dpi = 150); plot.new(); size <- dev.size("in"); cat(sprintf("mcp-repl-live-size %.1f %.1f\n", size[[1]], size[[2]]))"#;
+    let result = session.write_stdin_raw_with(input, Some(30.0)).await?;
+    if any_backend_unavailable(&[&result]) {
+        eprintln!("plot_images backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "live device size plot reported an error: {}",
+        result_text(&result)
+    );
+    assert!(
+        result_text(&result).contains("mcp-repl-live-size 13.5 6.0"),
+        "expected live device size to match console.plot options: {}",
+        result_text(&result)
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn plot_size_options_use_aspect_ratio_when_height_unset() -> TestResult<()> {
+    let session = spawn_server_with_files().await?;
+
+    let input = r#"options(console.plot.width = 4, console.plot.height = NULL, console.plot.asp = 0.5, console.plot.units = "in", console.plot.dpi = 100); plot(1:10); size <- dev.size("in"); cat(sprintf("mcp-repl-asp-size %.1f %.1f\n", size[[1]], size[[2]]))"#;
+    let result = session.write_stdin_raw_with(input, Some(30.0)).await?;
+    if any_backend_unavailable(&[&result]) {
+        eprintln!("plot_images backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "aspect ratio plot reported an error: {}",
+        result_text(&result)
+    );
+    assert!(
+        result_text(&result).contains("mcp-repl-asp-size 4.0 2.0"),
+        "expected live device height to come from console.plot.asp: {}",
+        result_text(&result)
+    );
+    let images = extract_images(&result);
+    assert!(
+        !images.is_empty(),
+        "expected aspect ratio plot to emit image content"
+    );
+    let (width, height) =
+        png_dimensions(&images[0].bytes).expect("aspect ratio plot did not return a valid png");
+    assert_eq!(
+        (width, height),
+        (400, 200),
+        "expected 4 inch width and 0.5 aspect at 100 dpi to render at 400x200"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn plot_height_option_takes_precedence_over_aspect_ratio() -> TestResult<()> {
+    let session = spawn_server_with_files().await?;
+
+    let input = r#"options(console.plot.width = 4, console.plot.height = 3, console.plot.asp = 0.5, console.plot.units = "in", console.plot.dpi = 100); plot(1:10); size <- dev.size("in"); cat(sprintf("mcp-repl-height-precedence-size %.1f %.1f\n", size[[1]], size[[2]]))"#;
+    let result = session.write_stdin_raw_with(input, Some(30.0)).await?;
+    if any_backend_unavailable(&[&result]) {
+        eprintln!("plot_images backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "height precedence plot reported an error: {}",
+        result_text(&result)
+    );
+    assert!(
+        result_text(&result).contains("mcp-repl-height-precedence-size 4.0 3.0"),
+        "expected console.plot.height to take precedence over console.plot.asp: {}",
+        result_text(&result)
+    );
+    let images = extract_images(&result);
+    assert!(
+        !images.is_empty(),
+        "expected height precedence plot to emit image content"
+    );
+    let (width, height) = png_dimensions(&images[0].bytes)
+        .expect("height precedence plot did not return a valid png");
+    assert_eq!(
+        (width, height),
+        (400, 300),
+        "expected explicit 4x3 inches at 100 dpi to render at 400x300"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn plot_size_option_changes_apply_to_next_managed_page() -> TestResult<()> {
+    let session = spawn_server_with_files().await?;
+
+    let input = r#"options(console.plot.width = 4, console.plot.height = 3, console.plot.asp = NULL, console.plot.units = "in", console.plot.dpi = 100); plot(1:10); first <- dev.size("in"); options(console.plot.width = 6, console.plot.height = 2, console.plot.dpi = 100); plot(1:10); second <- dev.size("in"); cat(sprintf("mcp-repl-persistent-size %.1f %.1f %.1f %.1f\n", first[[1]], first[[2]], second[[1]], second[[2]]))"#;
+    let result = session.write_stdin_raw_with(input, Some(30.0)).await?;
+    if any_backend_unavailable(&[&result]) {
+        eprintln!("plot_images backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "persistent managed device plot reported an error: {}",
+        result_text(&result)
+    );
+    assert!(
+        result_text(&result).contains("mcp-repl-persistent-size 4.0 3.0 6.0 2.0"),
+        "expected changed console.plot options to apply to the next managed page: {}",
+        result_text(&result)
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn plot_size_changes_do_not_resize_user_opened_device() -> TestResult<()> {
+    let session = spawn_server_with_files().await?;
+
+    let setup_input = r#"options(console.plot.width = 4, console.plot.height = 3, console.plot.dpi = 100); plot(1:10); grDevices::dev.off()"#;
+    let setup_result = session
+        .write_stdin_raw_with(setup_input, Some(30.0))
+        .await?;
+    if any_backend_unavailable(&[&setup_result]) {
+        eprintln!("plot_images backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert_ne!(
+        setup_result.is_error,
+        Some(true),
+        "managed device setup plot reported an error: {}",
+        result_text(&setup_result)
+    );
+
+    let input = r#"path <- tempfile(fileext = ".png"); options(console.plot.width = 6, console.plot.height = 2, console.plot.dpi = 100); grDevices::png(path, width = 5, height = 4, units = "in", res = 100); plot(1:10); size <- dev.size("in"); cat(sprintf("mcp-repl-user-device-size %.1f %.1f\n", size[[1]], size[[2]])); grDevices::dev.off(); unlink(path)"#;
+    let result = session.write_stdin_raw_with(input, Some(30.0)).await?;
+    if any_backend_unavailable(&[&result]) {
+        eprintln!("plot_images backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "user-opened device plot reported an error: {}",
+        result_text(&result)
+    );
+    assert!(
+        result_text(&result).contains("mcp-repl-user-device-size 5.0 4.0"),
+        "expected changed console.plot options not to resize an explicit user device: {}",
+        result_text(&result)
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn grid_plots_emit_images_and_updates() -> TestResult<()> {
     let session = spawn_server_with_files().await?;
     let mut steps = Vec::new();

--- a/tests/plot_images.rs
+++ b/tests/plot_images.rs
@@ -977,6 +977,88 @@ async fn plot_size_option_changes_apply_to_next_managed_page() -> TestResult<()>
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn plot_size_option_changes_wait_for_next_multi_panel_page() -> TestResult<()> {
+    let session = spawn_server_with_files().await?;
+
+    let input = r#"options(console.plot.width = 4, console.plot.height = 3, console.plot.asp = NULL, console.plot.units = "in", console.plot.dpi = 100); par(mfrow = c(1, 2)); plot(1:10); first <- dev.size("in"); options(console.plot.width = 6, console.plot.height = 2, console.plot.dpi = 100); plot(10:1); second <- dev.size("in"); cat(sprintf("mcp-repl-multipanel-size %.1f %.1f %.1f %.1f\n", first[[1]], first[[2]], second[[1]], second[[2]]))"#;
+    let result = session.write_stdin_raw_with(input, Some(30.0)).await?;
+    if any_backend_unavailable(&[&result]) {
+        eprintln!("plot_images backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "multi-panel size change plot reported an error: {}",
+        result_text(&result)
+    );
+    assert!(
+        result_text(&result).contains("mcp-repl-multipanel-size 4.0 3.0 4.0 3.0"),
+        "expected changed console.plot options to wait for the next multi-panel page: {}",
+        result_text(&result)
+    );
+    let images = extract_images(&result);
+    assert_eq!(
+        images.len(),
+        1,
+        "expected multi-panel page to remain one emitted image"
+    );
+    let (width, height) =
+        png_dimensions(&images[0].bytes).expect("multi-panel plot did not return a valid png");
+    assert_eq!(
+        (width, height),
+        (400, 300),
+        "expected active multi-panel page to keep its original size"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn plot_size_option_changes_preserve_par_on_reopened_managed_device() -> TestResult<()> {
+    let session = spawn_server_with_files().await?;
+
+    let input = r#"options(console.plot.width = 4, console.plot.height = 3, console.plot.asp = NULL, console.plot.units = "in", console.plot.dpi = 100); par(mfrow = c(1, 2), mar = c(2, 3, 4, 1)); plot(1:10); plot(10:1); options(console.plot.width = 6, console.plot.height = 2, console.plot.dpi = 100); plot(1:10); state <- c(par("mfrow"), par("mar"), par("mfg"), dev.size("in")); plot(10:1); cat(sprintf("mcp-repl-reopened-par mfrow=%d,%d mar=%.1f,%.1f,%.1f,%.1f mfg=%d,%d,%d,%d size=%.1f,%.1f\n", state[[1]], state[[2]], state[[3]], state[[4]], state[[5]], state[[6]], state[[7]], state[[8]], state[[9]], state[[10]], state[[11]], state[[12]]))"#;
+    let result = session.write_stdin_raw_with(input, Some(30.0)).await?;
+    if any_backend_unavailable(&[&result]) {
+        eprintln!("plot_images backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "reopened managed device par plot reported an error: {}",
+        result_text(&result)
+    );
+    assert!(
+        result_text(&result).contains(
+            "mcp-repl-reopened-par mfrow=1,2 mar=2.0,3.0,4.0,1.0 mfg=1,1,1,2 size=6.0,2.0"
+        ),
+        "expected reopened managed device to preserve par settings: {}",
+        result_text(&result)
+    );
+    let images = extract_images(&result);
+    assert_eq!(
+        images.len(),
+        2,
+        "expected one image before and one image after managed device resize"
+    );
+    let (width, height) = png_dimensions(&images[1].bytes)
+        .expect("resized multi-panel plot did not return a valid png");
+    assert_eq!(
+        (width, height),
+        (600, 200),
+        "expected reopened managed page to use updated size"
+    );
+
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn plot_size_changes_do_not_resize_user_opened_device() -> TestResult<()> {
     let session = spawn_server_with_files().await?;
 


### PR DESCRIPTION
## Summary

R console plot sizing options now control the managed graphics device while plotting code is drawing, not only the replayed PNG export. This fixes device-aware layout code that reads `dev.size()`, `par("pin")`, or text metrics during plot construction.

## User-facing changes

- `options(console.plot.width, console.plot.height, console.plot.units, console.plot.dpi)` now affect the live managed R plot device.
- Added `console.plot.asp` as height / width, matching the shape of knitr `fig.asp` and Quarto `fig-asp`.
- Documented that explicit user-opened graphics devices remain user-controlled.

## Internal changes

- Shared plot-size resolution between managed device creation and replay/export.
- Track the managed device by backing filepath as well as device number, so stale device numbers do not cause explicit user devices to be resized.
- Added public MCP plot tests for live device geometry, aspect ratio, precedence, resizing on new managed pages, and explicit user devices.
