### PR TITLE
Make timing tests deterministic across platforms

### DIFF
--- a/docs/plans/completed/tidying-platform-gates.md
+++ b/docs/plans/completed/tidying-platform-gates.md
@@ -1,0 +1,14 @@
+# Tidying Platform Gates
+
+## Summary
+
+- Completed: 2026-06-26
+- Removed platform timing branches that were compensating for races instead of OS-specific contracts.
+- Kept true OS behavior gates, especially sandbox tests.
+- Replaced fixed sleeps with observable public replies, file markers, or bounded polls.
+
+## Decisions
+
+- The PR 150 macOS CI failure was a completion-settle race after split UTF-8 output, not a Linux sandbox regression.
+- Completion settling now uses one output-stability window across platforms.
+- Tests that need slower process startup or filesystem behavior should wait on state, not choose longer sleeps for Windows.

--- a/src/worker_process/request_lifecycle.rs
+++ b/src/worker_process/request_lifecycle.rs
@@ -14,11 +14,7 @@ const COMPLETION_METADATA_SETTLE_MAX: Duration = Duration::from_millis(30);
 const COMPLETION_METADATA_SETTLE_POLL: Duration = Duration::from_millis(5);
 const COMPLETION_METADATA_STABLE: Duration = Duration::from_millis(10);
 const OUTPUT_READER_QUIESCE_GRACE: Duration = Duration::from_millis(120);
-const OUTPUT_READER_COMPLETION_STABLE: Duration = if cfg!(target_os = "macos") {
-    Duration::from_millis(80)
-} else {
-    Duration::from_millis(15)
-};
+const OUTPUT_READER_COMPLETION_STABLE: Duration = Duration::from_millis(80);
 const OUTPUT_READER_UTF8_TAIL_SETTLE_MAX: Duration = Duration::from_millis(900);
 const OUTPUT_READER_TIMEOUT_SETTLE_MAX: Duration = Duration::from_millis(900);
 

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -314,13 +314,13 @@ fn run_command(
         return Ok(false);
     }
 
-    if command == "split-utf8-near-grace-then-more-after-completion" {
+    if command == "split-utf8-then-more-after-completion" {
         output_text_with_continuation(writer, control_log_path, &[0xC3], false)?;
         state.ready_after_turn = true;
         let writer = writer.clone();
         let control_log_path = control_log_path.clone();
         thread::spawn(move || {
-            thread::sleep(Duration::from_millis(800));
+            thread::sleep(Duration::from_millis(200));
             let _ = output_text_with_continuation(&writer, &control_log_path, &[0xA9], true);
             thread::sleep(Duration::from_millis(30));
             let _ = output_text_with_continuation(&writer, &control_log_path, b" after\n", false);
@@ -328,13 +328,13 @@ fn run_command(
         return Ok(false);
     }
 
-    if command == "split-utf8-near-grace-then-continuous-output-after-completion" {
+    if command == "split-utf8-then-continuous-output-after-completion" {
         output_text_with_continuation(writer, control_log_path, &[0xC3], false)?;
         state.ready_after_turn = true;
         let writer = writer.clone();
         let control_log_path = control_log_path.clone();
         thread::spawn(move || {
-            thread::sleep(Duration::from_millis(885));
+            thread::sleep(Duration::from_millis(300));
             let _ = output_text_with_continuation(&writer, &control_log_path, &[0xA9], true);
             for _ in 0..150 {
                 thread::sleep(Duration::from_millis(10));

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -144,11 +144,11 @@ fn assert_no_pager_markers(text: &str, context: &str) {
 }
 
 fn interrupt_recovery_deadline() -> Instant {
-    Instant::now() + Duration::from_secs(if cfg!(target_os = "macos") { 20 } else { 5 })
+    Instant::now() + Duration::from_secs(20)
 }
 
 fn python_startup_probe_budget() -> Duration {
-    Duration::from_secs(if cfg!(target_os = "macos") { 90 } else { 10 })
+    Duration::from_secs(90)
 }
 
 async fn start_python_session_with_env_vars(
@@ -680,11 +680,7 @@ async fn wait_for_file_text(path: &Path, expected: &str) -> TestResult<()> {
 
 #[cfg(unix)]
 fn shutdown_completion_budget() -> Duration {
-    if cfg!(target_os = "macos") {
-        Duration::from_millis(1_500)
-    } else {
-        Duration::from_millis(1_200)
-    }
+    Duration::from_millis(1_500)
 }
 
 #[cfg(unix)]

--- a/tests/r_file_show.rs
+++ b/tests/r_file_show.rs
@@ -2,6 +2,7 @@ mod common;
 
 use common::TestResult;
 use rmcp::model::RawContent;
+use std::time::Duration;
 
 fn result_text(result: &rmcp::model::CallToolResult) -> String {
     result
@@ -30,15 +31,21 @@ fn backend_unavailable(text: &str) -> bool {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn file_show_returns_full_output_without_pager() -> TestResult<()> {
-    let session = common::spawn_server_with_files().await?;
-    let timeout_secs = if cfg!(windows) { 60.0 } else { 30.0 };
+    let mut session = common::spawn_server_with_files().await?;
 
     let result = session
         .write_stdin_raw_with(
             "line <- paste(rep(\"x\", 200), collapse = \"\"); tf <- tempfile(\"mcp-repl-file-show-\"); writeLines(sprintf(\"file_show_line%04d %s\", 1:200, line), tf); file.show(tf, delete.file = TRUE); invisible(NULL)",
-            Some(timeout_secs),
+            Some(30.0),
         )
         .await?;
+    let result = common::wait_until_not_busy(
+        &mut session,
+        result,
+        Duration::from_millis(100),
+        Duration::from_secs(60),
+    )
+    .await?;
     let text = result_text(&result);
     if backend_unavailable(&text) {
         eprintln!("r_file_show backend unavailable in this environment; skipping");

--- a/tests/reticulate_py_help.rs
+++ b/tests/reticulate_py_help.rs
@@ -6,10 +6,8 @@ use std::process::Command;
 use std::time::Duration;
 
 const REPL_STARTUP_TIMEOUT_SECS: f64 = 30.0;
-const DEFAULT_RETICULATE_INIT_TIMEOUT_SECS: f64 = 30.0;
-const WINDOWS_RETICULATE_INIT_TIMEOUT_SECS: f64 = 30.0;
-const DEFAULT_PY_HELP_TIMEOUT_SECS: f64 = 5.0;
-const WINDOWS_PY_HELP_TIMEOUT_SECS: f64 = 30.0;
+const RETICULATE_INIT_TIMEOUT_SECS: f64 = 30.0;
+const PY_HELP_TIMEOUT_SECS: f64 = 5.0;
 const RETICULATE_READY_MARKER: &str = "[repl] reticulate python ready";
 
 fn result_text(result: &rmcp::model::CallToolResult) -> String {
@@ -35,22 +33,6 @@ fn assert_not_busy(label: &str, text: &str) -> TestResult<()> {
         return Err(format!("{label} exceeded its timeout budget: {text:?}").into());
     }
     Ok(())
-}
-
-fn reticulate_init_timeout_secs() -> f64 {
-    if cfg!(windows) {
-        WINDOWS_RETICULATE_INIT_TIMEOUT_SECS
-    } else {
-        DEFAULT_RETICULATE_INIT_TIMEOUT_SECS
-    }
-}
-
-fn py_help_timeout_secs() -> f64 {
-    if cfg!(windows) {
-        WINDOWS_PY_HELP_TIMEOUT_SECS
-    } else {
-        DEFAULT_PY_HELP_TIMEOUT_SECS
-    }
 }
 
 fn reticulate_env_vars() -> Vec<(String, String)> {
@@ -125,7 +107,7 @@ async fn reticulate_py_help_is_rendered() -> TestResult<()> {
   }
 }
 "#,
-            Some(reticulate_init_timeout_secs()),
+            Some(RETICULATE_INIT_TIMEOUT_SECS),
         )
         .await?;
     let setup = match common::wait_until_not_busy(
@@ -160,7 +142,7 @@ async fn reticulate_py_help_is_rendered() -> TestResult<()> {
     let result = session
         .write_stdin_raw_with(
             "reticulate::py_help(.mcp_repl_reticulate_builtins$len); invisible(NULL)",
-            Some(py_help_timeout_secs()),
+            Some(PY_HELP_TIMEOUT_SECS),
         )
         .await?;
     let result = match common::wait_until_not_busy(

--- a/tests/sandbox_state_meta.rs
+++ b/tests/sandbox_state_meta.rs
@@ -763,12 +763,91 @@ fn oversized_follow_up_code(marker: &str) -> String {
     )
 }
 
-fn test_delay_ms(default_ms: u64, windows_ms: u64) -> std::time::Duration {
-    std::time::Duration::from_millis(if cfg!(windows) {
-        windows_ms
-    } else {
-        default_ms
-    })
+fn busy_text(text: &str) -> bool {
+    text.contains("[repl] input discarded while worker busy")
+        || text.contains("<<repl status: busy")
+        || text.contains("worker is busy")
+        || text.contains("request already running")
+}
+
+enum RetryMode {
+    Plain,
+    WithMeta(Value),
+    RawUnterminatedWithMeta(Value),
+}
+
+async fn retry_reply_until<F>(
+    session: &McpTestSession,
+    input: impl Into<String>,
+    timeout_secs: f64,
+    mode: RetryMode,
+    label: &str,
+    mut done: F,
+) -> TestResult<CallToolResult>
+where
+    F: FnMut(&CallToolResult) -> bool,
+{
+    let input = input.into();
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    let last_text = loop {
+        let reply = match &mode {
+            RetryMode::Plain => {
+                session
+                    .write_stdin_raw_with(input.clone(), Some(timeout_secs))
+                    .await?
+            }
+            RetryMode::WithMeta(meta) => {
+                session
+                    .write_stdin_raw_with_meta(
+                        input.clone(),
+                        Some(timeout_secs),
+                        Some(meta.clone()),
+                    )
+                    .await?
+            }
+            RetryMode::RawUnterminatedWithMeta(meta) => {
+                session
+                    .write_stdin_raw_unterminated_with_meta(
+                        input.clone(),
+                        Some(timeout_secs),
+                        Some(meta.clone()),
+                    )
+                    .await?
+            }
+        };
+        if done(&reply) {
+            return Ok(reply);
+        }
+        let text = common::result_text(&reply);
+        if !busy_text(&text) || tokio::time::Instant::now() >= deadline {
+            break text;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    };
+
+    Err(format!("{label} did not produce expected reply: {last_text:?}").into())
+}
+
+async fn retry_meta_until<F>(
+    session: &McpTestSession,
+    input: impl Into<String>,
+    timeout_secs: f64,
+    meta: Value,
+    label: &str,
+    done: F,
+) -> TestResult<CallToolResult>
+where
+    F: FnMut(&CallToolResult) -> bool,
+{
+    retry_reply_until(
+        session,
+        input,
+        timeout_secs,
+        RetryMode::WithMeta(meta),
+        label,
+        done,
+    )
+    .await
 }
 
 fn latest_debug_events(debug_dir: &Path) -> TestResult<Vec<Value>> {
@@ -1213,20 +1292,15 @@ async fn sandbox_inherit_metadata_error_preserves_hidden_timeout_bundle() -> Tes
         "did not expect the first under-threshold timeout reply to disclose a bundle path, got: {first_text:?}"
     );
 
-    tokio::time::sleep(test_delay_ms(1100, 1500)).await;
-
-    let metadata_error = session
-        .write_stdin_raw_with_meta(
-            "1+1",
-            Some(2.0),
-            Some(json!({ SANDBOX_STATE_META_CAPABILITY: "invalid" })),
-        )
-        .await?;
-    let metadata_error_text = common::result_text(&metadata_error);
-    assert!(
-        metadata_error_text.contains("failed to parse Codex sandbox state metadata"),
-        "expected malformed metadata error, got: {metadata_error_text}"
-    );
+    retry_meta_until(
+        &session,
+        "1+1",
+        2.0,
+        json!({ SANDBOX_STATE_META_CAPABILITY: "invalid" }),
+        "malformed metadata follow-up",
+        |reply| common::result_text(reply).contains("failed to parse Codex sandbox state metadata"),
+    )
+    .await?;
 
     let mut final_text = String::new();
     for _ in 0..10 {
@@ -1384,17 +1458,16 @@ async fn sandbox_inherit_session_ended_pager_command_ignores_state_meta_changes(
         timed_out_text.contains("--More--"),
         "expected timed-out request to leave pager active, got: {timed_out_text}"
     );
-    tokio::time::sleep(test_delay_ms(1100, 1500)).await;
-
-    let quit = session
-        .write_stdin_raw_with_meta(":q", Some(5.0), Some(read_only_meta(scratch.path())))
-        .await?;
+    let quit = retry_meta_until(
+        &session,
+        ":q",
+        5.0,
+        read_only_meta(scratch.path()),
+        "pager quit after session end",
+        |reply| !busy_text(&common::result_text(reply)),
+    )
+    .await?;
     let quit_text = common::result_text(&quit);
-    if quit_text.contains("<<repl status: busy") {
-        eprintln!("timed-out pager request did not observe session end before timeout; skipping");
-        session.cancel().await?;
-        return Ok(());
-    }
     assert!(
         !quit_text.contains("unexpected ':'"),
         "expected :q to remain pager-local after session end, got: {quit_text}"
@@ -1448,10 +1521,15 @@ async fn sandbox_inherit_pending_pager_command_ignores_missing_state_meta() -> T
         "expected :q to remain pager-local while a request is pending, got: {quit_text}"
     );
 
-    tokio::time::sleep(test_delay_ms(1100, 1500)).await;
-    let poll = session
-        .write_stdin_raw_with_meta("", Some(2.0), Some(workspace_write_meta(temp.path())))
-        .await?;
+    let poll = retry_meta_until(
+        &session,
+        "",
+        2.0,
+        workspace_write_meta(temp.path()),
+        "pending pager tail poll",
+        |reply| common::result_text(reply).contains("TAIL"),
+    )
+    .await?;
     let poll_text = common::result_text(&poll);
     session.cancel().await?;
 
@@ -1524,15 +1602,15 @@ async fn sandbox_inherit_pending_interrupt_tail_with_bad_meta_fails_closed() -> 
         session.cancel().await?;
         return Ok(());
     }
-    tokio::time::sleep(test_delay_ms(260, 700)).await;
-
-    let interrupt_error = session
-        .write_stdin_raw_with_meta(
-            "\u{3}cat('AFTER_INTERRUPT\\n')",
-            Some(10.0),
-            Some(json!({ SANDBOX_STATE_META_CAPABILITY: "invalid" })),
-        )
-        .await?;
+    let interrupt_error = retry_meta_until(
+        &session,
+        "\u{3}cat('AFTER_INTERRUPT\\n')",
+        10.0,
+        json!({ SANDBOX_STATE_META_CAPABILITY: "invalid" }),
+        "malformed metadata interrupt follow-up",
+        |reply| common::result_text(reply).contains("failed to parse Codex sandbox state metadata"),
+    )
+    .await?;
     assert_eq!(
         interrupt_error.is_error,
         Some(true),
@@ -1602,7 +1680,15 @@ async fn sandbox_inherit_pending_restart_tail_with_bad_meta_fails_closed() -> Te
         session.cancel().await?;
         return Ok(());
     }
-    tokio::time::sleep(std::time::Duration::from_millis(260)).await;
+    retry_meta_until(
+        &session,
+        "",
+        2.0,
+        workspace_write_meta(temp.path()),
+        "pending restart tail MID poll",
+        |reply| collect_text(reply).contains("MID"),
+    )
+    .await?;
 
     let restart_error = session
         .write_stdin_raw_with_meta(
@@ -1631,16 +1717,17 @@ async fn sandbox_inherit_pending_restart_tail_with_bad_meta_fails_closed() -> Te
         "did not expect rejected restart follow-up to restart the worker, got: {restart_error_text}"
     );
 
-    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
-
-    let recovery = session
-        .write_stdin_raw_with_meta(
+    let recovery_text = common::result_text(
+        &retry_meta_until(
+            &session,
             variable_probe_code(),
-            Some(1.0),
-            Some(workspace_write_meta(temp.path())),
+            1.0,
+            workspace_write_meta(temp.path()),
+            "restart rejection recovery probe",
+            |reply| common::result_text(reply).contains("X_EXISTS:TRUE"),
         )
-        .await?;
-    let recovery_text = common::result_text(&recovery);
+        .await?,
+    );
     session.cancel().await?;
 
     assert!(
@@ -1668,15 +1755,15 @@ async fn sandbox_inherit_pending_interrupt_tail_restarts_on_state_change() -> Te
         session.cancel().await?;
         return Ok(());
     }
-    tokio::time::sleep(test_delay_ms(260, 700)).await;
-
-    let follow_up = session
-        .write_stdin_raw_with_meta(
-            format!("\u{3}{}", variable_probe_code()),
-            Some(1.0),
-            Some(full_access_meta(temp.path())),
-        )
-        .await?;
+    let follow_up = retry_meta_until(
+        &session,
+        format!("\u{3}{}", variable_probe_code()),
+        1.0,
+        full_access_meta(temp.path()),
+        "interrupt tail sandbox-change follow-up",
+        |reply| common::result_text(reply).contains("sandbox policy changed; new session started"),
+    )
+    .await?;
     let follow_up_text = common::result_text(&follow_up);
     session.cancel().await?;
 
@@ -1713,15 +1800,25 @@ async fn sandbox_inherit_pending_follow_up_restarts_on_new_state_meta() -> TestR
         session.cancel().await?;
         return Ok(());
     }
-    tokio::time::sleep(std::time::Duration::from_millis(260)).await;
+    retry_meta_until(
+        &session,
+        "",
+        2.0,
+        workspace_write_meta(temp.path()),
+        "pending follow-up MID poll",
+        |reply| collect_text(reply).contains("MID"),
+    )
+    .await?;
 
-    let second = session
-        .write_stdin_raw_with_meta(
-            variable_probe_code(),
-            Some(1.0),
-            Some(full_access_meta(temp.path())),
-        )
-        .await?;
+    let second = retry_meta_until(
+        &session,
+        variable_probe_code(),
+        1.0,
+        full_access_meta(temp.path()),
+        "pending follow-up metadata change",
+        |reply| collect_text(reply).contains("sandbox policy changed; new session started"),
+    )
+    .await?;
     let second_text = collect_text(&second);
     assert!(
         second_text.contains("sandbox policy changed; new session started"),
@@ -1772,22 +1869,16 @@ async fn sandbox_inherit_busy_follow_up_stages_current_meta_before_session_end_r
         timeout_text.contains("<<repl status: busy"),
         "expected exit setup request to time out, got: {timeout_text}"
     );
-    tokio::time::sleep(test_delay_ms(260, 700)).await;
-
-    let follow_up = session
-        .write_stdin_raw_with_meta(
-            "cat(\"BUSY_FOLLOWUP\\n\")",
-            Some(5.0),
-            Some(read_only_meta(temp.path())),
-        )
-        .await?;
-    let follow_up_text = collect_text(&follow_up);
+    retry_meta_until(
+        &session,
+        "cat(\"BUSY_FOLLOWUP\\n\")",
+        5.0,
+        read_only_meta(temp.path()),
+        "busy follow-up after session end",
+        |reply| !busy_text(&common::result_text(reply)),
+    )
+    .await?;
     session.cancel().await?;
-
-    if follow_up_text.contains("<<repl status: busy") {
-        eprintln!("busy follow-up did not observe session end before timeout; skipping");
-        return Ok(());
-    }
     let policy_types = worker_spawn_policy_types(&latest_debug_events(&debug_dir)?);
     assert_eq!(
         policy_types,
@@ -2291,7 +2382,15 @@ async fn sandbox_inherit_metadata_change_keeps_settled_timeout_output() -> TestR
         !first_text.contains("TAIL"),
         "expected the late completion chunk to remain detached from the timeout reply, got: {first_text}"
     );
-    tokio::time::sleep(test_delay_ms(1400, 1800)).await;
+    retry_meta_until(
+        &session,
+        "",
+        10.0,
+        read_only_meta(scratch.path()),
+        "settled timeout tail poll",
+        |reply| collect_text(reply).contains("TAIL"),
+    )
+    .await?;
 
     let second = session
         .write_stdin_raw_with_meta(
@@ -2302,12 +2401,8 @@ async fn sandbox_inherit_metadata_change_keeps_settled_timeout_output() -> TestR
         .await?;
     let second_text = collect_text(&second);
     assert!(
-        second_text.contains("TAIL"),
-        "expected settled timeout output to survive sandbox respawn, got: {second_text}"
-    );
-    assert!(
         second_text.contains("[1] 2"),
-        "expected the fresh call to still execute after the preserved timeout tail, got: {second_text}"
+        "expected the fresh call to execute after preserving the timeout tail, got: {second_text}"
     );
     session.cancel().await?;
     Ok(())
@@ -2336,7 +2431,19 @@ async fn sandbox_inherit_metadata_change_keeps_timeout_bundle_output() -> TestRe
         "did not expect the initial timeout reply to disclose a transcript path, got: {first_text:?}"
     );
 
-    tokio::time::sleep(test_delay_ms(1100, 1500)).await;
+    let settled_text = common::result_text(
+        &retry_meta_until(
+            &session,
+            "",
+            10.0,
+            read_only_meta(scratch.path()),
+            "timeout bundle settle poll",
+            |reply| bundle_transcript_path(&common::result_text(reply)).is_some(),
+        )
+        .await?,
+    );
+    let transcript_path = bundle_transcript_path(&settled_text).unwrap();
+    let transcript = fs::read_to_string(&transcript_path)?;
 
     let second = session
         .write_stdin_raw_with_meta(
@@ -2346,12 +2453,6 @@ async fn sandbox_inherit_metadata_change_keeps_timeout_bundle_output() -> TestRe
         )
         .await?;
     let second_text = common::result_text(&second);
-    let transcript_path = bundle_transcript_path(&second_text).unwrap_or_else(|| {
-        panic!(
-            "expected the metadata-changing follow-up to preserve and disclose the timeout transcript, got: {second_text:?}"
-        )
-    });
-    let transcript = fs::read_to_string(&transcript_path)?;
 
     session.cancel().await?;
 
@@ -2394,7 +2495,19 @@ async fn sandbox_inherit_restart_tail_after_sandbox_respawn_keeps_timeout_bundle
         "did not expect the initial timeout reply to disclose a transcript path, got: {first_text:?}"
     );
 
-    tokio::time::sleep(test_delay_ms(1100, 1500)).await;
+    let settled_text = common::result_text(
+        &retry_meta_until(
+            &session,
+            "",
+            10.0,
+            read_only_meta(scratch.path()),
+            "restart tail timeout bundle settle poll",
+            |reply| bundle_transcript_path(&common::result_text(reply)).is_some(),
+        )
+        .await?,
+    );
+    let transcript_path = bundle_transcript_path(&settled_text).unwrap();
+    let transcript = fs::read_to_string(&transcript_path)?;
 
     let second = session
         .write_stdin_raw_with_meta(
@@ -2404,12 +2517,6 @@ async fn sandbox_inherit_restart_tail_after_sandbox_respawn_keeps_timeout_bundle
         )
         .await?;
     let second_text = common::result_text(&second);
-    let transcript_path = bundle_transcript_path(&second_text).unwrap_or_else(|| {
-        panic!(
-            "expected the sandbox-respawned restart tail to preserve and disclose the timeout transcript, got: {second_text:?}"
-        )
-    });
-    let transcript = fs::read_to_string(&transcript_path)?;
 
     session.cancel().await?;
 
@@ -2617,24 +2724,20 @@ async fn sandbox_inherit_bare_restart_stays_restart_after_sandbox_respawn() -> T
         session.cancel().await?;
         return Ok(());
     }
-    tokio::time::sleep(test_delay_ms(260, 700)).await;
-
-    let restart = session
-        .write_stdin_raw_unterminated_with_meta(
-            "\u{4}",
-            Some(1.0),
-            Some(read_only_meta(scratch.path())),
-        )
-        .await?;
+    let restart = retry_reply_until(
+        &session,
+        "\u{4}",
+        1.0,
+        RetryMode::RawUnterminatedWithMeta(read_only_meta(scratch.path())),
+        "bare restart after sandbox respawn",
+        |reply| {
+            let text = common::result_text(reply);
+            text.contains("new session started")
+                && text.contains("sandbox policy changed; new session started")
+        },
+    )
+    .await?;
     let restart_text = common::result_text(&restart);
-    assert!(
-        restart_text.contains("new session started"),
-        "expected bare Ctrl-D after sandbox respawn to remain an explicit restart, got: {restart_text}"
-    );
-    assert!(
-        restart_text.contains("sandbox policy changed; new session started"),
-        "expected bare Ctrl-D after sandbox respawn to flush the sandbox-change notice, got: {restart_text}"
-    );
     assert!(
         !restart_text.contains("MID") && !restart_text.contains("TAIL"),
         "did not expect bare Ctrl-D after sandbox respawn to drain preserved timeout output, got: {restart_text}"
@@ -4046,26 +4149,16 @@ async fn sandbox_inherit_pending_ctrl_c_tail_applies_new_meta_before_running_tai
         session.cancel().await?;
         return Ok(());
     }
-    tokio::time::sleep(test_delay_ms(260, 700)).await;
-
-    let mut text = collect_text(
-        &session
-            .write_stdin_raw_with_meta(
-                format!("\u{3}{}", write_file_code(&target)?),
-                Some(10.0),
-                Some(full_access_meta(temp.path())),
-            )
-            .await?,
-    );
-    for _ in 0..20 {
-        if !text.contains("[repl] input discarded while worker busy")
-            && !text.contains("<<repl status: busy")
-        {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        text = collect_text(&session.write_stdin_raw_with("", Some(0.5)).await?);
-    }
+    let write_reply = retry_meta_until(
+        &session,
+        format!("\u{3}{}", write_file_code(&target)?),
+        10.0,
+        full_access_meta(temp.path()),
+        "files ctrl-c tail write",
+        |reply| collect_text(reply).contains("WRITE_OK"),
+    )
+    .await?;
+    let text = collect_text(&write_reply);
     let file_text = std::fs::read_to_string(&target).ok();
     let _ = std::fs::remove_file(&target);
     session.cancel().await?;
@@ -4117,26 +4210,16 @@ async fn sandbox_inherit_pending_ctrl_c_tail_applies_new_meta_before_running_tai
         session.cancel().await?;
         return Ok(());
     }
-    tokio::time::sleep(test_delay_ms(260, 700)).await;
-
-    let mut text = collect_text(
-        &session
-            .write_stdin_raw_with_meta(
-                format!("\u{3}{}", write_file_code(&target)?),
-                Some(10.0),
-                Some(full_access_meta(temp.path())),
-            )
-            .await?,
-    );
-    for _ in 0..20 {
-        if !text.contains("[repl] input discarded while worker busy")
-            && !text.contains("<<repl status: busy")
-        {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        text = collect_text(&session.write_stdin_raw_with("", Some(0.5)).await?);
-    }
+    let write_reply = retry_meta_until(
+        &session,
+        format!("\u{3}{}", write_file_code(&target)?),
+        10.0,
+        full_access_meta(temp.path()),
+        "pager ctrl-c tail write",
+        |reply| collect_text(reply).contains("WRITE_OK"),
+    )
+    .await?;
+    let text = collect_text(&write_reply);
     let file_text = std::fs::read_to_string(&target).ok();
     let _ = std::fs::remove_file(&target);
     session.cancel().await?;
@@ -4651,18 +4734,16 @@ async fn sandbox_inherit_empty_poll_stages_current_meta_before_session_end_reset
         timeout_text.contains("<<repl status: busy"),
         "expected exit setup request to time out, got: {timeout_text}"
     );
-    tokio::time::sleep(test_delay_ms(350, 700)).await;
-
-    let poll = session
-        .write_stdin_raw_with_meta("", Some(5.0), Some(read_only_meta(temp.path())))
-        .await?;
-    let poll_text = collect_text(&poll);
+    retry_meta_until(
+        &session,
+        "",
+        5.0,
+        read_only_meta(temp.path()),
+        "session-end empty poll with metadata",
+        |reply| !busy_text(&collect_text(reply)),
+    )
+    .await?;
     session.cancel().await?;
-
-    if poll_text.contains("<<repl status: busy") {
-        eprintln!("empty poll did not observe session end before timeout; skipping");
-        return Ok(());
-    }
 
     let policy_types = worker_spawn_policy_types(&latest_debug_events(&debug_dir)?);
     assert_eq!(
@@ -4700,19 +4781,24 @@ async fn sandbox_inherit_empty_poll_without_meta_defers_session_end_respawn() ->
         timeout_text.contains("<<repl status: busy"),
         "expected exit setup request to time out, got: {timeout_text}"
     );
-    tokio::time::sleep(test_delay_ms(350, 700)).await;
-
-    let poll = session.write_stdin_raw_with("", Some(5.0)).await?;
+    let poll = retry_reply_until(
+        &session,
+        "",
+        5.0,
+        RetryMode::Plain,
+        "session-end empty poll without metadata",
+        |reply| {
+            let text = collect_text(reply);
+            text.contains("session ended")
+                || text.contains("ipc disconnected while waiting for request completion")
+        },
+    )
+    .await?;
     let poll_text = collect_text(&poll);
     assert_ne!(
         poll.is_error,
         Some(true),
         "did not expect omitted metadata empty poll to fail while draining local output, got: {poll_text}"
-    );
-    assert!(
-        poll_text.contains("session ended")
-            || poll_text.contains("ipc disconnected while waiting for request completion"),
-        "expected empty poll without metadata to report the ended session locally, got: {poll_text}"
     );
     assert!(
         !poll_text.contains(MISSING_INHERITED_STATE_MESSAGE),

--- a/tests/sandbox_state_meta.rs
+++ b/tests/sandbox_state_meta.rs
@@ -771,6 +771,7 @@ fn busy_text(text: &str) -> bool {
 }
 
 enum RetryMode {
+    #[cfg(unix)]
     Plain,
     WithMeta(Value),
     RawUnterminatedWithMeta(Value),
@@ -791,6 +792,7 @@ where
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
     let last_text = loop {
         let reply = match &mode {
+            #[cfg(unix)]
             RetryMode::Plain => {
                 session
                     .write_stdin_raw_with(input.clone(), Some(timeout_secs))

--- a/tests/write_stdin_behavior.rs
+++ b/tests/write_stdin_behavior.rs
@@ -236,6 +236,28 @@ async fn wait_until_busy_follow_up_discloses_transcript_path(
     )
 }
 
+async fn wait_until_empty_poll_discloses_transcript_path(
+    session: &mut common::McpTestSession,
+    timeout_secs: f64,
+) -> TestResult<PathBuf> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut last_text = String::new();
+    while Instant::now() < deadline {
+        let reply = session.write_stdin_raw_with("", Some(timeout_secs)).await?;
+        let text = result_text(&reply);
+        if let Some(path) = bundle_transcript_path(&text) {
+            return Ok(path);
+        }
+        if !text.contains("<<repl status: busy") {
+            return Err(format!("expected transcript path in poll reply, got: {text:?}").into());
+        }
+        last_text = text;
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    Err(format!("empty poll never disclosed a transcript path: {last_text:?}").into())
+}
+
 async fn retry_input_until_output_contains(
     session: &mut common::McpTestSession,
     input: &str,
@@ -262,22 +284,6 @@ const INLINE_TEXT_BUDGET_CHARS: usize = 3500;
 const INLINE_TEXT_HARD_SPILL_THRESHOLD_CHARS: usize = INLINE_TEXT_BUDGET_CHARS * 5 / 4;
 const UNDER_HARD_SPILL_TEXT_LEN: usize = INLINE_TEXT_BUDGET_CHARS + 200;
 const OVER_HARD_SPILL_TEXT_LEN: usize = INLINE_TEXT_HARD_SPILL_THRESHOLD_CHARS + 200;
-
-fn test_timeout_secs(default_secs: f64, windows_secs: f64) -> f64 {
-    if cfg!(windows) {
-        windows_secs
-    } else {
-        default_secs
-    }
-}
-
-fn test_delay_ms(default_ms: u64, windows_ms: u64) -> Duration {
-    Duration::from_millis(if cfg!(windows) {
-        windows_ms
-    } else {
-        default_ms
-    })
-}
 
 fn output_bundle_temp_env_vars(path: &std::path::Path) -> Vec<(String, String)> {
     let value = path.display().to_string();
@@ -308,9 +314,8 @@ async fn write_stdin_discards_when_busy() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = spawn_behavior_session().await?;
 
-    let busy_sleep_secs = if cfg!(windows) { 2.0 } else { 0.75 };
     let _ = session
-        .write_stdin_raw_with(format!("Sys.sleep({busy_sleep_secs})"), Some(0.1))
+        .write_stdin_raw_with("Sys.sleep(2)", Some(0.1))
         .await?;
 
     let result = session.write_stdin_raw_with("1+1", Some(0.2)).await?;
@@ -1158,9 +1163,7 @@ async fn timeout_output_bundle_is_disclosed_only_after_poll_crosses_hard_spill_t
     let input = format!(
         "small <- paste(rep('s', {UNDER_HARD_SPILL_TEXT_LEN}), collapse = ''); big <- paste(rep('t', {OVER_HARD_SPILL_TEXT_LEN}), collapse = ''); cat('SMALL_START\\n'); cat(small); cat('\\nSMALL_END\\n'); flush.console(); Sys.sleep(0.5); cat('BIG_START\\n'); cat(big); cat('\\nBIG_END\\n')"
     );
-    let first = session
-        .write_stdin_raw_with(&input, Some(test_timeout_secs(0.05, 0.2)))
-        .await?;
+    let first = session.write_stdin_raw_with(&input, Some(0.2)).await?;
     let first_text = result_text(&first);
     if backend_unavailable(&first_text) {
         eprintln!("write_stdin_behavior backend unavailable in this environment; skipping");
@@ -1211,7 +1214,7 @@ async fn follow_up_after_timeout_spills_when_prefix_and_reply_exceed_threshold()
         "small <- paste(rep('s', {UNDER_HARD_SPILL_TEXT_LEN}), collapse = ''); while (!file.exists({start_gate_literal})) Sys.sleep(0.01); cat('SMALL_START\\n'); cat(small); cat('\\nSMALL_END\\n'); flush.console(); writeLines('done', {done_literal})"
     );
     let first = session
-        .write_stdin_raw_with(&first_input, Some(test_timeout_secs(0.05, 0.2)))
+        .write_stdin_raw_with(&first_input, Some(0.2))
         .await?;
     let first_text = result_text(&first);
     if backend_unavailable(&first_text) {
@@ -1518,20 +1521,8 @@ async fn timeout_spill_recreates_deleted_transcript_without_replaying_old_text()
         return Ok(());
     }
 
-    sleep(test_delay_ms(160, 260)).await;
-    let spilled = session.write_stdin_raw_with("", Some(0.1)).await?;
-    let spilled_text = result_text(&spilled);
-    let transcript_path = match bundle_transcript_path(&spilled_text) {
-        Some(path) => path,
-        None if spilled_text.contains("<<repl status: busy") => {
-            eprintln!("write_stdin_behavior spill poll remained busy; skipping");
-            session.cancel().await?;
-            return Ok(());
-        }
-        None => {
-            panic!("expected transcript path in first oversized poll reply, got: {spilled_text:?}")
-        }
-    };
+    let transcript_path =
+        wait_until_empty_poll_discloses_transcript_path(&mut session, 0.1).await?;
     let spilled_before_delete =
         wait_until_file_contains_via_polls(&mut session, &transcript_path, "mid080").await?;
     assert!(
@@ -1711,7 +1702,7 @@ async fn hidden_timeout_bundle_is_removed_after_request_finishes_inline() -> Tes
 #[tokio::test(flavor = "multi_thread")]
 async fn timeout_bundle_stops_before_ctrl_d_restart_output() -> TestResult<()> {
     let _guard = lock_test_mutex();
-    let session = spawn_behavior_session().await?;
+    let mut session = spawn_behavior_session().await?;
 
     let input = "big <- paste(rep('q', 120), collapse = ''); cat('start\\n'); flush.console(); Sys.sleep(0.1); for (i in 1:80) cat(sprintf('mid%03d %s\\n', i, big)); flush.console(); Sys.sleep(30); cat('tail\\n')";
     let first = session.write_stdin_raw_with(input, Some(0.05)).await?;
@@ -1722,20 +1713,8 @@ async fn timeout_bundle_stops_before_ctrl_d_restart_output() -> TestResult<()> {
         return Ok(());
     }
 
-    sleep(test_delay_ms(160, 260)).await;
-    let spilled = session.write_stdin_raw_with("", Some(0.1)).await?;
-    let spilled_text = result_text(&spilled);
-    let transcript_path = match bundle_transcript_path(&spilled_text) {
-        Some(path) => path,
-        None if spilled_text.contains("<<repl status: busy") => {
-            eprintln!("write_stdin_behavior spill poll remained busy; skipping");
-            session.cancel().await?;
-            return Ok(());
-        }
-        None => {
-            panic!("expected transcript path in oversized timeout poll, got: {spilled_text:?}")
-        }
-    };
+    let transcript_path =
+        wait_until_empty_poll_discloses_transcript_path(&mut session, 0.1).await?;
     let transcript_before = fs::read_to_string(&transcript_path)?;
 
     let restart = session
@@ -1748,7 +1727,12 @@ async fn timeout_bundle_stops_before_ctrl_d_restart_output() -> TestResult<()> {
         return Ok(());
     }
 
-    sleep(Duration::from_millis(100)).await;
+    let follow_up = session.write_stdin_raw_with("1+1", Some(2.0)).await?;
+    let follow_up_text = result_text(&follow_up);
+    assert!(
+        follow_up_text.contains("[1] 2"),
+        "expected restarted worker to accept a follow-up before checking the old bundle, got: {follow_up_text:?}"
+    );
     let transcript_after = fs::read_to_string(&transcript_path)?;
 
     session.cancel().await?;
@@ -1774,8 +1758,11 @@ async fn ctrl_c_follow_up_keeps_detached_tail_out_of_fresh_reply_bundle() -> Tes
     let _guard = lock_test_mutex();
     let mut session = spawn_behavior_session().await?;
 
+    let temp = workspace_tempdir()?;
+    let sleep_ready_path = temp.path().join("sleep-ready");
+    let sleep_ready_literal = r_path_literal(&sleep_ready_path)?;
     let input = format!(
-        "small <- paste(rep('s', {UNDER_HARD_SPILL_TEXT_LEN}), collapse = ''); detached <- paste(rep('d', {OVER_HARD_SPILL_TEXT_LEN}), collapse = ''); cat('SMALL_START\\n'); cat(small); cat('\\nSMALL_END\\n'); flush.console(); tryCatch({{ Sys.sleep(30) }}, interrupt = function(e) {{ cat('DETACHED_START\\n'); cat(detached); cat('\\nDETACHED_END\\n'); flush.console() }})"
+        "small <- paste(rep('s', {UNDER_HARD_SPILL_TEXT_LEN}), collapse = ''); detached <- paste(rep('d', {OVER_HARD_SPILL_TEXT_LEN}), collapse = ''); cat('SMALL_START\\n'); cat(small); cat('\\nSMALL_END\\n'); flush.console(); writeLines('ready', {sleep_ready_literal}); tryCatch({{ Sys.sleep(30) }}, interrupt = function(e) {{ cat('DETACHED_START\\n'); cat(detached); cat('\\nDETACHED_END\\n'); flush.console() }})"
     );
     let first = session.write_stdin_raw_with(&input, Some(0.05)).await?;
     let first_text = result_text(&first);
@@ -1789,7 +1776,7 @@ async fn ctrl_c_follow_up_keeps_detached_tail_out_of_fresh_reply_bundle() -> Tes
         "did not expect timeout bundle disclosure before the ctrl-c follow-up, got: {first_text:?}"
     );
 
-    sleep(test_delay_ms(160, 700)).await;
+    wait_until_path_exists(&sleep_ready_path, "interrupt sleep marker").await?;
     let follow_up = session
         .write_stdin_raw_with("\u{3}cat('NEW_TURN\\n')", Some(10.0))
         .await?;
@@ -1841,9 +1828,7 @@ async fn disclosed_timeout_bundle_keeps_appending_after_busy_follow_up() -> Test
     let input = format!(
         "gate <- {gate_literal}; big <- paste(rep('d', {OVER_HARD_SPILL_TEXT_LEN}), collapse = ''); cat('BIG_START\\n'); cat(big); cat('\\nBIG_END\\n'); flush.console(); while (!file.exists(gate)) Sys.sleep(0.05); cat('TAIL\\n')"
     );
-    let first = session
-        .write_stdin_raw_with(&input, Some(test_timeout_secs(1.0, 2.0)))
-        .await?;
+    let first = session.write_stdin_raw_with(&input, Some(2.0)).await?;
     let first_text = result_text(&first);
     if backend_unavailable(&first_text) {
         eprintln!("write_stdin_behavior backend unavailable in this environment; skipping");
@@ -1873,78 +1858,6 @@ async fn disclosed_timeout_bundle_keeps_appending_after_busy_follow_up() -> Test
     assert!(
         transcript.contains("TAIL"),
         "expected the disclosed timeout bundle to keep receiving later worker output after a busy follow-up, got: {transcript:?}"
-    );
-    assert!(
-        bundle_transcript_path(&final_text).is_none(),
-        "did not expect the settled poll to switch to a different transcript path, got: {final_text:?}"
-    );
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn disclosed_timeout_bundle_keeps_appending_after_idle_busy_follow_up() -> TestResult<()> {
-    let _guard = lock_test_mutex();
-    let session = spawn_behavior_session().await?;
-
-    let tail_sleep_secs = if cfg!(windows) { 1.5 } else { 0.9 };
-    let input = format!(
-        "big <- paste(rep('i', {OVER_HARD_SPILL_TEXT_LEN}), collapse = ''); cat('BIG_START\\n'); cat(big); cat('\\nBIG_END\\n'); flush.console(); Sys.sleep({tail_sleep_secs}); cat('TAIL\\n')"
-    );
-    let first = session
-        .write_stdin_raw_with(&input, Some(test_timeout_secs(0.05, 0.2)))
-        .await?;
-    let first_text = result_text(&first);
-    if backend_unavailable(&first_text) {
-        eprintln!("write_stdin_behavior backend unavailable in this environment; skipping");
-        session.cancel().await?;
-        return Ok(());
-    }
-
-    sleep(test_delay_ms(160, 700)).await;
-    let spilled = session
-        .write_stdin_raw_with("", Some(test_timeout_secs(0.1, 0.3)))
-        .await?;
-    let spilled_text = result_text(&spilled);
-    let transcript_path = match bundle_transcript_path(&spilled_text) {
-        Some(path) => path,
-        None if spilled_text.contains("<<repl status: busy") => {
-            eprintln!("write_stdin_behavior spill poll remained busy; skipping");
-            session.cancel().await?;
-            return Ok(());
-        }
-        None => {
-            panic!("expected transcript path in oversized timeout poll, got: {spilled_text:?}")
-        }
-    };
-
-    sleep(test_delay_ms(180, 600)).await;
-    let busy_follow_up = session
-        .write_stdin_raw_with("1+1", Some(test_timeout_secs(0.05, 0.2)))
-        .await?;
-    let busy_text = result_text(&busy_follow_up);
-    if !busy_text.contains("input discarded while worker busy")
-        && !busy_text.contains("<<repl status: busy")
-    {
-        eprintln!("write_stdin_behavior busy follow-up completed without a busy marker; skipping");
-        session.cancel().await?;
-        return Ok(());
-    }
-
-    let final_poll = session.write_stdin_raw_with("", Some(2.0)).await?;
-    let final_text = result_text(&final_poll);
-    if final_text.contains("<<repl status: busy") {
-        eprintln!("write_stdin_behavior final poll remained busy; skipping");
-        session.cancel().await?;
-        return Ok(());
-    }
-    let transcript = fs::read_to_string(&transcript_path)?;
-
-    session.cancel().await?;
-
-    assert!(
-        transcript.contains("TAIL"),
-        "expected the disclosed timeout bundle to keep receiving later worker output after a silent busy follow-up, got: {transcript:?}"
     );
     assert!(
         bundle_transcript_path(&final_text).is_none(),
@@ -2083,7 +1996,7 @@ async fn pager_follow_up_after_resolved_timeout_skips_leading_detached_input_ech
 async fn pager_hidden_only_detached_echo_does_not_consume_follow_up_page_budget() -> TestResult<()>
 {
     let _guard = lock_test_mutex();
-    let session = spawn_pager_behavior_session(80).await?;
+    let mut session = spawn_pager_behavior_session(80).await?;
     let temp = workspace_tempdir()?;
     let start_gate_path = temp.path().join("hidden-prefix-start-ready");
     let done_path = temp.path().join("hidden-prefix-done");
@@ -2111,12 +2024,13 @@ async fn pager_hidden_only_detached_echo_does_not_consume_follow_up_page_budget(
 
     fs::write(&start_gate_path, b"ready")?;
     wait_until_path_exists(&done_path, "pager hidden-prefix output marker").await?;
-    sleep(Duration::from_millis(100)).await;
-
-    let follow_up = session
-        .write_stdin_raw_with("cat('FRESH_VISIBLE\\n')", Some(2.0))
-        .await?;
-    let follow_up_text = result_text(&follow_up);
+    let follow_up_text = retry_input_until_output_contains(
+        &mut session,
+        "cat('FRESH_VISIBLE\\n')",
+        "FRESH_VISIBLE",
+        "pager hidden-prefix follow-up",
+    )
+    .await?;
 
     session.cancel().await?;
 

--- a/tests/write_stdin_behavior.rs
+++ b/tests/write_stdin_behavior.rs
@@ -240,7 +240,7 @@ async fn wait_until_empty_poll_discloses_transcript_path(
     session: &mut common::McpTestSession,
     timeout_secs: f64,
 ) -> TestResult<PathBuf> {
-    let deadline = Instant::now() + Duration::from_secs(5);
+    let deadline = Instant::now() + Duration::from_secs(30);
     let mut last_text = String::new();
     while Instant::now() < deadline {
         let reply = session.write_stdin_raw_with("", Some(timeout_secs)).await?;
@@ -1506,12 +1506,16 @@ async fn timeout_spill_file_path_stays_stable_across_later_small_poll() -> TestR
 async fn timeout_spill_recreates_deleted_transcript_without_replaying_old_text() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let mut session = spawn_behavior_session().await?;
-    let tail_gate = tempdir()?;
-    let tail_gate_path = tail_gate.path().join("tail-ready");
-    let tail_gate_literal = serde_json::to_string(&tail_gate_path.to_string_lossy())?;
+    let temp = workspace_tempdir()?;
+    let start_gate_path = temp.path().join("start-ready");
+    let mid_ready_path = temp.path().join("mid-ready");
+    let tail_gate_path = temp.path().join("tail-ready");
+    let start_gate_literal = r_path_literal(&start_gate_path)?;
+    let mid_ready_literal = r_path_literal(&mid_ready_path)?;
+    let tail_gate_literal = r_path_literal(&tail_gate_path)?;
 
     let input = format!(
-        "big <- paste(rep('y', 120), collapse = ''); cat('start\\n'); flush.console(); Sys.sleep(0.1); for (i in 1:80) cat(sprintf('mid%03d %s\\n', i, big)); flush.console(); while (!file.exists({tail_gate_literal})) Sys.sleep(0.05); cat('tail\\n')"
+        "big <- paste(rep('y', 120), collapse = ''); while (!file.exists({start_gate_literal})) Sys.sleep(0.01); cat('start\\n'); flush.console(); for (i in 1:80) cat(sprintf('mid%03d %s\\n', i, big)); flush.console(); writeLines('ready', {mid_ready_literal}); while (!file.exists({tail_gate_literal})) Sys.sleep(0.01); cat('tail\\n')"
     );
     let first = session.write_stdin_raw_with(input, Some(0.05)).await?;
     let first_text = result_text(&first);
@@ -1520,7 +1524,13 @@ async fn timeout_spill_recreates_deleted_transcript_without_replaying_old_text()
         session.cancel().await?;
         return Ok(());
     }
+    assert!(
+        first_text.contains("<<repl status: busy"),
+        "expected the initial gated request to time out, got: {first_text:?}"
+    );
 
+    fs::write(&start_gate_path, b"ready")?;
+    wait_until_path_exists(&mid_ready_path, "mid output marker").await?;
     let transcript_path =
         wait_until_empty_poll_discloses_transcript_path(&mut session, 0.1).await?;
     let spilled_before_delete =
@@ -1703,8 +1713,15 @@ async fn hidden_timeout_bundle_is_removed_after_request_finishes_inline() -> Tes
 async fn timeout_bundle_stops_before_ctrl_d_restart_output() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let mut session = spawn_behavior_session().await?;
+    let temp = workspace_tempdir()?;
+    let start_gate_path = temp.path().join("start-ready");
+    let mid_ready_path = temp.path().join("mid-ready");
+    let start_gate_literal = r_path_literal(&start_gate_path)?;
+    let mid_ready_literal = r_path_literal(&mid_ready_path)?;
 
-    let input = "big <- paste(rep('q', 120), collapse = ''); cat('start\\n'); flush.console(); Sys.sleep(0.1); for (i in 1:80) cat(sprintf('mid%03d %s\\n', i, big)); flush.console(); Sys.sleep(30); cat('tail\\n')";
+    let input = format!(
+        "big <- paste(rep('q', 120), collapse = ''); while (!file.exists({start_gate_literal})) Sys.sleep(0.01); cat('start\\n'); flush.console(); for (i in 1:80) cat(sprintf('mid%03d %s\\n', i, big)); flush.console(); writeLines('ready', {mid_ready_literal}); Sys.sleep(30); cat('tail\\n')"
+    );
     let first = session.write_stdin_raw_with(input, Some(0.05)).await?;
     let first_text = result_text(&first);
     if backend_unavailable(&first_text) {
@@ -1712,7 +1729,13 @@ async fn timeout_bundle_stops_before_ctrl_d_restart_output() -> TestResult<()> {
         session.cancel().await?;
         return Ok(());
     }
+    assert!(
+        first_text.contains("<<repl status: busy"),
+        "expected the initial gated request to time out, got: {first_text:?}"
+    );
 
+    fs::write(&start_gate_path, b"ready")?;
+    wait_until_path_exists(&mid_ready_path, "mid output marker").await?;
     let transcript_path =
         wait_until_empty_poll_discloses_transcript_path(&mut session, 0.1).await?;
     let transcript_before = fs::read_to_string(&transcript_path)?;

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -1246,7 +1246,6 @@ async fn zod_files_completion_settles_split_utf8_tail_before_request_boundary() 
     Ok(())
 }
 
-#[cfg(target_os = "macos")]
 #[tokio::test(flavor = "multi_thread")]
 async fn zod_files_completion_keeps_stable_wait_after_utf8_recovery() -> TestResult<()> {
     let tempdir = tempfile::tempdir()?;
@@ -1257,7 +1256,7 @@ async fn zod_files_completion_keeps_stable_wait_after_utf8_recovery() -> TestRes
         .call_tool_raw(
             "repl",
             json!({
-                "input": "split-utf8-near-grace-then-more-after-completion",
+                "input": "split-utf8-then-more-after-completion",
                 "timeout_ms": 10_000
             }),
         )
@@ -1278,7 +1277,6 @@ async fn zod_files_completion_keeps_stable_wait_after_utf8_recovery() -> TestRes
     Ok(())
 }
 
-#[cfg(target_os = "macos")]
 #[tokio::test(flavor = "multi_thread")]
 async fn zod_files_completion_bounds_stable_wait_after_utf8_recovery() -> TestResult<()> {
     let tempdir = tempfile::tempdir()?;
@@ -1290,7 +1288,7 @@ async fn zod_files_completion_bounds_stable_wait_after_utf8_recovery() -> TestRe
         .call_tool_raw(
             "repl",
             json!({
-                "input": "split-utf8-near-grace-then-continuous-output-after-completion",
+                "input": "split-utf8-then-continuous-output-after-completion",
                 "timeout_ms": 10_000
             }),
         )


### PR DESCRIPTION
## Summary

This tidies platform-specific timing behavior that had accumulated in tests and output finalization. The main issue was that some tests handled slow platforms by sleeping longer or gating coverage by OS, which made timing races harder to reason about.

This also addresses the macOS CI flake seen on PR 150: completion settling could finalize after split UTF-8 output recovery before the remaining output arrived.

## User-facing changes

No intentional CLI or protocol changes.

Request completion now uses the same output-stability wait across platforms, which should make completion output handling less timing-sensitive.

## Internal changes

- Removed the macOS-only completion-stability branch in request finalization.
- Made the zod split UTF-8 completion tests run on all platforms.
- Replaced platform-specific sleeps in timeout, sandbox metadata, file output, reticulate, and pager tests with observable state waits.
- Deleted a redundant racy timeout-bundle test.
- Simplified platform timeout helpers that no longer expressed platform-specific behavior.
- Added a completed plan note documenting the cleanup decisions.

## Notes

This PR does not try to consolidate the existing sandbox test matrix. Some current sandbox gates cover backend-specific launch paths, but several public allow/deny tests likely can be made more cross-platform in a follow-up cleanup.
