### PR TITLE
Preserve split UTF-8 across input waits

### DIFF
--- a/src/worker_process/pending_poll.rs
+++ b/src/worker_process/pending_poll.rs
@@ -61,7 +61,7 @@ impl WorkerManager {
         } = if timed_out_elapsed.is_some() {
             self.drain_formatted_output()
         } else {
-            self.drain_final_formatted_output()
+            self.drain_completed_formatted_output(session_end)
         };
         let is_error = saw_stderr;
 

--- a/src/worker_process/reply_state.rs
+++ b/src/worker_process/reply_state.rs
@@ -145,6 +145,19 @@ impl WorkerManager {
         self.pending_output_tape.drain_final_output()
     }
 
+    pub(super) fn drain_completed_formatted_output(
+        &self,
+        session_end: bool,
+    ) -> FormattedPendingOutput {
+        if session_end {
+            self.drain_final_formatted_output()
+        } else {
+            // Keep an incomplete raw UTF-8 tail open at input_wait; the next accepted
+            // request seals it before fresh output can merge across requests.
+            self.drain_formatted_output()
+        }
+    }
+
     pub(super) fn drain_sealed_formatted_output(&self) -> FormattedPendingOutput {
         self.pending_output_tape.drain_sealed_output()
     }

--- a/src/worker_process/request_reply.rs
+++ b/src/worker_process/request_reply.rs
@@ -95,7 +95,7 @@ impl WorkerManager {
                 }
                 let mut contents = context.detached_prefix_contents;
                 contents.extend(context.reply_prefix_contents);
-                let formatted = self.drain_final_formatted_output();
+                let formatted = self.drain_completed_formatted_output(session_end);
                 let is_error = context.prefix_is_error || formatted.saw_stderr;
                 contents.extend(formatted.contents);
                 let built = build_completed_reply(

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -297,6 +297,7 @@ fn run_command(
             prompt: "v5> ".to_string(),
         })?;
         append_control_log(control_log_path.as_deref(), "input_wait")?;
+        sleep_for(200, sideband_interrupted, false);
         io::stdout().write_all(&[0xA9, b'\n'])?;
         io::stdout().flush()?;
         return Ok(false);

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -1111,7 +1111,7 @@ async fn zod_raw_split_utf8_survives_input_wait_marker() -> TestResult<()> {
     let first_text = result_text(&first);
 
     wait_for_log_contains(&control_log, "input_wait")?;
-    std::thread::sleep(Duration::from_millis(50));
+    std::thread::sleep(Duration::from_millis(250));
 
     let completed = session
         .call_tool_raw(


### PR DESCRIPTION
## Summary

- Preserve incomplete raw UTF-8 tails when a request completes at `input_wait`, so a continuation byte captured after the marker can still render as one character.
- Keep sealing behavior for session end and the next accepted request, preventing cross-request UTF-8 merges.
- Strengthen the zod protocol regression by delaying the continuation byte after `input_wait`.

## Public-facing changes

Files-mode output no longer escapes a split raw UTF-8 character when `input_wait` is observed before the output reader captures the continuation byte.

## Internal-only changes

- Added `drain_completed_formatted_output` to centralize completed-output drain semantics.
- Updated the zod worker fixture and regression timing.

## Testing

- `cargo check`
- `cargo build`
- `python3 tests/run_integration_tests.py --binary target/debug/mcp-repl`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo +nightly fmt`
