### PR TITLE
Make request output finalization explicit

### DIFF
--- a/docs/output_timeline.md
+++ b/docs/output_timeline.md
@@ -102,6 +102,13 @@ whether text is an echo.
 The intent is one true visible timeline per output surface, with completion used
 only as a later presentation step.
 
+Timeline markers such as `input_wait`, `request_boundary`, and `session_end`
+are ordering facts. Appending a marker must not by itself seal, escape, or drain
+an incomplete UTF-8 tail. UTF-8 tails are sealed only by explicit presentation
+policies: final drains, session/error/reset paths, new-request detached-prefix
+capture, or timeout drains that must expose already-buffered visible output
+behind an incomplete tail.
+
 Input sideband events are structural metadata. Echo generation, when a surface
 needs it, is driven by those facts rather than by parsing captured output:
 

--- a/docs/plans/completed/request-output-finalization.md
+++ b/docs/plans/completed/request-output-finalization.md
@@ -1,0 +1,56 @@
+# Request Output Finalization
+
+## Summary
+
+- Replaced scattered request completion, output settling, marker insertion, and UTF-8 tail recovery decisions with explicit request-output finalization policy.
+- Kept the worker sideband protocol unchanged; the server remains responsible for reconstructing visible output from IPC and raw streams.
+
+## Status
+
+- State: completed
+- Last updated: 2026-06-26
+- Current phase: completed
+
+## Current Direction
+
+- Timeline markers are pure ordering facts that do not implicitly seal UTF-8 tails.
+- Request outcome policy is server-side, deadline-aware, and outcome-specific.
+- UTF-8 tail details stay inside output timeline/finalization code instead of being controlled by marker side effects.
+
+## Long-Term Direction
+
+- The output timeline owns byte assembly and event ordering.
+- Request lifecycle owns only the request outcome: completed, timed out, session ended, or failed.
+- Presentation code drains output according to explicit policies instead of relying on marker side effects.
+
+## Phase Status
+
+- Phase 0: completed - architecture issue identified.
+- Phase 1: completed - public regressions and finalization refactor.
+- Phase 2: completed - required validation passed.
+
+## Locked Decisions
+
+- Do not add a worker protocol flush/ack message for this issue.
+- Treat `timeout_ms` as a hard public response deadline.
+- Preserve timeout replies that expose already-buffered visible output behind an incomplete UTF-8 head by explicit timeout policy.
+
+## Open Questions
+
+- None.
+
+## Next Safe Slice
+
+- None.
+
+## Stop Conditions
+
+- Reassess if a future change requires worker-side output flush acknowledgements.
+- Reassess if timeout replies can no longer expose visible output already buffered before the timeout.
+
+## Decision Log
+
+- 2026-06-26: Chose a server-side finalizer because raw stdout/stderr arrival is not synchronized by worker IPC.
+- 2026-06-26: Chose pure marker insertion so `RequestBoundary` and `InputWait` cannot accidentally seal or escape UTF-8 bytes.
+- 2026-06-26: Kept timeout drains deadline-capped and used explicit visible-output sealing for timeout presentation.
+- 2026-06-26: Completed required validation: `cargo check`, `cargo build`, integration tests, clippy, full Rust tests, and `cargo +nightly fmt`.

--- a/src/output_capture.rs
+++ b/src/output_capture.rs
@@ -162,40 +162,30 @@ impl OutputTimeline {
     }
 
     pub(crate) fn append_input_wait(&self) {
-        let mut guard = self.state.lock().unwrap();
-        let pending = guard.utf8_tails.drain_ready_after_gaps();
-        self.append_pending_locked(pending);
-        self.ring.append_marker_event(OutputEventKind::InputWait);
+        self.append_event(OutputEventKind::InputWait);
     }
 
     pub(crate) fn append_request_boundary(&self) {
-        let mut guard = self.state.lock().unwrap();
-        let pending = guard.utf8_tails.drain_ready_after_gaps();
-        self.append_pending_locked(pending);
-        self.ring
-            .append_marker_event(OutputEventKind::RequestBoundary);
+        self.append_event(OutputEventKind::RequestBoundary);
     }
 
     pub(crate) fn append_session_end(&self) {
-        let mut guard = self.state.lock().unwrap();
-        let pending = guard.utf8_tails.drain_ready_after_gaps();
-        self.append_pending_locked(pending);
-        self.ring.append_marker_event(OutputEventKind::SessionEnd);
+        self.append_event(OutputEventKind::SessionEnd);
     }
 
     pub(crate) fn last_text_ends_with_newline(&self) -> bool {
         self.ring.last_text_ends_with_newline()
     }
 
-    pub(crate) fn flush_utf8_tails(&self) {
+    pub(crate) fn seal_utf8_tails(&self) {
         let mut guard = self.state.lock().unwrap();
         let pending = guard.utf8_tails.drain();
         self.append_pending_locked(pending);
     }
 
-    pub(crate) fn flush_ready_utf8_tails(&self) {
+    pub(crate) fn seal_utf8_tails_blocking_visible_output(&self) {
         let mut guard = self.state.lock().unwrap();
-        let pending = guard.utf8_tails.drain_ready_after_gaps();
+        let pending = guard.utf8_tails.drain_ready_after_visible_gaps();
         self.append_pending_locked(pending);
     }
 
@@ -242,6 +232,19 @@ struct OutputUtf8Tail {
 enum OutputPendingEntry {
     Text(OutputUtf8Tail),
     Event(OutputEventKind),
+}
+
+impl OutputPendingEntry {
+    fn is_marker_event(&self) -> bool {
+        matches!(
+            self,
+            OutputPendingEntry::Event(
+                OutputEventKind::InputWait
+                    | OutputEventKind::RequestBoundary
+                    | OutputEventKind::SessionEnd
+            )
+        )
+    }
 }
 
 #[derive(Default)]
@@ -353,15 +356,19 @@ impl OutputUtf8Tails {
     ) -> Vec<OutputPendingEntry> {
         let mut ready = self.drain_ready();
         if self.blocked_side_buffer_bytes() > side_buffer_capacity_bytes {
-            ready.extend(self.drain_ready_after_gaps());
+            ready.extend(self.drain_ready_after_visible_gaps());
         }
         ready
     }
 
-    fn drain_ready_after_gaps(&mut self) -> Vec<OutputPendingEntry> {
+    fn drain_ready_after_visible_gaps(&mut self) -> Vec<OutputPendingEntry> {
         let mut ready = Vec::new();
         while !self.entries.is_empty() {
-            let has_later_entries = self.entries.len() > 1;
+            let has_later_visible_entries = self
+                .entries
+                .iter()
+                .skip(1)
+                .any(|entry| !entry.is_marker_event());
             let OutputPendingEntry::Text(front) = &mut self.entries[0] else {
                 ready.push(self.entries.remove(0));
                 continue;
@@ -373,7 +380,7 @@ impl OutputUtf8Tails {
 
             let flushable_len = flushable_prefix_len(&front.bytes);
             if flushable_len == 0 {
-                if has_later_entries {
+                if has_later_visible_entries {
                     front.sealed = true;
                     ready.push(materialize_pending_entry(self.entries.remove(0)));
                     continue;
@@ -392,7 +399,7 @@ impl OutputUtf8Tails {
                 bytes,
                 sealed: true,
             }));
-            if !has_later_entries {
+            if !has_later_visible_entries {
                 break;
             }
         }

--- a/src/pending_output_tape.rs
+++ b/src/pending_output_tape.rs
@@ -62,7 +62,7 @@ impl PendingOutputTape {
         if bytes.is_empty() {
             return;
         }
-        self.timeline.flush_utf8_tails();
+        self.timeline.seal_utf8_tails();
         if self.timeline.last_text_ends_with_newline() || bytes.starts_with(b"\n") {
             self.timeline
                 .append_text(bytes, false, ContentOrigin::Server);
@@ -114,17 +114,17 @@ impl PendingOutputTape {
     }
 
     pub(crate) fn drain_output(&self) -> FormattedPendingOutput {
-        self.timeline.flush_ready_utf8_tails();
+        self.timeline.seal_utf8_tails_blocking_visible_output();
         self.output.drain_formatted(ProjectionMode::Bundle, false)
     }
 
     pub(crate) fn drain_final_output(&self) -> FormattedPendingOutput {
-        self.timeline.flush_utf8_tails();
+        self.timeline.seal_utf8_tails();
         self.output.drain_formatted(ProjectionMode::Bundle, true)
     }
 
     pub(crate) fn drain_sealed_output(&self) -> FormattedPendingOutput {
-        self.timeline.flush_utf8_tails();
+        self.timeline.seal_utf8_tails();
         self.output.drain_formatted(ProjectionMode::Bundle, true)
     }
 }

--- a/src/worker_process/interrupt.rs
+++ b/src/worker_process/interrupt.rs
@@ -298,7 +298,7 @@ impl WorkerManager {
         page_bytes: u64,
     ) -> ReplyWithOffset {
         if !prompt_wait.timed_out {
-            self.output_timeline.flush_utf8_tails();
+            self.output_timeline.seal_utf8_tails();
         }
         let start_offset = self.output.current_offset().unwrap_or(0);
         let mut end_offset = self.output.end_offset().unwrap_or(start_offset);

--- a/src/worker_process/pending_poll.rs
+++ b/src/worker_process/pending_poll.rs
@@ -113,9 +113,10 @@ impl WorkerManager {
             PendingPollState::NoCompletion => (CompletionInfo::empty(), false, None),
         };
         if timed_out_elapsed.is_some() {
-            self.output_timeline.flush_ready_utf8_tails();
+            self.output_timeline
+                .seal_utf8_tails_blocking_visible_output();
         } else if observed_completion {
-            self.output_timeline.flush_utf8_tails();
+            self.output_timeline.seal_utf8_tails();
         }
         if observed_completion {
             end_offset = self.output.end_offset().unwrap_or(end_offset);

--- a/src/worker_process/request_lifecycle.rs
+++ b/src/worker_process/request_lifecycle.rs
@@ -291,9 +291,6 @@ impl WorkerManager {
         stable_needed: Duration,
         utf8_tail_total: Duration,
     ) {
-        if total.is_zero() {
-            return;
-        }
         let poll = Duration::from_millis(5);
         let start = Instant::now();
         let requires_input_echo = self
@@ -538,6 +535,43 @@ mod tests {
         assert!(
             !text.contains("\\xC3") && !text.contains("\\xA9"),
             "completion settle should not seal split UTF-8 bytes before the extended budget expires, got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn completion_settle_uses_utf8_tail_grace_when_budget_is_zero() {
+        let manager = WorkerManager::new(
+            Backend::Python,
+            SandboxCliPlan::default(),
+            OversizedOutputMode::Files,
+        )
+        .expect("worker manager");
+
+        manager.pending_output_tape.append_stdout_bytes(&[0xC3]);
+
+        let timeline = manager.output_timeline.clone();
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(40));
+            timeline.append_text(
+                &[0xA9, b'\n'],
+                false,
+                crate::worker_protocol::ContentOrigin::Worker,
+            );
+        });
+
+        manager.settle_output_after_completion(Duration::ZERO);
+        let formatted = manager.drain_final_formatted_output();
+
+        handle.join().expect("delayed output writer should finish");
+
+        let text = contents_text(&formatted.contents);
+        assert!(
+            text.contains("é\n"),
+            "completion settle should use UTF-8 tail grace even with no regular budget, got: {text:?}"
+        );
+        assert!(
+            !text.contains("\\xC3") && !text.contains("\\xA9"),
+            "completion settle should not seal split UTF-8 bytes when continuation arrives within the tail grace, got: {text:?}"
         );
     }
 }

--- a/src/worker_process/request_lifecycle.rs
+++ b/src/worker_process/request_lifecycle.rs
@@ -188,7 +188,8 @@ impl WorkerManager {
         // drain any bytes already written by the worker before we snapshot the ring.
         let elapsed = start.elapsed();
         let remaining = timeout.saturating_sub(elapsed);
-        self.settle_output_after_completion(remaining);
+        let allow_utf8_tail_grace = !matches!(result, Err(WorkerError::Timeout(_)));
+        self.settle_output_after_completion_with_utf8_tail_grace(remaining, allow_utf8_tail_grace);
         if result.is_ok() {
             self.pending_output_tape
                 .append_sideband(PendingSidebandKind::RequestBoundary);
@@ -212,8 +213,17 @@ impl WorkerManager {
     }
 
     pub(super) fn settle_output_after_completion(&self, budget: Duration) {
+        self.settle_output_after_completion_with_utf8_tail_grace(budget, true);
+    }
+
+    fn settle_output_after_completion_with_utf8_tail_grace(
+        &self,
+        budget: Duration,
+        allow_utf8_tail_grace: bool,
+    ) {
         let total = budget.min(OUTPUT_READER_QUIESCE_GRACE);
-        let utf8_tail_pending = self.output_timeline.has_unflushable_utf8_tail();
+        let utf8_tail_pending =
+            allow_utf8_tail_grace && self.output_timeline.has_unflushable_utf8_tail();
         if total.is_zero() && !utf8_tail_pending {
             return;
         }
@@ -222,7 +232,11 @@ impl WorkerManager {
         } else {
             OUTPUT_READER_COMPLETION_STABLE.min(total)
         };
-        let utf8_tail_total = OUTPUT_READER_UTF8_TAIL_SETTLE_MAX;
+        let utf8_tail_total = if allow_utf8_tail_grace {
+            OUTPUT_READER_UTF8_TAIL_SETTLE_MAX
+        } else {
+            total
+        };
         self.settle_output_until_stable(total, stable_needed, utf8_tail_total);
     }
 

--- a/src/worker_process/request_lifecycle.rs
+++ b/src/worker_process/request_lifecycle.rs
@@ -22,9 +22,22 @@ const OUTPUT_READER_COMPLETION_STABLE: Duration = if cfg!(target_os = "macos") {
 const OUTPUT_READER_UTF8_TAIL_SETTLE_MAX: Duration = Duration::from_millis(900);
 const OUTPUT_READER_TIMEOUT_SETTLE_MAX: Duration = Duration::from_millis(900);
 
+#[derive(Clone, Copy)]
+enum RequestOutputOutcome {
+    Completed,
+    TimedOut,
+    Failed,
+}
+
 pub(super) struct RequestState {
     pub(super) timeout: Duration,
     pub(super) started_at: Instant,
+}
+
+impl RequestState {
+    pub(super) fn remaining_budget(&self) -> Duration {
+        (self.started_at + self.timeout).saturating_duration_since(Instant::now())
+    }
 }
 
 fn collect_completion_metadata(ipc: &ServerIpcConnection) -> (Option<String>, Vec<String>) {
@@ -147,6 +160,7 @@ impl WorkerManager {
             .ipc_connection()
             .ok_or_else(|| WorkerError::Protocol("worker ipc unavailable".to_string()))?;
         let start = Instant::now();
+        let deadline = start + timeout;
         let mut result = self.driver.wait_for_completion(timeout, ipc.clone());
         if matches!(
             &result,
@@ -184,16 +198,7 @@ impl WorkerManager {
                 );
             }
         }
-        // Best-effort: after IPC completion, give the output reader threads a brief window to
-        // drain any bytes already written by the worker before we snapshot the ring.
-        let elapsed = start.elapsed();
-        let remaining = timeout.saturating_sub(elapsed);
-        let allow_utf8_tail_grace = !matches!(result, Err(WorkerError::Timeout(_)));
-        self.settle_output_after_completion_with_utf8_tail_grace(remaining, allow_utf8_tail_grace);
-        if result.is_ok() {
-            self.pending_output_tape
-                .append_sideband(PendingSidebandKind::RequestBoundary);
-        }
+        self.finalize_output_after_completion_wait(&result, deadline);
         if result.is_ok()
             && let Some(message) = ipc.take_protocol_error()
         {
@@ -213,29 +218,39 @@ impl WorkerManager {
     }
 
     pub(super) fn settle_output_after_completion(&self, budget: Duration) {
-        self.settle_output_after_completion_with_utf8_tail_grace(budget, true);
+        self.settle_output_for_request_outcome(
+            RequestOutputOutcome::Completed,
+            Instant::now() + budget,
+        );
     }
 
-    fn settle_output_after_completion_with_utf8_tail_grace(
-        &self,
-        budget: Duration,
-        allow_utf8_tail_grace: bool,
+    fn finalize_output_after_completion_wait(
+        &mut self,
+        result: &Result<CompletionInfo, WorkerError>,
+        deadline: Instant,
     ) {
-        let total = budget.min(OUTPUT_READER_QUIESCE_GRACE);
-        let utf8_tail_pending =
-            allow_utf8_tail_grace && self.output_timeline.has_unflushable_utf8_tail();
-        if total.is_zero() && !utf8_tail_pending {
+        let outcome = match result {
+            Ok(_) => RequestOutputOutcome::Completed,
+            Err(WorkerError::Timeout(_)) => RequestOutputOutcome::TimedOut,
+            Err(_) => RequestOutputOutcome::Failed,
+        };
+        self.settle_output_for_request_outcome(outcome, deadline);
+        if result.is_ok() {
+            self.pending_output_tape
+                .append_sideband(PendingSidebandKind::RequestBoundary);
+        }
+    }
+
+    fn settle_output_for_request_outcome(&self, outcome: RequestOutputOutcome, deadline: Instant) {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
             return;
         }
-        let stable_needed = if total.is_zero() && utf8_tail_pending {
-            OUTPUT_READER_COMPLETION_STABLE
-        } else {
-            OUTPUT_READER_COMPLETION_STABLE.min(total)
-        };
-        let utf8_tail_total = if allow_utf8_tail_grace {
-            OUTPUT_READER_UTF8_TAIL_SETTLE_MAX
-        } else {
-            total
+        let total = remaining.min(OUTPUT_READER_QUIESCE_GRACE);
+        let stable_needed = OUTPUT_READER_COMPLETION_STABLE.min(remaining);
+        let utf8_tail_total = match outcome {
+            RequestOutputOutcome::Completed => remaining.min(OUTPUT_READER_UTF8_TAIL_SETTLE_MAX),
+            RequestOutputOutcome::TimedOut | RequestOutputOutcome::Failed => total,
         };
         self.settle_output_until_stable(total, stable_needed, utf8_tail_total);
     }
@@ -264,8 +279,11 @@ impl WorkerManager {
         }
     }
 
-    pub(super) fn settle_output_after_timeout(&self) {
-        let total = OUTPUT_READER_TIMEOUT_SETTLE_MAX;
+    pub(super) fn settle_output_after_timeout(&self, budget: Duration) {
+        let total = budget.min(OUTPUT_READER_TIMEOUT_SETTLE_MAX);
+        if total.is_zero() {
+            return;
+        }
         let stable_needed = Duration::from_millis(40);
         let poll = Duration::from_millis(5);
         let start = Instant::now();
@@ -326,7 +344,11 @@ impl WorkerManager {
         let mut stable_for = Duration::from_millis(0);
         loop {
             let elapsed = start.elapsed();
-            if elapsed >= total && (!saw_utf8_tail_pending || elapsed >= utf8_tail_total) {
+            if elapsed >= total
+                && (!saw_utf8_tail_pending
+                    || (elapsed >= utf8_tail_total
+                        && (utf8_tail_pending || stable_for >= stable_needed)))
+            {
                 return;
             }
             thread::sleep(poll);
@@ -540,7 +562,7 @@ mod tests {
             );
         });
 
-        manager.settle_output_after_completion(OUTPUT_READER_QUIESCE_GRACE);
+        manager.settle_output_after_completion(OUTPUT_READER_UTF8_TAIL_SETTLE_MAX);
         let formatted = manager.drain_final_formatted_output();
 
         handle.join().expect("delayed output writer should finish");
@@ -557,7 +579,7 @@ mod tests {
     }
 
     #[test]
-    fn completion_settle_uses_utf8_tail_grace_when_budget_is_zero() {
+    fn completion_settle_does_not_wait_when_budget_is_zero() {
         let manager = WorkerManager::new(
             Backend::Python,
             SandboxCliPlan::default(),
@@ -584,17 +606,17 @@ mod tests {
 
         let text = contents_text(&formatted.contents);
         assert!(
-            text.contains("é\n"),
-            "completion settle should use UTF-8 tail grace even with no regular budget, got: {text:?}"
+            text.contains("\\xC3"),
+            "completion settle should respect a zero budget and leave sealing to final drain, got: {text:?}"
         );
         assert!(
-            !text.contains("\\xC3") && !text.contains("\\xA9"),
-            "completion settle should not seal split UTF-8 bytes when continuation arrives within the tail grace, got: {text:?}"
+            !text.contains("é"),
+            "completion settle should not wait for UTF-8 continuation bytes after a zero budget, got: {text:?}"
         );
     }
 
     #[test]
-    fn completion_settle_keeps_stability_window_after_zero_budget_utf8_recovery() {
+    fn completion_settle_keeps_stability_window_after_utf8_recovery() {
         let manager = WorkerManager::new(
             Backend::Python,
             SandboxCliPlan::default(),
@@ -620,7 +642,7 @@ mod tests {
             );
         });
 
-        manager.settle_output_after_completion(Duration::ZERO);
+        manager.settle_output_after_completion(Duration::from_millis(200));
         let formatted = manager.drain_final_formatted_output();
 
         handle.join().expect("delayed output writer should finish");

--- a/src/worker_process/request_lifecycle.rs
+++ b/src/worker_process/request_lifecycle.rs
@@ -19,6 +19,7 @@ const OUTPUT_READER_COMPLETION_STABLE: Duration = if cfg!(target_os = "macos") {
 } else {
     Duration::from_millis(15)
 };
+const OUTPUT_READER_UTF8_TAIL_SETTLE_MAX: Duration = Duration::from_millis(900);
 const OUTPUT_READER_TIMEOUT_SETTLE_MAX: Duration = Duration::from_millis(900);
 
 pub(super) struct RequestState {
@@ -212,11 +213,13 @@ impl WorkerManager {
 
     pub(super) fn settle_output_after_completion(&self, budget: Duration) {
         let total = budget.min(OUTPUT_READER_QUIESCE_GRACE);
-        if total.is_zero() {
+        let utf8_tail_pending = self.output_timeline.has_unflushable_utf8_tail();
+        if total.is_zero() && !utf8_tail_pending {
             return;
         }
         let stable_needed = OUTPUT_READER_COMPLETION_STABLE.min(total);
-        self.settle_output_until_stable(total, stable_needed);
+        let utf8_tail_total = OUTPUT_READER_UTF8_TAIL_SETTLE_MAX;
+        self.settle_output_until_stable(total, stable_needed, utf8_tail_total);
     }
 
     pub(super) fn wait_for_late_files_output_after_settled_completion(&self, budget: Duration) {
@@ -282,7 +285,12 @@ impl WorkerManager {
         )
     }
 
-    fn settle_output_until_stable(&self, total: Duration, stable_needed: Duration) {
+    fn settle_output_until_stable(
+        &self,
+        total: Duration,
+        stable_needed: Duration,
+        utf8_tail_total: Duration,
+    ) {
         if total.is_zero() {
             return;
         }
@@ -298,15 +306,21 @@ impl WorkerManager {
             OversizedOutputMode::Pager => self.output.current_progress_seq(),
         };
         let mut utf8_tail_pending = self.output_timeline.has_unflushable_utf8_tail();
+        let mut saw_utf8_tail_pending = utf8_tail_pending;
         let mut input_echo_ready = !requires_input_echo || self.pending_input_echoes_seen() > 0;
         let mut stable_for = Duration::from_millis(0);
-        while start.elapsed() < total {
+        loop {
+            let elapsed = start.elapsed();
+            if elapsed >= total && (!saw_utf8_tail_pending || elapsed >= utf8_tail_total) {
+                return;
+            }
             thread::sleep(poll);
             let now = match self.oversized_output {
                 OversizedOutputMode::Files => self.pending_output_tape.current_seq(),
                 OversizedOutputMode::Pager => self.output.current_progress_seq(),
             };
             let now_utf8_tail_pending = self.output_timeline.has_unflushable_utf8_tail();
+            saw_utf8_tail_pending |= now_utf8_tail_pending;
             if !input_echo_ready && self.pending_input_echoes_seen() > 0 {
                 input_echo_ready = true;
                 stable_for = Duration::from_millis(0);
@@ -487,6 +501,43 @@ mod tests {
         assert!(
             !text.contains("\\xC3") && !text.contains("\\xA9"),
             "completion settle should not seal split UTF-8 bytes when continuation arrives within the grace window, got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn completion_settle_extends_quiesce_while_utf8_tail_is_pending() {
+        let manager = WorkerManager::new(
+            Backend::Python,
+            SandboxCliPlan::default(),
+            OversizedOutputMode::Files,
+        )
+        .expect("worker manager");
+
+        manager.pending_output_tape.append_stdout_bytes(&[0xC3]);
+
+        let timeline = manager.output_timeline.clone();
+        let handle = thread::spawn(move || {
+            thread::sleep(OUTPUT_READER_QUIESCE_GRACE + Duration::from_millis(80));
+            timeline.append_text(
+                &[0xA9, b'\n'],
+                false,
+                crate::worker_protocol::ContentOrigin::Worker,
+            );
+        });
+
+        manager.settle_output_after_completion(OUTPUT_READER_QUIESCE_GRACE);
+        let formatted = manager.drain_final_formatted_output();
+
+        handle.join().expect("delayed output writer should finish");
+
+        let text = contents_text(&formatted.contents);
+        assert!(
+            text.contains("é\n"),
+            "completion settle should extend past normal quiesce while UTF-8 tail is pending, got: {text:?}"
+        );
+        assert!(
+            !text.contains("\\xC3") && !text.contains("\\xA9"),
+            "completion settle should not seal split UTF-8 bytes before the extended budget expires, got: {text:?}"
         );
     }
 }

--- a/src/worker_process/request_lifecycle.rs
+++ b/src/worker_process/request_lifecycle.rs
@@ -525,7 +525,7 @@ mod tests {
             );
         });
 
-        manager.settle_output_after_completion(Duration::from_millis(120));
+        manager.settle_output_after_completion(Duration::from_millis(200));
         let formatted = manager.drain_final_formatted_output();
 
         handle.join().expect("delayed output writer should finish");

--- a/src/worker_process/request_lifecycle.rs
+++ b/src/worker_process/request_lifecycle.rs
@@ -188,11 +188,11 @@ impl WorkerManager {
         // drain any bytes already written by the worker before we snapshot the ring.
         let elapsed = start.elapsed();
         let remaining = timeout.saturating_sub(elapsed);
+        self.settle_output_after_completion(remaining);
         if result.is_ok() {
             self.pending_output_tape
                 .append_sideband(PendingSidebandKind::RequestBoundary);
         }
-        self.settle_output_after_completion(remaining);
         if result.is_ok()
             && let Some(message) = ipc.take_protocol_error()
         {
@@ -386,9 +386,9 @@ impl WorkerManager {
         match status {
             Ok(()) => {
                 let mut settled_completion = completion_info_from_ipc(&ipc, false);
+                self.settle_output_after_completion(Duration::from_millis(120));
                 self.pending_output_tape
                     .append_sideband(PendingSidebandKind::RequestBoundary);
-                self.settle_output_after_completion(Duration::from_millis(120));
                 let worker_exited = match self.process.as_mut() {
                     Some(process) => match process.is_running() {
                         Ok(running) => !running,
@@ -427,9 +427,9 @@ impl WorkerManager {
 
     pub(super) fn settle_pending_session_end(&mut self, ipc: &ServerIpcConnection) {
         let settled_completion = completion_info_from_ipc(ipc, true);
+        self.settle_output_after_completion(Duration::from_millis(120));
         self.pending_output_tape
             .append_sideband(PendingSidebandKind::RequestBoundary);
-        self.settle_output_after_completion(Duration::from_millis(120));
         self.note_session_end(true);
         self.clear_pending_request_state();
         self.settled_pending_completion = Some(settled_completion);

--- a/src/worker_process/request_lifecycle.rs
+++ b/src/worker_process/request_lifecycle.rs
@@ -346,8 +346,8 @@ impl WorkerManager {
             let elapsed = start.elapsed();
             if elapsed >= total
                 && (!saw_utf8_tail_pending
-                    || (elapsed >= utf8_tail_total
-                        && (utf8_tail_pending || stable_for >= stable_needed)))
+                    || elapsed >= utf8_tail_total
+                    || (!utf8_tail_pending && stable_for >= stable_needed))
             {
                 return;
             }

--- a/src/worker_process/request_lifecycle.rs
+++ b/src/worker_process/request_lifecycle.rs
@@ -217,7 +217,11 @@ impl WorkerManager {
         if total.is_zero() && !utf8_tail_pending {
             return;
         }
-        let stable_needed = OUTPUT_READER_COMPLETION_STABLE.min(total);
+        let stable_needed = if total.is_zero() && utf8_tail_pending {
+            OUTPUT_READER_COMPLETION_STABLE
+        } else {
+            OUTPUT_READER_COMPLETION_STABLE.min(total)
+        };
         let utf8_tail_total = OUTPUT_READER_UTF8_TAIL_SETTLE_MAX;
         self.settle_output_until_stable(total, stable_needed, utf8_tail_total);
     }
@@ -568,6 +572,49 @@ mod tests {
         assert!(
             text.contains("é\n"),
             "completion settle should use UTF-8 tail grace even with no regular budget, got: {text:?}"
+        );
+        assert!(
+            !text.contains("\\xC3") && !text.contains("\\xA9"),
+            "completion settle should not seal split UTF-8 bytes when continuation arrives within the tail grace, got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn completion_settle_keeps_stability_window_after_zero_budget_utf8_recovery() {
+        let manager = WorkerManager::new(
+            Backend::Python,
+            SandboxCliPlan::default(),
+            OversizedOutputMode::Files,
+        )
+        .expect("worker manager");
+
+        manager.pending_output_tape.append_stdout_bytes(&[0xC3]);
+
+        let timeline = manager.output_timeline.clone();
+        let handle = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(40));
+            timeline.append_text(
+                &[0xA9],
+                false,
+                crate::worker_protocol::ContentOrigin::Worker,
+            );
+            thread::sleep(Duration::from_millis(10));
+            timeline.append_text(
+                b" after\n",
+                false,
+                crate::worker_protocol::ContentOrigin::Worker,
+            );
+        });
+
+        manager.settle_output_after_completion(Duration::ZERO);
+        let formatted = manager.drain_final_formatted_output();
+
+        handle.join().expect("delayed output writer should finish");
+
+        let text = contents_text(&formatted.contents);
+        assert!(
+            text.contains("é after\n"),
+            "completion settle should keep a stability window after UTF-8 recovery, got: {text:?}"
         );
         assert!(
             !text.contains("\\xC3") && !text.contains("\\xA9"),

--- a/src/worker_process/request_reply.rs
+++ b/src/worker_process/request_reply.rs
@@ -43,7 +43,7 @@ impl WorkerManager {
         page_bytes: u64,
     ) -> ReplyWithOffset {
         self.last_detached_prefix_item_count = context.detached_prefix_contents.len();
-        self.output_timeline.flush_utf8_tails();
+        self.output_timeline.seal_utf8_tails();
         let end_offset = self.output.end_offset().unwrap_or(context.start_offset);
         let first_page_budget = page_bytes.saturating_sub(context.prefix_bytes);
         let mut contents = context.detached_prefix_contents;
@@ -128,7 +128,7 @@ impl WorkerManager {
                 }
 
                 if self.should_settle_output_after_timeout() {
-                    self.settle_output_after_timeout();
+                    self.settle_output_after_timeout(request.remaining_budget());
                 }
                 self.pending_request = true;
                 self.pending_request_started_at = Some(request.started_at);
@@ -170,7 +170,7 @@ impl WorkerManager {
                 if session_end {
                     self.note_session_end(true);
                 }
-                self.output_timeline.flush_utf8_tails();
+                self.output_timeline.seal_utf8_tails();
                 let end_offset = self.output.end_offset().unwrap_or(context.start_offset);
                 let first_page_budget = page_bytes.saturating_sub(context.prefix_bytes);
                 let mut contents = context.detached_prefix_contents;
@@ -233,7 +233,8 @@ impl WorkerManager {
 
                 self.pending_request = true;
                 self.pending_request_started_at = Some(request.started_at);
-                self.output_timeline.flush_ready_utf8_tails();
+                self.output_timeline
+                    .seal_utf8_tails_blocking_visible_output();
                 let end_offset = self.output.end_offset().unwrap_or(0);
                 let first_page_budget = page_bytes.saturating_sub(context.prefix_bytes);
                 let mut contents = context.detached_prefix_contents;

--- a/src/worker_process/restart.rs
+++ b/src/worker_process/restart.rs
@@ -99,7 +99,7 @@ impl WorkerManager {
         &mut self,
         timeout: Duration,
     ) -> RestartShutdownSnapshot {
-        self.output_timeline.flush_utf8_tails();
+        self.output_timeline.seal_utf8_tails();
         let pre_shutdown_end_offset = self
             .process
             .is_some()
@@ -107,7 +107,7 @@ impl WorkerManager {
         if let Some(process) = self.process.take() {
             let _ = process.shutdown_graceful(timeout);
         }
-        self.output_timeline.flush_utf8_tails();
+        self.output_timeline.seal_utf8_tails();
         let post_shutdown_end_offset = self.output.end_offset();
         RestartShutdownSnapshot::Pager {
             pre_shutdown_end_offset,

--- a/src/worker_process/session_lifecycle.rs
+++ b/src/worker_process/session_lifecycle.rs
@@ -75,7 +75,7 @@ impl WorkerManager {
                             .pending_output_tape
                             .append_stdout_status_line(message.as_bytes()),
                         OversizedOutputMode::Pager => {
-                            self.output_timeline.flush_utf8_tails();
+                            self.output_timeline.seal_utf8_tails();
                             if self.output_timeline.last_text_ends_with_newline() {
                                 self.output_timeline.append_text(
                                     message.as_bytes(),

--- a/src/worker_process/session_reset_reply.rs
+++ b/src/worker_process/session_reset_reply.rs
@@ -45,7 +45,7 @@ impl WorkerManager {
         page_bytes: u64,
         meta: &str,
     ) -> ReplyWithOffset {
-        self.output_timeline.flush_utf8_tails();
+        self.output_timeline.seal_utf8_tails();
         let end_offset = self.output.end_offset().unwrap_or(0);
         self.build_session_reset_reply_pager_to_offset(page_bytes, meta, end_offset)
     }

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -320,10 +320,26 @@ fn run_command(
         let writer = writer.clone();
         let control_log_path = control_log_path.clone();
         thread::spawn(move || {
-            thread::sleep(Duration::from_millis(885));
+            thread::sleep(Duration::from_millis(800));
             let _ = output_text_with_continuation(&writer, &control_log_path, &[0xA9], true);
             thread::sleep(Duration::from_millis(30));
             let _ = output_text_with_continuation(&writer, &control_log_path, b" after\n", false);
+        });
+        return Ok(false);
+    }
+
+    if command == "split-utf8-near-grace-then-continuous-output-after-completion" {
+        output_text_with_continuation(writer, control_log_path, &[0xC3], false)?;
+        state.ready_after_turn = true;
+        let writer = writer.clone();
+        let control_log_path = control_log_path.clone();
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(885));
+            let _ = output_text_with_continuation(&writer, &control_log_path, &[0xA9], true);
+            for _ in 0..150 {
+                thread::sleep(Duration::from_millis(10));
+                let _ = output_text_with_continuation(&writer, &control_log_path, b".", false);
+            }
         });
         return Ok(false);
     }

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -309,6 +309,12 @@ fn run_command(
         return Ok(false);
     }
 
+    if command == "partial-utf8-then-sleep" {
+        output_text_with_continuation(writer, control_log_path, &[0xC3], false)?;
+        sleep_for(200, sideband_interrupted, false);
+        return Ok(false);
+    }
+
     if command == "raw-split-utf8-around-input-wait" {
         io::stdout().write_all(&[0xC3])?;
         io::stdout().flush()?;

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -255,6 +255,18 @@ fn run_command(
         return Ok(false);
     }
 
+    if command == "partial-stderr-utf8-then-late-stderr-after-completion" {
+        output_stderr_text_with_continuation(writer, control_log_path, &[0xC3], false)?;
+        state.ready_after_turn = true;
+        let writer = writer.clone();
+        let control_log_path = control_log_path.clone();
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(950));
+            let _ = output_stderr_text(&writer, &control_log_path, b"after\n");
+        });
+        return Ok(false);
+    }
+
     if command == "partial-stdout-then-newline-stderr" {
         output_text(writer, control_log_path, b"partial")?;
         output_stderr_text(writer, control_log_path, b"\nerr\n")?;
@@ -298,6 +310,20 @@ fn run_command(
         thread::spawn(move || {
             thread::sleep(Duration::from_millis(40));
             let _ = output_text_with_continuation(&writer, &control_log_path, &[0xA9, b'\n'], true);
+        });
+        return Ok(false);
+    }
+
+    if command == "split-utf8-near-grace-then-more-after-completion" {
+        output_text_with_continuation(writer, control_log_path, &[0xC3], false)?;
+        state.ready_after_turn = true;
+        let writer = writer.clone();
+        let control_log_path = control_log_path.clone();
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(885));
+            let _ = output_text_with_continuation(&writer, &control_log_path, &[0xA9], true);
+            thread::sleep(Duration::from_millis(30));
+            let _ = output_text_with_continuation(&writer, &control_log_path, b" after\n", false);
         });
         return Ok(false);
     }
@@ -520,6 +546,16 @@ fn output_stderr_text(
 ) -> io::Result<()> {
     append_control_log(control_log_path.as_deref(), "output_text stderr")?;
     writer.output_text("stderr", bytes)
+}
+
+fn output_stderr_text_with_continuation(
+    writer: &IpcWriter,
+    control_log_path: &Option<PathBuf>,
+    bytes: &[u8],
+    is_continuation: bool,
+) -> io::Result<()> {
+    append_control_log(control_log_path.as_deref(), "output_text stderr")?;
+    writer.output_text_with_continuation("stderr", bytes, is_continuation)
 }
 
 fn output_image(

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -116,6 +116,7 @@ fn run_worker(
         input_line_after_input_wait: false,
         session_end_after_input_wait: false,
         bad_output_after_input_wait: None,
+        ready_after_turn: false,
     };
     while let Ok(message) = rx.recv() {
         match message {
@@ -177,9 +178,15 @@ fn run_turn(
         state.previous_line_empty = command.is_empty();
     }
 
-    let prompt = std::mem::replace(&mut state.next_prompt, "v5> ".to_string());
-    writer.send(&WorkerToServer::InputWait { prompt })?;
-    append_control_log(control_log_path.as_deref(), "input_wait")?;
+    if state.ready_after_turn {
+        state.ready_after_turn = false;
+        writer.send(&WorkerToServer::Ready {})?;
+        append_control_log(control_log_path.as_deref(), "ready")?;
+    } else {
+        let prompt = std::mem::replace(&mut state.next_prompt, "v5> ".to_string());
+        writer.send(&WorkerToServer::InputWait { prompt })?;
+        append_control_log(control_log_path.as_deref(), "input_wait")?;
+    }
     emit_deferred_protocol_faults(writer, control_log_path, state)?;
     Ok(false)
 }
@@ -279,6 +286,19 @@ fn run_command(
         output_image(writer, control_log_path, b"img")?;
         sleep_for(200, sideband_interrupted, false);
         output_text_with_continuation(writer, control_log_path, &[0xA9], true)?;
+        return Ok(false);
+    }
+
+    if command == "split-utf8-after-completion" {
+        output_text_with_continuation(writer, control_log_path, &[0xC3], false)?;
+        output_image(writer, control_log_path, b"img")?;
+        state.ready_after_turn = true;
+        let writer = writer.clone();
+        let control_log_path = control_log_path.clone();
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(40));
+            let _ = output_text_with_continuation(&writer, &control_log_path, &[0xA9, b'\n'], true);
+        });
         return Ok(false);
     }
 
@@ -557,6 +577,7 @@ struct CommandState {
     input_line_after_input_wait: bool,
     session_end_after_input_wait: bool,
     bad_output_after_input_wait: Option<Duration>,
+    ready_after_turn: bool,
 }
 
 fn start_control_reader(

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -818,7 +818,7 @@ emit_at_wait = True; value = input("plot wait> ")
 #[tokio::test(flavor = "multi_thread")]
 async fn python_timeout_drains_later_stderr_after_incomplete_stdout_utf8_tail() -> TestResult<()> {
     let _guard = lock_test_mutex();
-    let Some(mut session) = start_python_session().await? else {
+    let Some(session) = start_python_session().await? else {
         return Ok(());
     };
 
@@ -866,32 +866,38 @@ sys.stdout.flush()
         "expected sealed UTF-8 head before later stderr, got: {text:?}"
     );
 
-    let poll = session.write_stdin_raw_with("", Some(5.0)).await?;
-    let poll = common::wait_until_not_busy(
-        &mut session,
-        poll,
-        Duration::from_millis(50),
-        Duration::from_secs(10),
-    )
-    .await?;
-    let poll_text = result_text(&poll);
+    let mut poll = session.write_stdin_raw_with("", Some(5.0)).await?;
+    let mut poll_text = result_text(&poll);
+    let mut completion_text = poll_text.clone();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline && is_busy_response(&poll_text) {
+        sleep(Duration::from_millis(50)).await;
+        poll = session
+            .write_stdin_raw_unterminated_with("", Some(2.0))
+            .await?;
+        poll_text = result_text(&poll);
+        completion_text.push_str(&poll_text);
+    }
 
     session.cancel().await?;
 
     assert!(
-        !poll_text.contains("STDERR_READY"),
-        "stderr already drained in timeout reply should not repeat on completion poll, got: {poll_text:?}"
+        !is_busy_response(&poll_text),
+        "expected request to finish after polling, got: {completion_text:?}"
     );
-    let tail_idx = poll_text
-        .find("\\xA9")
-        .ok_or_else(|| format!("expected remaining UTF-8 continuation byte, got: {poll_text:?}"))?;
-    let done_idx = poll_text
-        .find("STDOUT_DONE")
-        .ok_or_else(|| format!("expected trailing stdout, got: {poll_text:?}"))?;
     assert!(
-        tail_idx < done_idx,
-        "expected continuation byte before later stdout, got: {poll_text:?}"
+        !completion_text.contains("STDERR_READY"),
+        "stderr already drained in timeout reply should not repeat on completion polls, got: {completion_text:?}"
     );
+    let done_idx = completion_text
+        .find("STDOUT_DONE")
+        .ok_or_else(|| format!("expected trailing stdout, got: {completion_text:?}"))?;
+    if let Some(tail_idx) = completion_text.find("\\xA9") {
+        assert!(
+            tail_idx < done_idx,
+            "expected continuation byte before later stdout, got: {completion_text:?}"
+        );
+    }
     Ok(())
 }
 

--- a/tests/write_stdin_behavior.rs
+++ b/tests/write_stdin_behavior.rs
@@ -1268,13 +1268,18 @@ async fn follow_up_after_timeout_spills_when_prefix_and_reply_exceed_threshold()
 async fn busy_follow_up_reuses_hidden_timeout_bundle_when_it_first_spills() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let mut session = spawn_behavior_session().await?;
+    let temp = workspace_tempdir()?;
+    let entered_gate_path = temp.path().join("entered-gate");
+    let start_gate_path = temp.path().join("start-ready");
+    let tail_gate_path = temp.path().join("tail-ready");
+    let entered_gate_literal = r_path_literal(&entered_gate_path)?;
+    let start_gate_literal = r_path_literal(&start_gate_path)?;
+    let tail_gate_literal = r_path_literal(&tail_gate_path)?;
 
     let input = format!(
-        "small <- paste(rep('s', {UNDER_HARD_SPILL_TEXT_LEN}), collapse = ''); big <- paste(rep('t', {OVER_HARD_SPILL_TEXT_LEN}), collapse = ''); Sys.sleep(0.1); cat('SMALL_START\\n'); cat(small); cat('\\nSMALL_END\\n'); flush.console(); cat('BIG_START\\n'); cat(big); cat('\\nBIG_END\\n'); flush.console(); Sys.sleep(0.6); cat('TAIL\\n')"
+        "small <- paste(rep('s', {UNDER_HARD_SPILL_TEXT_LEN}), collapse = ''); big <- paste(rep('t', {OVER_HARD_SPILL_TEXT_LEN}), collapse = ''); writeLines('ready', {entered_gate_literal}); while (!file.exists({start_gate_literal})) Sys.sleep(0.01); cat('SMALL_START\\n'); cat(small); cat('\\nSMALL_END\\n'); flush.console(); cat('BIG_START\\n'); cat(big); cat('\\nBIG_END\\n'); flush.console(); while (!file.exists({tail_gate_literal})) Sys.sleep(0.01); cat('TAIL\\n')"
     );
-    let first = session
-        .write_stdin_raw_with(&input, Some(test_timeout_secs(0.005, 0.05)))
-        .await?;
+    let first = session.write_stdin_raw_with(&input, Some(0.05)).await?;
     let first_text = result_text(&first);
     if backend_unavailable(&first_text) {
         eprintln!("write_stdin_behavior backend unavailable in this environment; skipping");
@@ -1286,13 +1291,10 @@ async fn busy_follow_up_reuses_hidden_timeout_bundle_when_it_first_spills() -> T
         "did not expect timeout bundle disclosure before the busy follow-up, got: {first_text:?}"
     );
 
-    sleep(test_delay_ms(160, 700)).await;
-    let Some(transcript_path) = wait_until_busy_follow_up_discloses_transcript_path(
-        &mut session,
-        "1+1",
-        test_timeout_secs(0.1, 0.3),
-    )
-    .await?
+    wait_until_path_exists(&entered_gate_path, "worker output gate").await?;
+    fs::write(&start_gate_path, b"ready")?;
+    let Some(transcript_path) =
+        wait_until_busy_follow_up_discloses_transcript_path(&mut session, "1+1", 0.3).await?
     else {
         eprintln!("write_stdin_behavior busy follow-up completed without a busy marker; skipping");
         session.cancel().await?;
@@ -1314,6 +1316,7 @@ async fn busy_follow_up_reuses_hidden_timeout_bundle_when_it_first_spills() -> T
         "did not expect busy marker text inside the worker transcript, got: {spilled_text:?}"
     );
 
+    fs::write(&tail_gate_path, b"ready")?;
     let final_poll = session.write_stdin_raw_with("", Some(0.1)).await?;
     let final_poll = wait_until_not_busy(&mut session, final_poll).await?;
     let final_text = result_text(&final_poll);
@@ -1344,13 +1347,18 @@ async fn pager_busy_follow_up_reuses_hidden_timeout_bundle_when_it_first_spills(
 {
     let _guard = lock_test_mutex();
     let mut session = spawn_pager_behavior_session(20_000).await?;
+    let temp = workspace_tempdir()?;
+    let entered_gate_path = temp.path().join("entered-gate");
+    let start_gate_path = temp.path().join("start-ready");
+    let tail_gate_path = temp.path().join("tail-ready");
+    let entered_gate_literal = r_path_literal(&entered_gate_path)?;
+    let start_gate_literal = r_path_literal(&start_gate_path)?;
+    let tail_gate_literal = r_path_literal(&tail_gate_path)?;
 
     let input = format!(
-        "small <- paste(rep('s', {UNDER_HARD_SPILL_TEXT_LEN}), collapse = ''); big <- paste(rep('t', {OVER_HARD_SPILL_TEXT_LEN}), collapse = ''); Sys.sleep(0.1); cat('SMALL_START\\n'); cat(small); cat('\\nSMALL_END\\n'); flush.console(); cat('BIG_START\\n'); cat(big); cat('\\nBIG_END\\n'); flush.console(); Sys.sleep(0.6); cat('TAIL\\n')"
+        "small <- paste(rep('s', {UNDER_HARD_SPILL_TEXT_LEN}), collapse = ''); big <- paste(rep('t', {OVER_HARD_SPILL_TEXT_LEN}), collapse = ''); writeLines('ready', {entered_gate_literal}); while (!file.exists({start_gate_literal})) Sys.sleep(0.01); cat('SMALL_START\\n'); cat(small); cat('\\nSMALL_END\\n'); flush.console(); cat('BIG_START\\n'); cat(big); cat('\\nBIG_END\\n'); flush.console(); while (!file.exists({tail_gate_literal})) Sys.sleep(0.01); cat('TAIL\\n')"
     );
-    let first = session
-        .write_stdin_raw_with(&input, Some(test_timeout_secs(0.005, 0.05)))
-        .await?;
+    let first = session.write_stdin_raw_with(&input, Some(0.05)).await?;
     let first_text = result_text(&first);
     if backend_unavailable(&first_text) {
         eprintln!("write_stdin_behavior backend unavailable in this environment; skipping");
@@ -1362,13 +1370,10 @@ async fn pager_busy_follow_up_reuses_hidden_timeout_bundle_when_it_first_spills(
         "did not expect timeout bundle disclosure before the pager busy follow-up, got: {first_text:?}"
     );
 
-    sleep(test_delay_ms(160, 700)).await;
-    let Some(transcript_path) = wait_until_busy_follow_up_discloses_transcript_path(
-        &mut session,
-        "1+1",
-        test_timeout_secs(0.1, 0.3),
-    )
-    .await?
+    wait_until_path_exists(&entered_gate_path, "pager worker output gate").await?;
+    fs::write(&start_gate_path, b"ready")?;
+    let Some(transcript_path) =
+        wait_until_busy_follow_up_discloses_transcript_path(&mut session, "1+1", 0.3).await?
     else {
         eprintln!(
             "write_stdin_behavior pager busy follow-up completed without a busy marker; skipping"
@@ -1392,6 +1397,7 @@ async fn pager_busy_follow_up_reuses_hidden_timeout_bundle_when_it_first_spills(
         "did not expect pager busy marker text inside the worker transcript, got: {spilled_text:?}"
     );
 
+    fs::write(&tail_gate_path, b"ready")?;
     let final_poll = session.write_stdin_raw_with("", Some(0.1)).await?;
     let final_poll = wait_until_not_busy(&mut session, final_poll).await?;
     let final_text = result_text(&final_poll);

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -909,13 +909,13 @@ async fn zod_files_timeout_drains_event_after_incomplete_utf8() -> TestResult<()
         "expected the delayed UTF-8 request to time out, got: {timeout_text:?}"
     );
     assert!(
-        timeout_text.contains("é"),
-        "timeout drain should complete a delayed split UTF-8 tail before later output, got: {timeout_text:?}"
+        !timeout_text.contains("é"),
+        "timeout reply should not wait for the delayed UTF-8 tail grace, got: {timeout_text:?}"
     );
     assert_eq!(
         result_image_count(&timed_out),
         1,
-        "timeout drain should pass later complete events after completing a split UTF-8 tail"
+        "timeout reply should include the image emitted before the timeout"
     );
 
     let completed = session
@@ -932,8 +932,8 @@ async fn zod_files_timeout_drains_event_after_incomplete_utf8() -> TestResult<()
     session.cancel().await?;
 
     assert!(
-        !text.contains("\\xA9"),
-        "the continuation byte should not flush separately after timeout drain completed the split UTF-8 tail, got: {text:?}"
+        text.contains("\\xA9"),
+        "the delayed UTF-8 continuation should remain available on the follow-up poll, got: {text:?}"
     );
 
     Ok(())
@@ -969,6 +969,39 @@ async fn zod_files_timeout_drains_stderr_after_incomplete_utf8() -> TestResult<(
     assert!(
         timeout_text.contains("stderr: tail-visible\n"),
         "timeout drain should expose later stderr after an incomplete UTF-8 tail, got: {timeout_text:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_files_timeout_does_not_wait_for_utf8_tail_grace_after_expiry() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_server(&control_log).await?;
+
+    let started = std::time::Instant::now();
+    let timed_out = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "partial-utf8-then-sleep",
+                "timeout_ms": 50
+            }),
+        )
+        .await?;
+    let elapsed = started.elapsed();
+    let timeout_text = result_text(&timed_out);
+
+    session.cancel().await?;
+
+    assert!(
+        timeout_text.contains("<<repl status: busy"),
+        "expected the incomplete UTF-8 request to time out, got: {timeout_text:?}"
+    );
+    assert!(
+        elapsed < Duration::from_millis(500),
+        "timeout should not wait for the UTF-8 tail grace after expiry; elapsed {elapsed:?}"
     );
 
     Ok(())
@@ -1022,20 +1055,36 @@ async fn zod_pager_timeout_drains_event_after_incomplete_utf8() -> TestResult<()
         .await?;
     let timeout_text = result_text(&timed_out);
 
-    session.cancel().await?;
-
     assert!(
         timeout_text.contains("<<repl status: busy"),
         "expected the delayed UTF-8 request to time out, got: {timeout_text:?}"
     );
     assert!(
-        timeout_text.contains("é"),
-        "pager timeout should complete a delayed split UTF-8 tail before later output, got: {timeout_text:?}"
+        !timeout_text.contains("é"),
+        "pager timeout should not wait for the delayed UTF-8 tail grace, got: {timeout_text:?}"
     );
     assert_eq!(
         result_image_count(&timed_out),
         1,
-        "pager timeout should expose later complete events after completing a split UTF-8 tail"
+        "pager timeout should include the image emitted before the timeout"
+    );
+
+    let completed = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let text = result_text(&completed);
+
+    session.cancel().await?;
+
+    assert!(
+        text.contains("\\xA9"),
+        "the delayed UTF-8 continuation should remain available on the pager follow-up poll, got: {text:?}"
     );
 
     Ok(())

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -1167,6 +1167,37 @@ async fn zod_pager_output_text_matching_input_line_remains_visible() -> TestResu
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn zod_files_completion_settles_split_utf8_tail_before_request_boundary() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_server(&control_log).await?;
+
+    let result = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "split-utf8-after-completion",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let text = result_text(&result);
+
+    session.cancel().await?;
+
+    assert!(
+        text.contains("é\n"),
+        "completion should combine delayed UTF-8 continuation bytes before the request boundary, got: {text:?}"
+    );
+    assert!(
+        !text.contains("\\xC3") && !text.contains("\\xA9"),
+        "completion should not seal split UTF-8 bytes when the continuation arrives during settle, got: {text:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn zod_worker_v5_split_utf8_stdout_survives_interleaved_stderr() -> TestResult<()> {
     let tempdir = tempfile::tempdir()?;
     let control_log = tempdir.path().join("control.log");

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -909,13 +909,13 @@ async fn zod_files_timeout_drains_event_after_incomplete_utf8() -> TestResult<()
         "expected the delayed UTF-8 request to time out, got: {timeout_text:?}"
     );
     assert!(
-        timeout_text.contains("\\xC3"),
-        "timeout drain should flush an incomplete leading UTF-8 tail before later output, got: {timeout_text:?}"
+        timeout_text.contains("é"),
+        "timeout drain should complete a delayed split UTF-8 tail before later output, got: {timeout_text:?}"
     );
     assert_eq!(
         result_image_count(&timed_out),
         1,
-        "timeout drain should pass later complete events after flushing an incomplete UTF-8 tail"
+        "timeout drain should pass later complete events after completing a split UTF-8 tail"
     );
 
     let completed = session
@@ -932,8 +932,8 @@ async fn zod_files_timeout_drains_event_after_incomplete_utf8() -> TestResult<()
     session.cancel().await?;
 
     assert!(
-        text.contains("\\xA9"),
-        "the later continuation byte should flush separately after the timeout drained the prefix, got: {text:?}"
+        !text.contains("\\xA9"),
+        "the continuation byte should not flush separately after timeout drain completed the split UTF-8 tail, got: {text:?}"
     );
 
     Ok(())
@@ -1029,13 +1029,13 @@ async fn zod_pager_timeout_drains_event_after_incomplete_utf8() -> TestResult<()
         "expected the delayed UTF-8 request to time out, got: {timeout_text:?}"
     );
     assert!(
-        timeout_text.contains("\\xC3"),
-        "pager timeout should flush an incomplete leading UTF-8 tail before later output, got: {timeout_text:?}"
+        timeout_text.contains("é"),
+        "pager timeout should complete a delayed split UTF-8 tail before later output, got: {timeout_text:?}"
     );
     assert_eq!(
         result_image_count(&timed_out),
         1,
-        "pager timeout should expose later complete events after flushing an incomplete UTF-8 tail"
+        "pager timeout should expose later complete events after completing a split UTF-8 tail"
     );
 
     Ok(())

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -1278,6 +1278,40 @@ async fn zod_files_completion_keeps_stable_wait_after_utf8_recovery() -> TestRes
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_files_completion_bounds_stable_wait_after_utf8_recovery() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_server(&control_log).await?;
+
+    let start = std::time::Instant::now();
+    let result = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "split-utf8-near-grace-then-continuous-output-after-completion",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let elapsed = start.elapsed();
+    let text = result_text(&result);
+
+    session.cancel().await?;
+
+    assert!(
+        elapsed < Duration::from_millis(1_600),
+        "completion should cap UTF-8 settle even when later output prevents stability; elapsed {elapsed:?}, got: {text:?}"
+    );
+    assert!(
+        text.contains("é"),
+        "completion should include UTF-8 recovery before the cap, got: {text:?}"
+    );
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn zod_files_request_boundary_resets_stderr_after_sealed_utf8_tail() -> TestResult<()> {
     let tempdir = tempfile::tempdir()?;

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -1246,6 +1246,86 @@ async fn zod_files_completion_settles_split_utf8_tail_before_request_boundary() 
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_files_completion_keeps_stable_wait_after_utf8_recovery() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_server(&control_log).await?;
+
+    let result = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "split-utf8-near-grace-then-more-after-completion",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let text = result_text(&result);
+
+    session.cancel().await?;
+
+    assert!(
+        text.contains("é after\n"),
+        "completion should keep settling after UTF-8 recovery near the grace deadline, got: {text:?}"
+    );
+    assert!(
+        !text.contains("\\xC3") && !text.contains("\\xA9"),
+        "completion should not seal split UTF-8 bytes when the continuation arrives during settle, got: {text:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zod_files_request_boundary_resets_stderr_after_sealed_utf8_tail() -> TestResult<()> {
+    let tempdir = tempfile::tempdir()?;
+    let control_log = tempdir.path().join("control.log");
+    let session = spawn_zod_server(&control_log).await?;
+
+    let first = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "partial-stderr-utf8-then-late-stderr-after-completion",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let first_text = result_text(&first);
+    assert!(
+        !first_text.contains("\\xC3"),
+        "completed request should keep an incomplete UTF-8 tail detached, got: {first_text:?}"
+    );
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let second = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let second_text = result_text(&second);
+
+    session.cancel().await?;
+
+    assert!(
+        second_text.contains("stderr: \\xC3stderr: after\n"),
+        "request boundary should reset stderr rendering after sealing the prior UTF-8 tail, got: {second_text:?}"
+    );
+    assert!(
+        !second_text.contains("stderr: \\xC3after\n"),
+        "stderr rendering state leaked across the sealed UTF-8 tail, got: {second_text:?}"
+    );
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn zod_worker_v5_split_utf8_stdout_survives_interleaved_stderr() -> TestResult<()> {
     let tempdir = tempfile::tempdir()?;


### PR DESCRIPTION
## Summary

Refactor request output finalization so completion, timeout, session-end/error/reset paths, marker insertion, and UTF-8 tail sealing use explicit server-side policies instead of marker side effects.

This keeps the worker sideband protocol unchanged while making the server's output timeline contract clearer: markers are ordering facts, and UTF-8 tails are sealed only by named presentation policies.

## Public-facing changes

- Preserve split UTF-8 output when continuation bytes arrive during completion settling, including after normal output-reader quiescence.
- Keep `timeout_ms` as a hard response budget: timeout replies do not wait for the UTF-8 tail recovery window after expiry.
- Continue exposing already-buffered visible output, such as images or stderr, behind an incomplete UTF-8 tail in timeout replies.
- Prevent stderr rendering state from leaking across request boundaries after an incomplete UTF-8 tail is later sealed.

## Internal changes

- Make `input_wait`, `request_boundary`, and `session_end` pure timeline markers that do not implicitly drain or seal UTF-8 state.
- Replace generic UTF-8 flushing calls with explicit seal policies for final drains and timeout-visible-output drains.
- Add deadline-aware request output outcomes for completed, timed-out, and failed completion waits.
- Add zod fixture commands and public regressions for completion, timeout, and request-boundary UTF-8 behavior.
- Make busy follow-up bundle tests deterministic with file gates instead of scheduler sleeps.
- Document the timeline marker and UTF-8 sealing contract, and record the completed design plan.

## Testing

- `cargo check`
- `cargo build`
- `python3 tests/run_integration_tests.py --binary target/debug/mcp-repl`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo +nightly fmt`
