### PR TITLE
Add manual PyPI backfill release path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,24 @@ on:
     tags:
       - 'v*.*.*'
       - '!v*\+*'
+  workflow_dispatch:
+    inputs:
+      pypi_backfill_tag:
+        description: "Manual PyPI backfill tag (existing vX.Y.Z or vX.Y.Z-rcN)"
+        required: true
+        type: string
 
 concurrency:
-  group: release-${{ github.ref_name }}
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.pypi_backfill_tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   checks:
     name: ${{ matrix.target }}
-    if: github.ref_type == 'tag'
+    if: (github.event_name == 'push' && github.ref_type == 'tag') || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.os }}
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.pypi_backfill_tag || github.ref_name }}
     strategy:
       fail-fast: false
       matrix:
@@ -34,7 +42,30 @@ jobs:
             artifact_name: release-x86_64-pc-windows-msvc
 
     steps:
+      - name: Validate requested release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+(\.[0-9]+){2}(-(a|b|rc)[0-9]+)?$ ]]; then
+            echo "release tag must be final semver like v0.1.0 or PyPI-compatible prerelease semver like v0.1.0-rc1" >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: Prepare manual PyPI backfill metadata
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f pyproject.toml ]; then
+            git show "${GITHUB_SHA}:pyproject.toml" > pyproject.toml
+            echo "target tag does not contain pyproject.toml; restored packaging metadata from workflow ref ${GITHUB_SHA}"
+          fi
+          test -f pyproject.toml
 
       - name: Set up Rust (stable)
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -57,14 +88,9 @@ jobs:
 
       - name: Validate release tag matches Cargo version
         shell: bash
-        env:
-          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+(\.[0-9]+){2}(-(a|b|rc)[0-9]+)?$ ]]; then
-            echo "release tag must be final semver like v0.1.0 or PyPI-compatible prerelease semver like v0.1.0-rc1" >&2
-            exit 1
-          fi
+          git rev-parse "refs/tags/${RELEASE_TAG}" >/dev/null
           release_version="${RELEASE_TAG#v}"
           cargo_version="$(cargo metadata --no-deps --format-version 1 | python -c 'import json, sys; print(json.load(sys.stdin)["packages"][0]["version"])')"
           if [ "${cargo_version}" != "${release_version}" ]; then
@@ -137,14 +163,25 @@ jobs:
         run: |
           .\target\release\mcp-repl.exe --help
 
+      - name: Detect release CLI contract
+        id: release_cli_contract_available
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -f tests/release_cli_contract.rs ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Release CLI contract
-        if: matrix.os != 'windows-2022'
+        if: matrix.os != 'windows-2022' && steps.release_cli_contract_available.outputs.exists == 'true'
         env:
           MCP_REPL_RELEASE_BINARY: target/release/mcp-repl
         run: cargo test --test release_cli_contract --quiet
 
       - name: Release CLI contract (windows)
-        if: matrix.os == 'windows-2022'
+        if: matrix.os == 'windows-2022' && steps.release_cli_contract_available.outputs.exists == 'true'
         shell: pwsh
         env:
           MCP_REPL_RELEASE_BINARY: target/release/mcp-repl.exe
@@ -230,7 +267,7 @@ jobs:
 
   publish-release:
     name: publish-release
-    if: github.ref_type == 'tag' && needs.checks.result == 'success'
+    if: github.event_name == 'push' && github.ref_type == 'tag' && needs.checks.result == 'success'
     needs: checks
     runs-on: ubuntu-22.04
     permissions:
@@ -351,7 +388,7 @@ jobs:
 
   publish-pypi:
     name: publish-pypi
-    if: github.ref_type == 'tag' && needs.checks.result == 'success'
+    if: needs.checks.result == 'success' && ((github.event_name == 'push' && github.ref_type == 'tag') || github.event_name == 'workflow_dispatch')
     needs: checks
     runs-on: ubuntu-22.04
     permissions:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,8 +1,9 @@
 # Releasing
 
-Release only from an immutable semver tag. No rolling dev release, moving dev
-tag, or backfill workflow is part of the supported release process. No backfill
-workflow exists for repairing old tags.
+Release only from an immutable semver tag. The only supported manual backfill is
+the PyPI-only dispatch below, and it must target an existing immutable semver
+tag. No rolling dev release, moving dev tag, or workflow for repairing old
+GitHub Release assets is part of the supported release process.
 
 ## Checklist
 
@@ -24,6 +25,28 @@ that the tag matches the Cargo package version, runs the release check matrix,
 builds GitHub Release archives, builds PyPI wheels, smoke-tests installed
 wheels, publishes `posit-mcp-repl` to PyPI, and creates or updates the GitHub
 release.
+
+## Manual PyPI Backfill
+
+Use this path only when a downstream plugin is blocked and `posit-mcp-repl`
+must be published before the next scheduled release tag.
+
+1. Confirm the target is an existing immutable semver tag whose version is not
+   already on PyPI.
+2. Open the `Release` workflow in GitHub Actions and run it manually.
+3. Set `pypi_backfill_tag` to the existing tag, for example `vX.Y.Z`.
+
+The manual dispatch checks out that tag, validates that the tag is final semver
+or PyPI-compatible prerelease semver, validates that it matches `Cargo.toml`,
+runs the normal release matrix, builds and smoke-tests the wheels, and then runs
+only `publish-pypi`. For tags that predate PyPI packaging, the dispatch overlays
+the current `pyproject.toml` packaging metadata only; the compiled source still
+comes from the immutable tag. Checks run from the tag's source tree, so checks
+added after that tag run only when their test files exist in the tag.
+
+The manual dispatch does not create or update the GitHub release, move tags,
+publish a dev version, repair old GitHub Release assets, or upload an sdist. If
+the version already exists on PyPI, publishing fails.
 
 ## PyPI Trusted Publisher
 

--- a/tests/docs_contracts.rs
+++ b/tests/docs_contracts.rs
@@ -321,7 +321,7 @@ fn ci_workflow_validates_release_packaging_without_publishing() {
 }
 
 #[test]
-fn release_workflow_defines_tag_only_publishing_contract() {
+fn release_workflow_defines_tag_and_manual_pypi_publishing_contract() {
     let workflow = read(&repo_root().join(".github/workflows/release.yml"));
 
     for required in [
@@ -329,11 +329,20 @@ fn release_workflow_defines_tag_only_publishing_contract() {
         "tags:",
         "- 'v*.*.*'",
         "- '!v*\\+*'",
+        "workflow_dispatch:",
+        "pypi_backfill_tag:",
+        "Manual PyPI backfill tag",
         "publish-release:",
         "publish-pypi:",
-        "github.ref_type == 'tag'",
+        "if: (github.event_name == 'push' && github.ref_type == 'tag') || github.event_name == 'workflow_dispatch'",
+        "RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.pypi_backfill_tag || github.ref_name }}",
+        "ref: ${{ env.RELEASE_TAG }}",
         "fetch-depth: 0",
+        "Prepare manual PyPI backfill metadata",
+        "${GITHUB_SHA}:pyproject.toml",
+        "target tag does not contain pyproject.toml",
         "Validate release tag matches Cargo version",
+        "git rev-parse \"refs/tags/${RELEASE_TAG}\" >/dev/null",
         "^v[0-9]+(\\.[0-9]+){2}(-(a|b|rc)[0-9]+)?$",
         "Decide whether this tag should be latest",
         "id: latest_guard",
@@ -372,9 +381,14 @@ fn release_workflow_defines_tag_only_publishing_contract() {
         "run: cargo test --quiet",
         "MCP_REPL_CODEX_BACKEND: mock",
         "Release CLI contract",
+        "Detect release CLI contract",
+        "release_cli_contract_available",
+        "steps.release_cli_contract_available.outputs.exists == 'true'",
         "MCP_REPL_RELEASE_BINARY: target/release/mcp-repl",
         "MCP_REPL_RELEASE_BINARY: target/release/mcp-repl.exe",
         "cargo test --test release_cli_contract --quiet",
+        "if: github.event_name == 'push' && github.ref_type == 'tag' && needs.checks.result == 'success'",
+        "if: needs.checks.result == 'success' && ((github.event_name == 'push' && github.ref_type == 'tag') || github.event_name == 'workflow_dispatch')",
         "-F draft=false",
         "-F prerelease=\"${prerelease_flag}\"",
         "--prerelease",
@@ -387,7 +401,6 @@ fn release_workflow_defines_tag_only_publishing_contract() {
     }
 
     for forbidden in [
-        "workflow_dispatch:",
         "release_tag:",
         "publish-dev:",
         "group: publish-dev",
@@ -480,7 +493,17 @@ fn releasing_docs_define_checklist_and_wheel_only_pypi_policy() {
         "manylinux2014",
         "R is optional",
         "No rolling dev release",
-        "No backfill workflow",
+        "Manual PyPI Backfill",
+        "`pypi_backfill_tag`",
+        "existing immutable semver tag",
+        "before the next scheduled release tag",
+        "tags that predate PyPI packaging",
+        "current `pyproject.toml` packaging metadata only",
+        "compiled source still comes from the immutable tag",
+        "Checks run from the tag's source tree",
+        "checks added after that tag run only when their test files exist",
+        "does not create or update the GitHub release",
+        "version already exists on PyPI",
     ] {
         assert_contains_wrapped_text(&docs, required, "docs/releasing.md");
     }


### PR DESCRIPTION
## Summary

Add a narrow manual PyPI backfill path to the existing release workflow so `posit-mcp-repl` can be published for an existing release tag when downstream plugin work is blocked before the next scheduled tag.

## User-facing changes

- Documents a `Release` workflow manual dispatch using `pypi_backfill_tag`.
- Makes the constraints explicit: existing immutable semver tags only, PyPI-only publishing, no dev release, no tag movement, no GitHub Release repair, and no sdist upload.

## Internal changes

- Reuses the release check matrix for tag pushes and manual dispatches.
- Keeps GitHub Release publishing limited to tag pushes.
- Lets manual dispatches overlay current `pyproject.toml` metadata for tags that predate PyPI packaging while compiling source from the immutable tag.
- Skips the release CLI contract only when an old tag lacks that test file.
- Updates docs-contract coverage for the new release workflow contract and release guide text.
