### PR TITLE
Relax manual PyPI backfill checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
           cache-bin: false
 
       - name: Install nightly rustfmt
+        if: github.event_name == 'push' && github.ref_type == 'tag'
         run: rustup toolchain install nightly --profile minimal --component rustfmt
 
       - name: Set up Python
@@ -99,30 +100,33 @@ jobs:
           fi
 
       - name: cargo check
+        if: github.event_name == 'push' && github.ref_type == 'tag'
         run: cargo check
 
       - name: cargo build
+        if: github.event_name == 'push' && github.ref_type == 'tag'
         run: cargo build
 
       - name: Windows sandbox setup
-        if: matrix.os == 'windows-2022'
+        if: github.event_name == 'push' && github.ref_type == 'tag' && matrix.os == 'windows-2022'
         shell: pwsh
         run: .\target\debug\mcp-repl.exe windows-sandbox setup
 
       - name: Python public API suite
-        if: matrix.os != 'windows-2022'
+        if: github.event_name == 'push' && github.ref_type == 'tag' && matrix.os != 'windows-2022'
         run: python3 tests/run_integration_tests.py --binary target/debug/mcp-repl
 
       - name: Python public API suite (windows)
-        if: matrix.os == 'windows-2022'
+        if: github.event_name == 'push' && github.ref_type == 'tag' && matrix.os == 'windows-2022'
         shell: pwsh
         run: python tests/run_integration_tests.py --binary target/debug/mcp-repl.exe
 
       - name: cargo clippy
+        if: github.event_name == 'push' && github.ref_type == 'tag'
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Install Codex CLI
-        if: matrix.os != 'windows-2022'
+        if: github.event_name == 'push' && github.ref_type == 'tag' && matrix.os != 'windows-2022'
         shell: bash
         run: |
           set -euo pipefail
@@ -133,7 +137,7 @@ jobs:
           codex --version
 
       - name: Install Codex CLI (windows)
-        if: matrix.os == 'windows-2022'
+        if: github.event_name == 'push' && github.ref_type == 'tag' && matrix.os == 'windows-2022'
         shell: pwsh
         run: |
           npm install -g @openai/codex
@@ -143,11 +147,13 @@ jobs:
           & (Join-Path $npmPrefix "codex.cmd") --version
 
       - name: cargo test
+        if: github.event_name == 'push' && github.ref_type == 'tag'
         env:
           MCP_REPL_CODEX_BACKEND: mock
         run: cargo test --quiet -- --test-threads=5
 
       - name: cargo +nightly fmt
+        if: github.event_name == 'push' && github.ref_type == 'tag'
         run: cargo +nightly fmt --all -- --check
 
       - name: cargo build --release
@@ -163,32 +169,21 @@ jobs:
         run: |
           .\target\release\mcp-repl.exe --help
 
-      - name: Detect release CLI contract
-        id: release_cli_contract_available
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -f tests/release_cli_contract.rs ]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Release CLI contract
-        if: matrix.os != 'windows-2022' && steps.release_cli_contract_available.outputs.exists == 'true'
+        if: github.event_name == 'push' && github.ref_type == 'tag' && matrix.os != 'windows-2022'
         env:
           MCP_REPL_RELEASE_BINARY: target/release/mcp-repl
         run: cargo test --test release_cli_contract --quiet
 
       - name: Release CLI contract (windows)
-        if: matrix.os == 'windows-2022' && steps.release_cli_contract_available.outputs.exists == 'true'
+        if: github.event_name == 'push' && github.ref_type == 'tag' && matrix.os == 'windows-2022'
         shell: pwsh
         env:
           MCP_REPL_RELEASE_BINARY: target/release/mcp-repl.exe
         run: cargo test --test release_cli_contract --quiet
 
       - name: Package release archive
-        if: matrix.os != 'windows-2022'
+        if: github.event_name == 'push' && github.ref_type == 'tag' && matrix.os != 'windows-2022'
         shell: bash
         run: |
           set -euo pipefail
@@ -199,7 +194,7 @@ jobs:
           tar -C dist -czf "dist/${{ matrix.asset_name }}" "mcp-repl-${{ matrix.target }}"
 
       - name: Package release archive (windows)
-        if: matrix.os == 'windows-2022'
+        if: github.event_name == 'push' && github.ref_type == 'tag' && matrix.os == 'windows-2022'
         shell: pwsh
         run: |
           $packageDir = "dist/mcp-repl-${{ matrix.target }}"
@@ -252,6 +247,7 @@ jobs:
           .\wheel-smoke\Scripts\mcp-repl.exe --help
 
       - name: Upload packaged artifact
+        if: github.event_name == 'push' && github.ref_type == 'tag'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -38,11 +38,12 @@ must be published before the next scheduled release tag.
 
 The manual dispatch checks out that tag, validates that the tag is final semver
 or PyPI-compatible prerelease semver, validates that it matches `Cargo.toml`,
-runs the normal release matrix, builds and smoke-tests the wheels, and then runs
-only `publish-pypi`. For tags that predate PyPI packaging, the dispatch overlays
-the current `pyproject.toml` packaging metadata only; the compiled source still
-comes from the immutable tag. Checks run from the tag's source tree, so checks
-added after that tag run only when their test files exist in the tag.
+builds and smoke-tests the release binary and PyPI wheels, and then runs only
+`publish-pypi`. It does not rerun historical validation checks; this path assumes
+that the checks required at the time already passed when the tag was created.
+For tags that predate PyPI packaging, the dispatch overlays the current
+`pyproject.toml` packaging metadata only; the compiled source still comes from
+the immutable tag.
 
 The manual dispatch does not create or update the GitHub release, move tags,
 publish a dev version, repair old GitHub Release assets, or upload an sdist. If

--- a/tests/docs_contracts.rs
+++ b/tests/docs_contracts.rs
@@ -381,12 +381,10 @@ fn release_workflow_defines_tag_and_manual_pypi_publishing_contract() {
         "run: cargo test --quiet",
         "MCP_REPL_CODEX_BACKEND: mock",
         "Release CLI contract",
-        "Detect release CLI contract",
-        "release_cli_contract_available",
-        "steps.release_cli_contract_available.outputs.exists == 'true'",
         "MCP_REPL_RELEASE_BINARY: target/release/mcp-repl",
         "MCP_REPL_RELEASE_BINARY: target/release/mcp-repl.exe",
         "cargo test --test release_cli_contract --quiet",
+        "if: github.event_name == 'push' && github.ref_type == 'tag'",
         "if: github.event_name == 'push' && github.ref_type == 'tag' && needs.checks.result == 'success'",
         "if: needs.checks.result == 'success' && ((github.event_name == 'push' && github.ref_type == 'tag') || github.event_name == 'workflow_dispatch')",
         "-F draft=false",
@@ -422,6 +420,10 @@ fn release_workflow_defines_tag_and_manual_pypi_publishing_contract() {
         "steps.release_tag.outputs.latest",
         "manylinux: auto",
         "matrix.manylinux",
+        "Detect Python public API suite",
+        "python_public_api_suite_available",
+        "Detect release CLI contract",
+        "release_cli_contract_available",
     ] {
         assert!(
             !workflow.contains(forbidden),
@@ -500,13 +502,19 @@ fn releasing_docs_define_checklist_and_wheel_only_pypi_policy() {
         "tags that predate PyPI packaging",
         "current `pyproject.toml` packaging metadata only",
         "compiled source still comes from the immutable tag",
-        "Checks run from the tag's source tree",
-        "checks added after that tag run only when their test files exist",
+        "does not rerun historical validation checks",
+        "already passed when the tag was created",
+        "builds and smoke-tests the release binary and PyPI wheels",
         "does not create or update the GitHub release",
         "version already exists on PyPI",
     ] {
         assert_contains_wrapped_text(&docs, required, "docs/releasing.md");
     }
+
+    assert!(
+        !normalized_whitespace(&docs).contains("runs the normal release matrix"),
+        "manual PyPI backfill docs should not imply historical tags rerun the current validation matrix"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Relax manual PyPI backfill runs so they do not rerun validation checks from the current release workflow against historical tags. A backfilled tag is assumed to have satisfied the checks that were required when the tag was originally created; the manual path should only rebuild and smoke-test the artifacts needed to publish `posit-mcp-repl`.

## User-facing changes

- Clarifies the release guide for manual PyPI backfills.
- Documents that manual backfills build and smoke-test the release binary and PyPI wheels, then publish only to PyPI.
- Documents that manual backfills do not rerun historical validation checks.

## Internal changes

- Keeps full check, test, lint, formatting, client integration, release CLI contract, and GitHub Release archive steps on tag-push releases only.
- Leaves manual dispatches with tag/version validation, release build, binary smoke test, PyPI wheel build, wheel smoke test, wheel artifact upload, and PyPI publishing.
- Updates docs-contract coverage so the manual path cannot drift back toward rerunning the current validation matrix.
