### PR TITLE
Fix Linux sandbox review regressions

### DIFF
--- a/docs/futurework/test-helper-classification-consolidation.md
+++ b/docs/futurework/test-helper-classification-consolidation.md
@@ -1,0 +1,81 @@
+# Test Helper Classification Consolidation
+
+## Summary
+
+Several integration tests classify backend startup failures, busy replies, and
+sandbox availability by matching repeated lists of rendered text snippets. Those
+helpers should be consolidated behind shared test predicates so individual tests
+do not grow new local lists of equivalent string variants.
+
+## Motivation
+
+The immediate trigger was a Linux CI failure where a bubblewrap feature probe
+reported the same mount class with a different stderr detail string. The fix for
+that case belongs in the stable classifier: match the `bwrap` old-root to
+new-root bind failure shape, not a list of exact bwrap detail messages or
+temporary directory paths.
+
+The same maintenance problem appears more broadly in test helpers. Many test
+files carry local versions of:
+
+- backend/runtime unavailable classification,
+- busy response classification,
+- sandbox or bubblewrap unavailable classification.
+
+When those lists diverge, CI failures become harder to interpret because each
+test file has its own notion of an ignorable environment failure.
+
+## Observed Candidates
+
+- `tests/common/mod.rs` already exposes `backend_unavailable()` and
+  `is_busy_response()`.
+- Local `backend_unavailable()` helpers appear in many files, including
+  `tests/manage_session_behavior.rs`, `tests/pager.rs`, `tests/r_help.rs`,
+  `tests/r_startup.rs`, `tests/write_stdin_behavior.rs`, and related pager/R
+  tests.
+- Local busy-response helpers appear in files such as `tests/r_startup.rs`,
+  `tests/python_backend.rs`, and `tests/interrupt.rs`.
+- Linux bubblewrap availability matching is split between `tests/sandbox.rs`
+  and `tests/codex_integration.rs`.
+
+## Intended Direction
+
+- Move shared classification into `tests/common/mod.rs`.
+- Prefer helpers that describe the stable class being detected, for example
+  `backend_unavailable(text)`, `is_busy_response(text)`, and
+  `linux_bwrap_unavailable(text)`.
+- Keep test-specific exceptions local only when they express a unique contract
+  for that test.
+- Add focused unit tests for classification boundaries when a helper matches a
+  broad class of external stderr or protocol text.
+- Do not match temporary path names or runner-specific detail strings unless the
+  test is explicitly about path rendering.
+
+## Non-Goals
+
+- Rewriting output snapshots.
+- Hiding real product errors behind broad skip logic.
+- Changing public reply text.
+- Reclassifying failures that should stay hard failures.
+
+## Suggested Slice
+
+Start with one duplicated family, such as `backend_unavailable()`. Replace local
+helpers with `tests/common/mod.rs` one file at a time, then run the affected
+test file before moving to the next. Save Linux bwrap-specific consolidation for
+a separate slice so sandbox-specific behavior remains easy to review.
+
+## Verification
+
+For a narrow docs-only update, run:
+
+```sh
+cargo test --test docs_contracts
+```
+
+For the actual test-helper refactor, run the changed test files directly and
+finish with:
+
+```sh
+cargo test --quiet
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,7 @@ checked-in execution plans without relying on stale notes.
 - `docs/futurework/worker-session-tempdir-rotation.md`: deferred design note on rotating worker tempdir paths per launch so stale temp trees do not block respawn.
 - `docs/futurework/stronger-worker-child-containment.md`: deferred design note on tighter worker descendant containment, especially on Windows.
 - `docs/futurework/stdin-transport-single-owner.md`: historical and deferred design note for keeping managed input batches owned by the worker queue.
+- `docs/futurework/test-helper-classification-consolidation.md`: deferred cleanup note on consolidating duplicated test predicates for backend, busy, and sandbox availability classification.
 - `docs/futurework/repl-interaction-rough-edges.md`: candidate UX polish items observed during live REPL use.
 
 ## Maintenance Rules

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -3854,10 +3854,13 @@ fn prepare_linux_missing_writable_roots(
 
         let mut created_dirs = root
             .ancestors()
+            .skip(1)
             .take_while(|path| *path != first_missing)
             .map(Path::to_path_buf)
             .collect::<Vec<_>>();
-        created_dirs.push(first_missing);
+        if first_missing != root {
+            created_dirs.push(first_missing);
+        }
         created_dirs.reverse();
         command.synthetic_mount_targets.extend(
             created_dirs
@@ -6405,6 +6408,57 @@ mod tests {
         assert!(
             !denied_path.exists(),
             "rejected missing deny target should not be created on the host"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_bwrap_missing_writable_root_is_not_cleanup_owned() {
+        let root = Builder::new()
+            .prefix("mcp-repl-bwrap-missing-writable-root-")
+            .tempdir()
+            .expect("tempdir");
+        let writable_parent = root.path().join("generated");
+        let writable_root = writable_parent.join("output");
+        let session_temp_dir = root.path().join("session");
+        let file_system_policy = FileSystemSandboxPolicy::restricted(vec![
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::Root,
+                },
+                access: FileSystemAccessMode::Read,
+            },
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Path {
+                    path: writable_root.clone(),
+                },
+                access: FileSystemAccessMode::Write,
+            },
+        ]);
+
+        let command =
+            linux_bwrap_filesystem_args(&file_system_policy, root.path(), &session_temp_dir)
+                .expect("missing writable root should build bwrap args");
+
+        assert!(
+            writable_root.is_dir(),
+            "missing declared writable root should be materialized"
+        );
+        assert!(
+            !command
+                .synthetic_mount_targets
+                .contains(&LinuxSyntheticMountTarget::EmptyDirectory(
+                    writable_root.clone()
+                )),
+            "declared writable root should not be removed by synthetic cleanup: {:?}",
+            command.synthetic_mount_targets
+        );
+        assert!(
+            command
+                .synthetic_mount_targets
+                .contains(&LinuxSyntheticMountTarget::EmptyDirectory(writable_parent)),
+            "parent directories synthesized only for bwrap mounting may be cleanup-owned: {:?}",
+            command.synthetic_mount_targets
         );
     }
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -3661,7 +3661,7 @@ fn linux_bwrap_filesystem_args(
         }
         read_only_subpaths.sort_by_key(|path| linux_path_depth(path));
         for subpath in read_only_subpaths {
-            let allow_missing_protected_metadata_synthesis = mount_root == session_temp_dir;
+            let allow_missing_protected_metadata_synthesis = true;
             append_linux_read_only_subpath_args(
                 &mut command,
                 &subpath,
@@ -3941,15 +3941,13 @@ fn append_linux_missing_read_only_subpath_args(
     allowed_write_paths: &[PathBuf],
     allow_missing_protected_metadata_synthesis: bool,
 ) -> Result<(), String> {
-    if linux_protected_metadata_name(path).is_some() {
-        if allow_missing_protected_metadata_synthesis {
-            append_linux_empty_directory_ro_bind_args(command, path, allowed_write_paths)?;
-            command
-                .synthetic_mount_targets
-                .push(LinuxSyntheticMountTarget::EmptyDirectory(
-                    path.to_path_buf(),
-                ));
-        }
+    if linux_protected_metadata_name(path).is_some() && allow_missing_protected_metadata_synthesis {
+        append_linux_empty_directory_ro_bind_args(command, path, allowed_write_paths)?;
+        command
+            .synthetic_mount_targets
+            .push(LinuxSyntheticMountTarget::EmptyDirectory(
+                path.to_path_buf(),
+            ));
         return Ok(());
     }
     if is_within_allowed_write_paths(path, allowed_write_paths) {
@@ -6294,7 +6292,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn linux_bwrap_missing_protected_metadata_under_writable_root_is_not_synthesized() {
+    fn linux_bwrap_missing_protected_metadata_under_writable_root_is_synthesized() {
         let root = Builder::new()
             .prefix("mcp-repl-bwrap-protected-metadata-")
             .tempdir()
@@ -6328,28 +6326,28 @@ mod tests {
         let codex_text = linux_path_to_string(&codex_path);
 
         assert!(
-            !command
+            command
                 .args
                 .windows(2)
                 .any(|args| args[0] == "--dir" && args[1] == codex_text),
-            "missing protected metadata should not create a bwrap mount target: {:?}",
+            "missing protected metadata should create a bwrap mount target: {:?}",
             command.args
         );
         assert!(
-            !command
+            command
                 .args
                 .windows(3)
                 .any(|args| args[0] == "--ro-bind" && args[2] == codex_text),
-            "missing protected metadata should not bind over a missing target: {:?}",
+            "missing protected metadata should bind over the synthetic target: {:?}",
             command.args
         );
         assert!(
-            !command
+            command
                 .synthetic_mount_targets
                 .contains(&LinuxSyntheticMountTarget::EmptyDirectory(
                     codex_path.clone()
                 )),
-            "missing protected metadata should not require host cleanup: {:?}",
+            "missing protected metadata should require host cleanup: {:?}",
             command.synthetic_mount_targets
         );
         assert!(

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -3842,13 +3842,14 @@ fn prepare_linux_missing_writable_roots(
             )
         })?;
 
-        let mut created_dirs = root
-            .ancestors()
-            .skip(1)
-            .take_while(|path| *path != first_missing)
-            .map(Path::to_path_buf)
-            .collect::<Vec<_>>();
+        let mut created_dirs = Vec::new();
         if first_missing != root {
+            created_dirs = root
+                .ancestors()
+                .skip(1)
+                .take_while(|path| *path != first_missing)
+                .map(Path::to_path_buf)
+                .collect::<Vec<_>>();
             created_dirs.push(first_missing);
         }
         created_dirs.reverse();

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -4788,12 +4788,8 @@ fn linux_apply_sandbox_policy_to_current_thread(
                     .to_string(),
             );
         }
-        let writable_roots = linux_landlock_writable_root_paths(
-            &file_system_policy,
-            cwd,
-            session_temp_dir,
-            matches!(sandbox_policy, SandboxPolicy::WorkspaceWrite { .. }),
-        )?;
+        let writable_roots =
+            linux_landlock_writable_root_paths(&file_system_policy, cwd, session_temp_dir)?;
         linux_install_filesystem_landlock_rules_on_current_thread(writable_roots)?;
     }
 
@@ -4805,7 +4801,6 @@ fn linux_landlock_writable_root_paths(
     file_system_policy: &FileSystemSandboxPolicy,
     cwd: &Path,
     session_temp_dir: &Path,
-    allow_read_only_carveout_degradation: bool,
 ) -> Result<Vec<PathBuf>, String> {
     let writable_roots =
         file_system_policy.get_writable_roots_with_cwd(cwd, Some(session_temp_dir));
@@ -4816,9 +4811,8 @@ fn linux_landlock_writable_root_paths(
         ) {
             continue;
         }
-        if (!writable_root.read_only_subpaths.is_empty()
-            || !writable_root.protected_metadata_names.is_empty())
-            && !allow_read_only_carveout_degradation
+        if !writable_root.read_only_subpaths.is_empty()
+            || !writable_root.protected_metadata_names.is_empty()
         {
             return Err(format!(
                 "read-only carveouts inside writable root {} are not supported by the legacy Linux Landlock filesystem backend",
@@ -6052,7 +6046,6 @@ mod tests {
             &file_system_policy,
             &writable_root,
             &session_temp_dir,
-            false,
         )
         .expect_err("legacy Landlock should reject writable roots with protected carveouts");
 
@@ -6068,7 +6061,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn linux_landlock_allows_legacy_workspace_write_metadata_carveouts() {
+    fn linux_landlock_workspace_write_metadata_carveouts_fail_closed() {
         let writable_root = PathBuf::from("/tmp/mcp-repl-landlock-legacy-workspace");
         let session_temp_dir = PathBuf::from("/tmp/mcp-repl-landlock-session");
         let file_system_policy = linux_effective_file_system_policy(
@@ -6081,17 +6074,16 @@ mod tests {
             &session_temp_dir,
         );
 
-        let writable_roots = linux_landlock_writable_root_paths(
+        let err = linux_landlock_writable_root_paths(
             &file_system_policy,
             &writable_root,
             &session_temp_dir,
-            true,
         )
-        .expect("legacy workspace-write should degrade metadata carveouts under Landlock");
+        .expect_err("legacy workspace-write should reject protected metadata carveouts");
 
         assert!(
-            writable_roots.iter().any(|root| root == &writable_root),
-            "workspace root should stay writable in legacy Landlock fallback: {writable_roots:?}"
+            err.contains("read-only carveouts inside writable root"),
+            "unexpected error: {err}"
         );
     }
 
@@ -6108,7 +6100,7 @@ mod tests {
         );
 
         let writable_roots =
-            linux_landlock_writable_root_paths(&file_system_policy, &cwd, &session_temp_dir, false)
+            linux_landlock_writable_root_paths(&file_system_policy, &cwd, &session_temp_dir)
                 .expect("session temp writable root should not make legacy Landlock fail closed");
 
         assert_eq!(writable_roots, vec![session_temp_dir]);

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1281,7 +1281,7 @@ pub fn sandbox_state_update_from_codex_meta(
         sandbox_policy,
         sandbox_cwd: Some(sandbox_cwd),
         #[cfg(target_os = "linux")]
-        use_linux_sandbox_bwrap: use_legacy_landlock.then_some(false),
+        use_linux_sandbox_bwrap: Some(!use_legacy_landlock),
         #[cfg(not(target_os = "linux"))]
         use_linux_sandbox_bwrap: None,
         #[cfg(target_os = "linux")]
@@ -6895,7 +6895,7 @@ mod tests {
         #[cfg(target_os = "linux")]
         assert_eq!(update.use_legacy_landlock, Some(false));
         #[cfg(target_os = "linux")]
-        assert!(update.use_linux_sandbox_bwrap.is_none());
+        assert_eq!(update.use_linux_sandbox_bwrap, Some(true));
         #[cfg(not(target_os = "linux"))]
         assert!(update.use_linux_sandbox_bwrap.is_none());
     }
@@ -6924,11 +6924,20 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn codex_sandbox_state_meta_non_legacy_preserves_disabled_linux_bwrap() {
+    fn codex_sandbox_state_meta_non_legacy_reenables_linux_bwrap_after_legacy() {
         let sandbox_cwd = std::env::temp_dir().join("mcp-repl-codex-meta-cwd");
         let sandbox_cwd_uri = url::Url::from_file_path(&sandbox_cwd)
             .expect("absolute sandbox cwd should convert to file URI")
             .to_string();
+        let legacy_update = sandbox_state_update_from_codex_meta(&json!({
+            "permissionProfile": {
+                "type": "disabled"
+            },
+            "sandboxCwd": sandbox_cwd_uri,
+            "useLegacyLandlock": true,
+            "codexLinuxSandboxExe": serde_json::Value::Null,
+        }))
+        .expect("legacy Codex sandbox metadata");
         let non_legacy_update = sandbox_state_update_from_codex_meta(&json!({
             "permissionProfile": {
                 "type": "disabled"
@@ -6939,15 +6948,21 @@ mod tests {
         }))
         .expect("non-legacy Codex sandbox metadata");
         let mut state = SandboxState {
-            use_linux_sandbox_bwrap: false,
+            use_linux_sandbox_bwrap: true,
             ..SandboxState::default()
         };
+
+        state.apply_update(legacy_update);
+        assert!(
+            !state.use_linux_sandbox_bwrap,
+            "legacy Codex metadata should disable Linux bwrap"
+        );
 
         state.apply_update(non_legacy_update);
 
         assert!(
-            !state.use_linux_sandbox_bwrap,
-            "non-legacy Codex metadata should not override an explicitly disabled Linux bwrap default"
+            state.use_linux_sandbox_bwrap,
+            "non-legacy Codex metadata should re-enable Linux bwrap after legacy metadata clears"
         );
     }
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -3225,12 +3225,31 @@ fn linux_find_bwrap_program() -> Option<PathBuf> {
 }
 
 #[cfg(target_os = "linux")]
-fn linux_build_inner_seccomp_command(args: &LinuxSandboxArgs) -> Result<Vec<String>, String> {
+struct LinuxInnerSeccompCommand {
+    command: Vec<String>,
+    helper_dir: tempfile::TempDir,
+}
+
+#[cfg(target_os = "linux")]
+fn linux_build_inner_seccomp_command(
+    args: &LinuxSandboxArgs,
+) -> Result<LinuxInnerSeccompCommand, String> {
     let current_exe = std::env::current_exe().map_err(|err| err.to_string())?;
+    let helper_dir = Builder::new()
+        .prefix("mcp-repl-linux-helper-")
+        .tempdir_in(&args.session_temp_dir)
+        .map_err(|err| err.to_string())?;
+    let helper_exe = helper_dir.path().join("codex-linux-sandbox");
+    std::os::unix::fs::symlink(&current_exe, &helper_exe).map_err(|err| {
+        format!(
+            "failed to create Linux sandbox helper link at {}: {err}",
+            helper_exe.to_string_lossy()
+        )
+    })?;
     let policy = sanitize_linux_sandbox_policy(&args.sandbox_policy);
     let policy_json = serde_json::to_string(&policy).map_err(|err| err.to_string())?;
     let mut inner = vec![
-        current_exe.to_string_lossy().to_string(),
+        helper_exe.to_string_lossy().to_string(),
         "--sandbox-policy-cwd".to_string(),
         args.sandbox_policy_cwd.to_string_lossy().to_string(),
         "--session-temp-dir".to_string(),
@@ -3245,7 +3264,10 @@ fn linux_build_inner_seccomp_command(args: &LinuxSandboxArgs) -> Result<Vec<Stri
             .iter()
             .map(|arg| arg.to_string_lossy().to_string()),
     );
-    Ok(inner)
+    Ok(LinuxInnerSeccompCommand {
+        command: inner,
+        helper_dir,
+    })
 }
 
 #[cfg(target_os = "linux")]
@@ -3281,7 +3303,7 @@ fn linux_exec_bwrap_sandbox(args: LinuxSandboxArgs) -> Result<(), String> {
             network_mode,
         );
     let bwrap_command = create_linux_bwrap_command_args(
-        inner,
+        inner.command,
         &file_system_policy,
         &args.sandbox_policy_cwd,
         &args.session_temp_dir,
@@ -3292,9 +3314,10 @@ fn linux_exec_bwrap_sandbox(args: LinuxSandboxArgs) -> Result<(), String> {
         args,
         preserved_files,
         empty_file_source_index: _,
-        preserved_tempdirs,
+        mut preserved_tempdirs,
         synthetic_mount_targets,
     } = bwrap_command;
+    preserved_tempdirs.push(inner.helper_dir);
     make_linux_files_inheritable(&preserved_files)?;
     let synthetic_mount_targets_for_cleanup = synthetic_mount_targets.clone();
     let mut full_command = Vec::with_capacity(1 + args.len());
@@ -6561,6 +6584,48 @@ mod tests {
             !command.args.iter().any(|arg| arg == "--argv0"),
             "bwrap args should work with Ubuntu 22.04 bubblewrap 0.6.1: {:?}",
             command.args
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_inner_bwrap_command_invokes_helper_argv0_path() {
+        let root = Builder::new()
+            .prefix("mcp-repl-inner-helper-")
+            .tempdir()
+            .expect("tempdir");
+        let session_temp_dir = root.path().join("session");
+        std::fs::create_dir_all(&session_temp_dir).expect("session temp dir");
+        let args = LinuxSandboxArgs {
+            sandbox_policy_cwd: root.path().to_path_buf(),
+            session_temp_dir: session_temp_dir.clone(),
+            sandbox_policy: SandboxPolicy::WorkspaceWrite {
+                writable_roots: Vec::new(),
+                network_access: false,
+                exclude_tmpdir_env_var: false,
+                exclude_slash_tmp: false,
+            },
+            command: vec![std::ffi::OsString::from("/bin/true")],
+            use_bwrap_sandbox: true,
+            apply_seccomp_then_exec: false,
+            no_proc: false,
+        };
+
+        let inner = linux_build_inner_seccomp_command(&args).expect("inner seccomp command");
+
+        assert_eq!(
+            Path::new(&inner.command[0]).file_name(),
+            Some(std::ffi::OsStr::new("codex-linux-sandbox")),
+            "inner bwrap command must dispatch through the helper argv0 path"
+        );
+        assert!(
+            Path::new(&inner.command[0]).starts_with(&session_temp_dir),
+            "helper argv0 path should live in the bwrap-visible session temp dir: {:?}",
+            inner.command
+        );
+        assert!(
+            Path::new(&inner.command[0]).is_symlink(),
+            "helper argv0 path should be a link to the current executable"
         );
     }
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -3628,7 +3628,13 @@ fn linux_bwrap_filesystem_args(
         }
         read_only_subpaths.sort_by_key(|path| linux_path_depth(path));
         for subpath in read_only_subpaths {
-            append_linux_read_only_subpath_args(&mut command, &subpath, &allowed_write_paths)?;
+            let allow_missing_protected_metadata_synthesis = mount_root == session_temp_dir;
+            append_linux_read_only_subpath_args(
+                &mut command,
+                &subpath,
+                &allowed_write_paths,
+                allow_missing_protected_metadata_synthesis,
+            )?;
         }
 
         let mut nested_unreadable_roots = unreadable_roots
@@ -3834,6 +3840,7 @@ fn append_linux_read_only_subpath_args(
     command: &mut LinuxBwrapCommand,
     subpath: &Path,
     allowed_write_paths: &[PathBuf],
+    allow_missing_protected_metadata_synthesis: bool,
 ) -> Result<(), String> {
     if let Some(symlink) = first_writable_symlink_component_in_path(subpath, allowed_write_paths) {
         return Err(format!(
@@ -3850,6 +3857,7 @@ fn append_linux_read_only_subpath_args(
                 command,
                 &first_missing,
                 allowed_write_paths,
+                allow_missing_protected_metadata_synthesis,
             )?;
         }
         return Ok(());
@@ -3895,17 +3903,26 @@ fn append_linux_missing_read_only_subpath_args(
     command: &mut LinuxBwrapCommand,
     path: &Path,
     allowed_write_paths: &[PathBuf],
+    allow_missing_protected_metadata_synthesis: bool,
 ) -> Result<(), String> {
     if linux_protected_metadata_name(path).is_some() {
-        append_linux_empty_directory_ro_bind_args(command, path, allowed_write_paths)?;
-        command
-            .synthetic_mount_targets
-            .push(LinuxSyntheticMountTarget::EmptyDirectory(
-                path.to_path_buf(),
-            ));
-    } else {
-        append_linux_empty_file_bind_data_args(command, path, Some("000"), true)?;
+        if allow_missing_protected_metadata_synthesis {
+            append_linux_empty_directory_ro_bind_args(command, path, allowed_write_paths)?;
+            command
+                .synthetic_mount_targets
+                .push(LinuxSyntheticMountTarget::EmptyDirectory(
+                    path.to_path_buf(),
+                ));
+        }
+        return Ok(());
     }
+    if is_within_allowed_write_paths(path, allowed_write_paths) {
+        return Err(format!(
+            "cannot enforce sandbox read-only path {} because it does not exist under a writable root with the Linux bubblewrap backend",
+            path.display()
+        ));
+    }
+    append_linux_empty_file_bind_data_args(command, path, Some("000"), true)?;
     Ok(())
 }
 
@@ -4316,7 +4333,10 @@ fn append_linux_unreadable_root_args(
         if let Some(first_missing) = find_first_non_existent_component(unreadable_root)
             && is_within_allowed_write_paths(&first_missing, allowed_write_paths)
         {
-            append_linux_empty_file_bind_data_args(command, &first_missing, Some("000"), true)?;
+            return Err(format!(
+                "cannot enforce sandbox deny-read path {} because it does not exist under a writable root with the Linux bubblewrap backend",
+                first_missing.display()
+            ));
         }
         return Ok(());
     }
@@ -6238,7 +6258,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn linux_bwrap_missing_protected_metadata_uses_namespace_dir_and_read_only_empty_bind() {
+    fn linux_bwrap_missing_protected_metadata_under_writable_root_is_not_synthesized() {
         let root = Builder::new()
             .prefix("mcp-repl-bwrap-protected-metadata-")
             .tempdir()
@@ -6270,59 +6290,88 @@ mod tests {
             linux_bwrap_filesystem_args(&file_system_policy, root.path(), &session_temp_dir)
                 .expect("missing protected metadata should build bwrap args");
         let codex_text = linux_path_to_string(&codex_path);
-        let dir_index = command
-            .args
-            .windows(2)
-            .position(|args| args[0] == "--dir" && args[1] == codex_text)
-            .expect("missing protected metadata should create its mount target inside bwrap");
-        let bind_index = command
-            .args
-            .windows(3)
-            .position(|args| args[0] == "--ro-bind" && args[2] == codex_text)
-            .expect("missing protected metadata should use a read-only empty directory bind");
-        assert!(
-            dir_index < bind_index,
-            "protected metadata mount target must exist before the bind: {:?}",
-            command.args
-        );
-        let bind_args = command
-            .args
-            .windows(3)
-            .find(|args| args[0] == "--ro-bind" && args[2] == codex_text)
-            .expect("missing protected metadata should use a read-only empty directory bind");
-        let source_path = PathBuf::from(&bind_args[1]);
 
-        assert!(
-            !codex_path.exists(),
-            "missing protected metadata target should be created inside bwrap, not on the host"
-        );
-        assert!(
-            command
-                .preserved_tempdirs
-                .iter()
-                .any(|tempdir| tempdir.path() == source_path),
-            "directory bind should reference a preserved empty source directory"
-        );
         assert!(
             !command
                 .args
                 .windows(2)
-                .any(|args| args[0] == "--remount-ro" && args[1] == codex_text),
-            "missing protected metadata should not require tmpfs remount-ro: {:?}",
+                .any(|args| args[0] == "--dir" && args[1] == codex_text),
+            "missing protected metadata should not create a bwrap mount target: {:?}",
             command.args
         );
-        let protected_target = LinuxSyntheticMountTarget::EmptyDirectory(codex_path.clone());
         assert!(
-            command.synthetic_mount_targets.contains(&protected_target),
-            "missing protected metadata target should be cleaned up after bwrap exits: {:?}",
+            !command
+                .args
+                .windows(3)
+                .any(|args| args[0] == "--ro-bind" && args[2] == codex_text),
+            "missing protected metadata should not bind over a missing target: {:?}",
+            command.args
+        );
+        assert!(
+            !command
+                .synthetic_mount_targets
+                .contains(&LinuxSyntheticMountTarget::EmptyDirectory(
+                    codex_path.clone()
+                )),
+            "missing protected metadata should not require host cleanup: {:?}",
             command.synthetic_mount_targets
         );
         assert!(
-            command
-                .preserved_tempdirs
-                .iter()
-                .all(|tempdir| !tempdir.path().starts_with(root.path())),
-            "empty bind sources must stay outside sandbox writable roots"
+            !codex_path.exists(),
+            "missing protected metadata target should not be created on the host"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_bwrap_missing_deny_path_under_writable_root_fails_closed() {
+        let root = Builder::new()
+            .prefix("mcp-repl-bwrap-missing-deny-")
+            .tempdir()
+            .expect("tempdir");
+        for protected_name in PROTECTED_METADATA_SUBPATHS {
+            std::fs::create_dir(root.path().join(protected_name)).expect("metadata dir");
+        }
+        let denied_path = root.path().join("secret.txt");
+        let session_temp_dir = root.path().join("session");
+        let file_system_policy = FileSystemSandboxPolicy::restricted(vec![
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::Root,
+                },
+                access: FileSystemAccessMode::Read,
+            },
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Path {
+                    path: root.path().to_path_buf(),
+                },
+                access: FileSystemAccessMode::Write,
+            },
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Path {
+                    path: denied_path.clone(),
+                },
+                access: FileSystemAccessMode::Deny,
+            },
+        ]);
+
+        let err = match linux_bwrap_filesystem_args(
+            &file_system_policy,
+            root.path(),
+            &session_temp_dir,
+        ) {
+            Ok(_) => panic!("missing deny path under writable root should fail closed"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.contains("cannot enforce sandbox deny-read path")
+                && err.contains("does not exist under a writable root"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            !denied_path.exists(),
+            "rejected missing deny target should not be created on the host"
         );
     }
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -388,16 +388,6 @@ impl FileSystemSandboxPolicy {
     #[cfg(target_os = "macos")]
     fn include_platform_defaults(&self) -> bool {
         !self.has_full_disk_read_access()
-            && matches!(self.kind, FileSystemSandboxKind::Restricted)
-            && self.entries.iter().any(|entry| {
-                entry.access.can_read()
-                    && matches!(
-                        &entry.path,
-                        FileSystemPath::Special {
-                            value: FileSystemSpecialPath::Minimal,
-                        }
-                    )
-            })
     }
 
     #[cfg(target_os = "linux")]
@@ -7380,7 +7370,7 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn codex_permission_profile_project_read_excludes_seatbelt_platform_defaults() {
+    fn codex_permission_profile_project_read_includes_seatbelt_platform_defaults() {
         let sandbox_cwd = std::env::temp_dir().join("mcp-repl-codex-meta-project-read");
         let update = sandbox_state_update_from_codex_meta(&json!({
             "permissionProfile": {
@@ -7427,8 +7417,8 @@ mod tests {
             .expect("seatbelt policy argument");
 
         assert!(
-            !policy.contains(MACOS_RESTRICTED_READ_ONLY_PLATFORM_DEFAULTS),
-            "project-root read profile should not include platform defaults: {policy}"
+            policy.contains(MACOS_RESTRICTED_READ_ONLY_PLATFORM_DEFAULTS),
+            "expected project-root read profile to include platform defaults: {policy}"
         );
     }
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -4755,11 +4755,7 @@ fn is_proc_mount_failure(stderr: &str) -> bool {
 
 #[cfg(target_os = "linux")]
 fn is_bwrap_proc_probe_quiet_retry_failure(stderr: &str) -> bool {
-    stderr.contains("Can't bind mount /oldroot/")
-        && stderr.contains(" on /newroot/")
-        && (stderr.contains("Unable to mount source on destination: No such file or directory")
-            || stderr
-                .contains("Unable to remount destination with correct flags: Invalid argument"))
+    stderr.contains("bwrap: Can't bind mount /oldroot/") && stderr.contains(" on /newroot/")
 }
 
 #[cfg(target_os = "linux")]
@@ -5949,12 +5945,9 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn bwrap_proc_probe_quiet_retry_detects_old_bind_target_stderr() {
+    fn bwrap_proc_probe_quiet_retry_detects_oldroot_bind_stderr() {
         assert!(is_bwrap_proc_probe_quiet_retry_failure(
-            "bwrap: Can't bind mount /oldroot/home/runner/.cache/mcp-repl/bwrap/mcp-repl-bwrap-empty-dir-bm2Cuc on /newroot/home/runner/work/mcp-repl/mcp-repl/.agents: Unable to mount source on destination: No such file or directory"
-        ));
-        assert!(is_bwrap_proc_probe_quiet_retry_failure(
-            "bwrap: Can't bind mount /oldroot/home/runner/.cache/mcp-repl/bwrap/mcp-repl-bwrap-empty-dir-FlEdOV on /newroot/home/runner/work/mcp-repl/mcp-repl/.agents: Unable to remount destination with correct flags: Invalid argument"
+            "bwrap: Can't bind mount /oldroot/bind-source on /newroot/workspace/.agents: future bwrap detail"
         ));
         assert!(!is_bwrap_proc_probe_quiet_retry_failure(
             "bwrap: Unable to remount destination with correct flags: Invalid argument"

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -388,6 +388,16 @@ impl FileSystemSandboxPolicy {
     #[cfg(target_os = "macos")]
     fn include_platform_defaults(&self) -> bool {
         !self.has_full_disk_read_access()
+            && matches!(self.kind, FileSystemSandboxKind::Restricted)
+            && self.entries.iter().any(|entry| {
+                entry.access.can_read()
+                    && matches!(
+                        &entry.path,
+                        FileSystemPath::Special {
+                            value: FileSystemSpecialPath::Minimal,
+                        }
+                    )
+            })
     }
 
     #[cfg(target_os = "linux")]
@@ -7137,7 +7147,7 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn codex_permission_profile_meta_accepts_minimal_read_policy() {
+    fn codex_permission_profile_minimal_read_includes_seatbelt_platform_defaults() {
         let sandbox_cwd = std::env::temp_dir().join("mcp-repl-codex-meta-minimal-read");
         let update = sandbox_state_update_from_codex_meta(&json!({
             "permissionProfile": {
@@ -7172,6 +7182,26 @@ mod tests {
         assert!(
             !update.sandbox_policy.has_full_disk_read_access(),
             "minimal read policy must not be flattened to full read access"
+        );
+
+        let state = SandboxState {
+            sandbox_policy: update.sandbox_policy,
+            sandbox_cwd: update.sandbox_cwd.expect("sandbox cwd"),
+            ..SandboxState::default()
+        };
+        let prepared =
+            prepare_worker_command(Path::new("/bin/echo"), vec!["ok".to_string()], &state)
+                .expect("seatbelt command should prepare");
+        let policy = prepared
+            .args
+            .windows(2)
+            .find(|pair| pair[0] == "-p")
+            .map(|pair| pair[1].as_str())
+            .expect("seatbelt policy argument");
+
+        assert!(
+            policy.contains(MACOS_RESTRICTED_READ_ONLY_PLATFORM_DEFAULTS),
+            "expected minimal profile seatbelt policy to include platform defaults: {policy}"
         );
     }
 
@@ -7218,7 +7248,7 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn codex_permission_profile_project_read_includes_seatbelt_platform_defaults() {
+    fn codex_permission_profile_project_read_excludes_seatbelt_platform_defaults() {
         let sandbox_cwd = std::env::temp_dir().join("mcp-repl-codex-meta-project-read");
         let update = sandbox_state_update_from_codex_meta(&json!({
             "permissionProfile": {
@@ -7265,8 +7295,8 @@ mod tests {
             .expect("seatbelt policy argument");
 
         assert!(
-            policy.contains(MACOS_RESTRICTED_READ_ONLY_PLATFORM_DEFAULTS),
-            "expected restricted profile seatbelt policy to include platform defaults: {policy}"
+            !policy.contains(MACOS_RESTRICTED_READ_ONLY_PLATFORM_DEFAULTS),
+            "project-root read profile should not include platform defaults: {policy}"
         );
     }
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -4743,8 +4743,12 @@ fn linux_apply_sandbox_policy_to_current_thread(
                     .to_string(),
             );
         }
-        let writable_roots =
-            linux_landlock_writable_root_paths(&file_system_policy, cwd, session_temp_dir)?;
+        let writable_roots = linux_landlock_writable_root_paths(
+            &file_system_policy,
+            cwd,
+            session_temp_dir,
+            matches!(sandbox_policy, SandboxPolicy::WorkspaceWrite { .. }),
+        )?;
         linux_install_filesystem_landlock_rules_on_current_thread(writable_roots)?;
     }
 
@@ -4756,6 +4760,7 @@ fn linux_landlock_writable_root_paths(
     file_system_policy: &FileSystemSandboxPolicy,
     cwd: &Path,
     session_temp_dir: &Path,
+    allow_read_only_carveout_degradation: bool,
 ) -> Result<Vec<PathBuf>, String> {
     let writable_roots =
         file_system_policy.get_writable_roots_with_cwd(cwd, Some(session_temp_dir));
@@ -4766,8 +4771,9 @@ fn linux_landlock_writable_root_paths(
         ) {
             continue;
         }
-        if !writable_root.read_only_subpaths.is_empty()
-            || !writable_root.protected_metadata_names.is_empty()
+        if (!writable_root.read_only_subpaths.is_empty()
+            || !writable_root.protected_metadata_names.is_empty())
+            && !allow_read_only_carveout_degradation
         {
             return Err(format!(
                 "read-only carveouts inside writable root {} are not supported by the legacy Linux Landlock filesystem backend",
@@ -6001,6 +6007,7 @@ mod tests {
             &file_system_policy,
             &writable_root,
             &session_temp_dir,
+            false,
         )
         .expect_err("legacy Landlock should reject writable roots with protected carveouts");
 
@@ -6011,6 +6018,35 @@ mod tests {
         assert!(
             err.contains(&writable_root.display().to_string()),
             "error should identify the widened writable root: {err}"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_landlock_allows_legacy_workspace_write_metadata_carveouts() {
+        let writable_root = PathBuf::from("/tmp/mcp-repl-landlock-legacy-workspace");
+        let session_temp_dir = PathBuf::from("/tmp/mcp-repl-landlock-session");
+        let file_system_policy = linux_effective_file_system_policy(
+            &SandboxPolicy::WorkspaceWrite {
+                writable_roots: Vec::new(),
+                network_access: false,
+                exclude_tmpdir_env_var: true,
+                exclude_slash_tmp: true,
+            },
+            &session_temp_dir,
+        );
+
+        let writable_roots = linux_landlock_writable_root_paths(
+            &file_system_policy,
+            &writable_root,
+            &session_temp_dir,
+            true,
+        )
+        .expect("legacy workspace-write should degrade metadata carveouts under Landlock");
+
+        assert!(
+            writable_roots.iter().any(|root| root == &writable_root),
+            "workspace root should stay writable in legacy Landlock fallback: {writable_roots:?}"
         );
     }
 
@@ -6027,7 +6063,7 @@ mod tests {
         );
 
         let writable_roots =
-            linux_landlock_writable_root_paths(&file_system_policy, &cwd, &session_temp_dir)
+            linux_landlock_writable_root_paths(&file_system_policy, &cwd, &session_temp_dir, false)
                 .expect("session temp writable root should not make legacy Landlock fail closed");
 
         assert_eq!(writable_roots, vec![session_temp_dir]);

--- a/src/worker_process/request_lifecycle.rs
+++ b/src/worker_process/request_lifecycle.rs
@@ -630,7 +630,6 @@ mod tests {
                 false,
                 crate::worker_protocol::ContentOrigin::Worker,
             );
-            thread::sleep(Duration::from_millis(10));
             timeline.append_text(
                 b" after\n",
                 false,

--- a/src/worker_process/sandbox_state.rs
+++ b/src/worker_process/sandbox_state.rs
@@ -129,8 +129,10 @@ impl WorkerManager {
     // today that reset reuses the same configured path in place.
     fn prepare_sandbox_state_update(
         &mut self,
-        mut update: SandboxStateUpdate,
+        update: SandboxStateUpdate,
     ) -> Result<PreparedSandboxStateUpdate, WorkerError> {
+        #[cfg(target_os = "linux")]
+        let mut update = update;
         #[cfg(target_os = "linux")]
         self.apply_linux_bwrap_default_override(&mut update);
         let update_for_log = serde_json::to_value(&update)

--- a/src/worker_process/sandbox_state.rs
+++ b/src/worker_process/sandbox_state.rs
@@ -129,8 +129,10 @@ impl WorkerManager {
     // today that reset reuses the same configured path in place.
     fn prepare_sandbox_state_update(
         &mut self,
-        update: SandboxStateUpdate,
+        mut update: SandboxStateUpdate,
     ) -> Result<PreparedSandboxStateUpdate, WorkerError> {
+        #[cfg(target_os = "linux")]
+        self.apply_linux_bwrap_default_override(&mut update);
         let update_for_log = serde_json::to_value(&update)
             .unwrap_or_else(|err| serde_json::json!({"serialize_error": err.to_string()}));
         crate::sandbox::log_sandbox_policy_update(&update.sandbox_policy);
@@ -172,6 +174,13 @@ impl WorkerManager {
     fn apply_linux_bwrap_fallback_override(&self, state: &mut SandboxState) {
         if self.linux_bwrap_fallback_disabled {
             state.use_linux_sandbox_bwrap = false;
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn apply_linux_bwrap_default_override(&self, update: &mut SandboxStateUpdate) {
+        if !self.sandbox_defaults.use_linux_sandbox_bwrap {
+            update.use_linux_sandbox_bwrap = update.use_linux_sandbox_bwrap.map(|_| false);
         }
     }
 

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -347,7 +347,7 @@ fn run_command(
     if command == "partial-utf8-stderr-then-sleep" {
         output_text_with_continuation(writer, control_log_path, &[0xC3], false)?;
         output_stderr_text(writer, control_log_path, b"tail-visible\n")?;
-        sleep_for(200, sideband_interrupted, false);
+        sleep_for(1000, sideband_interrupted, false);
         return Ok(false);
     }
 

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -1256,6 +1256,56 @@ for (i in seq_along(targets)) {{
 
 #[cfg(target_os = "linux")]
 #[tokio::test(flavor = "multi_thread")]
+async fn sandbox_bwrap_preserves_empty_missing_writable_root_after_exit() -> TestResult<()> {
+    if !linux_bwrap_available() {
+        eprintln!("bwrap unavailable; skipping");
+        return Ok(());
+    }
+    let repo_root = std::env::current_dir()?;
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let writable_parent = repo_root.join(format!("mcp-repl-bwrap-missing-root-{nanos}"));
+    let writable_root = writable_parent.join("generated").join("output");
+
+    let session = spawn_server_with_sandbox_state_and_env(
+        sandbox_state_workspace_write_with_roots(false, vec![writable_root.clone()]),
+        vec![("MCP_REPL_USE_LINUX_BWRAP".to_string(), "1".to_string())],
+    )
+    .await?;
+    let target = writable_root.to_string_lossy().to_string();
+    let code = format!(
+        r#"
+target <- {target:?}
+dir.create(target, recursive = TRUE, showWarnings = FALSE)
+cat("ROOT_EXISTS=", dir.exists(target), "\n", sep = "")
+"#
+    );
+    let result = session.write_stdin_raw_with(&code, Some(10.0)).await?;
+    let text = collect_text(&result);
+    if bwrap_worker_unavailable(&text) {
+        eprintln!("bwrap unavailable in this environment; skipping");
+        session.cancel().await?;
+        let _ = std::fs::remove_dir_all(&writable_parent);
+        return Ok(());
+    }
+    assert!(
+        text.contains("ROOT_EXISTS=TRUE"),
+        "expected worker to observe missing writable root, got: {text}"
+    );
+
+    session.cancel().await?;
+    assert!(
+        writable_root.is_dir(),
+        "empty declared writable root should survive bwrap teardown"
+    );
+    let _ = std::fs::remove_dir_all(&writable_parent);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test(flavor = "multi_thread")]
 async fn sandbox_workspace_write_blocks_network_access_bwrap() -> TestResult<()> {
     if !linux_bwrap_available() {
         eprintln!("bwrap unavailable; skipping");

--- a/tests/sandbox.rs
+++ b/tests/sandbox.rs
@@ -1256,7 +1256,7 @@ for (i in seq_along(targets)) {{
 
 #[cfg(target_os = "linux")]
 #[tokio::test(flavor = "multi_thread")]
-async fn sandbox_bwrap_preserves_empty_missing_writable_root_after_exit() -> TestResult<()> {
+async fn sandbox_bwrap_preserves_existing_missing_root_parent_after_exit() -> TestResult<()> {
     if !linux_bwrap_available() {
         eprintln!("bwrap unavailable; skipping");
         return Ok(());
@@ -1267,7 +1267,8 @@ async fn sandbox_bwrap_preserves_empty_missing_writable_root_after_exit() -> Tes
         .unwrap_or_default()
         .as_nanos();
     let writable_parent = repo_root.join(format!("mcp-repl-bwrap-missing-root-{nanos}"));
-    let writable_root = writable_parent.join("generated").join("output");
+    std::fs::create_dir_all(&writable_parent)?;
+    let writable_root = writable_parent.join("output");
 
     let session = spawn_server_with_sandbox_state_and_env(
         sandbox_state_workspace_write_with_roots(false, vec![writable_root.clone()]),
@@ -1280,6 +1281,7 @@ async fn sandbox_bwrap_preserves_empty_missing_writable_root_after_exit() -> Tes
 target <- {target:?}
 dir.create(target, recursive = TRUE, showWarnings = FALSE)
 cat("ROOT_EXISTS=", dir.exists(target), "\n", sep = "")
+unlink(target, recursive = TRUE)
 "#
     );
     let result = session.write_stdin_raw_with(&code, Some(10.0)).await?;
@@ -1297,8 +1299,8 @@ cat("ROOT_EXISTS=", dir.exists(target), "\n", sep = "")
 
     session.cancel().await?;
     assert!(
-        writable_root.is_dir(),
-        "empty declared writable root should survive bwrap teardown"
+        writable_parent.is_dir(),
+        "pre-existing writable root parent should survive bwrap teardown"
     );
     let _ = std::fs::remove_dir_all(&writable_parent);
     Ok(())

--- a/tests/sandbox_state_meta.rs
+++ b/tests/sandbox_state_meta.rs
@@ -191,6 +191,15 @@ fn workspace_write_meta(sandbox_cwd: &Path) -> Value {
     )
 }
 
+#[cfg(target_os = "linux")]
+fn legacy_workspace_write_meta(sandbox_cwd: &Path) -> Value {
+    codex_sandbox_state_meta(
+        workspace_write_profile(),
+        sandbox_cwd,
+        /*use_legacy_landlock*/ true,
+    )
+}
+
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn workspace_write_with_glob_deny_meta(sandbox_cwd: &Path, pattern: &str) -> Value {
     let mut entries = vec![
@@ -2993,6 +3002,39 @@ async fn sandbox_inherit_project_subpath_write_meta_allows_missing_writable_root
     assert!(
         target.exists(),
         "write under missing project subpath root should create {}",
+        target.display()
+    );
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test(flavor = "multi_thread")]
+async fn sandbox_inherit_legacy_landlock_workspace_write_meta_fails_closed_for_metadata_carveouts()
+-> TestResult<()> {
+    let _guard = test_guard();
+    let scratch = repo_scratch_dir("sandbox-legacy-landlock-protected")?;
+    for protected_name in [".git", ".agents", ".codex"] {
+        fs::create_dir(scratch.path().join(protected_name))?;
+    }
+    let target = scratch.path().join(".git/deny.txt");
+    let session = spawn_inherit_server(scratch.path()).await?;
+    let result = session
+        .write_stdin_raw_with_meta(
+            write_file_code(&target)?,
+            Some(10.0),
+            Some(legacy_workspace_write_meta(scratch.path())),
+        )
+        .await?;
+    let text = collect_text(&result);
+    session.cancel().await?;
+
+    assert!(
+        text.contains("ipc disconnected while waiting for worker_ready"),
+        "expected legacy Landlock workspace-write metadata to fail closed at worker startup, got: {text}"
+    );
+    assert!(
+        !target.exists(),
+        "legacy Landlock failure should happen before worker writes protected metadata {}",
         target.display()
     );
     Ok(())

--- a/tests/sandbox_state_meta.rs
+++ b/tests/sandbox_state_meta.rs
@@ -3050,35 +3050,67 @@ for (protected_name in c(".git", ".agents", ".codex")) {{
         session.cancel().await?;
         return Ok(());
     }
-    assert!(
-        text.contains("ALLOWED_WRITE_OK"),
-        "expected explicit path write root to allow ordinary writes, got: {text}"
-    );
-    assert!(
-        !text.contains("ALLOWED_WRITE_ERROR:"),
-        "explicit path write root unexpectedly blocked ordinary write: {text}"
-    );
-    for protected_name in [".git", ".agents", ".codex"] {
+    #[cfg(target_os = "linux")]
+    {
         assert!(
-            text.contains(&format!("PROTECTED_WRITE_ERROR:{protected_name}:")),
-            "expected explicit path write root to block missing protected metadata {protected_name}, got: {text}"
+            text.contains("ALLOWED_WRITE_OK"),
+            "expected Linux bwrap explicit path write root to allow ordinary writes, got: {text}"
         );
         assert!(
-            !text.contains(&format!("PROTECTED_WRITE_OK:{protected_name}")),
-            "explicit path write root unexpectedly allowed protected metadata write {protected_name}: {text}"
+            !text.contains("ALLOWED_WRITE_ERROR:"),
+            "Linux bwrap explicit path write root unexpectedly blocked ordinary write: {text}"
         );
+        for protected_name in [".git", ".agents", ".codex"] {
+            assert!(
+                text.contains(&format!("PROTECTED_WRITE_OK:{protected_name}")),
+                "Linux bwrap cannot block missing protected metadata without creating a host placeholder first; got: {text}"
+            );
+        }
+        session.cancel().await?;
+        assert!(
+            writable_root.join("allowed.txt").exists(),
+            "ordinary write under explicit root should create the target file"
+        );
+        for protected_name in [".git", ".agents", ".codex"] {
+            assert!(
+                writable_root.join(protected_name).exists(),
+                "Linux bwrap missing protected metadata write should create {} after user code runs",
+                writable_root.join(protected_name).display()
+            );
+        }
     }
-    session.cancel().await?;
-    assert!(
-        writable_root.join("allowed.txt").exists(),
-        "ordinary write under explicit root should create the target file"
-    );
-    for protected_name in [".git", ".agents", ".codex"] {
+    #[cfg(target_os = "macos")]
+    {
         assert!(
-            !writable_root.join(protected_name).exists(),
-            "protected metadata write should not create {}",
-            writable_root.join(protected_name).display()
+            text.contains("ALLOWED_WRITE_OK"),
+            "expected explicit path write root to allow ordinary writes, got: {text}"
         );
+        assert!(
+            !text.contains("ALLOWED_WRITE_ERROR:"),
+            "explicit path write root unexpectedly blocked ordinary write: {text}"
+        );
+        for protected_name in [".git", ".agents", ".codex"] {
+            assert!(
+                text.contains(&format!("PROTECTED_WRITE_ERROR:{protected_name}:")),
+                "expected explicit path write root to block missing protected metadata {protected_name}, got: {text}"
+            );
+            assert!(
+                !text.contains(&format!("PROTECTED_WRITE_OK:{protected_name}")),
+                "explicit path write root unexpectedly allowed protected metadata write {protected_name}: {text}"
+            );
+        }
+        session.cancel().await?;
+        assert!(
+            writable_root.join("allowed.txt").exists(),
+            "ordinary write under explicit root should create the target file"
+        );
+        for protected_name in [".git", ".agents", ".codex"] {
+            assert!(
+                !writable_root.join(protected_name).exists(),
+                "protected metadata write should not create {}",
+                writable_root.join(protected_name).display()
+            );
+        }
     }
     Ok(())
 }
@@ -3141,31 +3173,52 @@ tryCatch({{
         eprintln!("sandbox_state_meta backend unavailable in this environment; skipping");
         return Ok(());
     }
-    assert!(
-        text.contains("ALIAS_ALLOWED_WRITE_OK"),
-        "expected canonical writable-root alias to allow ordinary writes, got: {text}"
-    );
-    assert!(
-        !text.contains("ALIAS_ALLOWED_WRITE_ERROR:"),
-        "canonical writable-root alias unexpectedly blocked ordinary write: {text}"
-    );
-    assert!(
-        text.contains("ALIAS_PROTECTED_WRITE_ERROR:"),
-        "expected canonical writable-root alias to block missing protected metadata, got: {text}"
-    );
-    assert!(
-        !text.contains("ALIAS_PROTECTED_WRITE_OK"),
-        "canonical writable-root alias unexpectedly allowed protected metadata write: {text}"
-    );
-    assert!(
-        canonical_scratch.join("allowed.txt").exists(),
-        "ordinary write through canonical writable-root alias should create the target file"
-    );
-    assert!(
-        !protected_dir.exists(),
-        "protected metadata write should not create {}",
-        protected_dir.display()
-    );
+    #[cfg(target_os = "linux")]
+    {
+        assert!(
+            (text.contains("cannot enforce sandbox read-only path")
+                && text.contains("does not exist under a writable root"))
+                || text.contains("ipc disconnected while waiting for worker_ready"),
+            "expected Linux bwrap to reject missing protected metadata alias under writable root, got: {text}"
+        );
+        assert!(
+            !canonical_scratch.join("allowed.txt").exists(),
+            "rejected Linux protected metadata alias policy should not run user code"
+        );
+        assert!(
+            !protected_dir.exists(),
+            "rejected Linux protected metadata alias policy should not create {}",
+            protected_dir.display()
+        );
+    }
+    #[cfg(target_os = "macos")]
+    {
+        assert!(
+            text.contains("ALIAS_ALLOWED_WRITE_OK"),
+            "expected canonical writable-root alias to allow ordinary writes, got: {text}"
+        );
+        assert!(
+            !text.contains("ALIAS_ALLOWED_WRITE_ERROR:"),
+            "canonical writable-root alias unexpectedly blocked ordinary write: {text}"
+        );
+        assert!(
+            text.contains("ALIAS_PROTECTED_WRITE_ERROR:"),
+            "expected canonical writable-root alias to block missing protected metadata, got: {text}"
+        );
+        assert!(
+            !text.contains("ALIAS_PROTECTED_WRITE_OK"),
+            "canonical writable-root alias unexpectedly allowed protected metadata write: {text}"
+        );
+        assert!(
+            canonical_scratch.join("allowed.txt").exists(),
+            "ordinary write through canonical writable-root alias should create the target file"
+        );
+        assert!(
+            !protected_dir.exists(),
+            "protected metadata write should not create {}",
+            protected_dir.display()
+        );
+    }
     Ok(())
 }
 
@@ -3304,8 +3357,10 @@ tryCatch({{
     #[cfg(target_os = "linux")]
     {
         assert!(
-            text.contains("WRITE_ERROR:"),
-            "expected Linux bwrap literal glob-denied future create to fail, got: {text}"
+            (text.contains("cannot enforce sandbox deny-read path")
+                && text.contains("does not exist under a writable root"))
+                || text.contains("ipc disconnected while waiting for worker_ready"),
+            "expected Linux bwrap to reject literal glob-denied future create, got: {text}"
         );
         assert!(
             !text.contains("WRITE_OK"),
@@ -3581,31 +3636,52 @@ tryCatch({{
         eprintln!("sandbox_state_meta backend unavailable in this environment; skipping");
         return Ok(());
     }
-    assert!(
-        text.contains("PATH_DENY_ALIAS_ALLOWED_WRITE_OK"),
-        "expected canonical writable-root alias to allow ordinary writes, got: {text}"
-    );
-    assert!(
-        !text.contains("PATH_DENY_ALIAS_ALLOWED_WRITE_ERROR:"),
-        "canonical writable-root alias unexpectedly blocked ordinary write: {text}"
-    );
-    assert!(
-        text.contains("PATH_DENY_ALIAS_WRITE_ERROR:"),
-        "expected canonical path-deny alias to block missing denied path creation, got: {text}"
-    );
-    assert!(
-        !text.contains("PATH_DENY_ALIAS_WRITE_OK"),
-        "canonical path-deny alias unexpectedly allowed denied path creation: {text}"
-    );
-    assert!(
-        canonical_scratch.join("allowed.txt").exists(),
-        "ordinary write through canonical writable-root alias should create the target file"
-    );
-    assert!(
-        !canonical_denied_dir.exists(),
-        "path-deny write should not create {}",
-        canonical_denied_dir.display()
-    );
+    #[cfg(target_os = "linux")]
+    {
+        assert!(
+            (text.contains("cannot enforce sandbox deny-read path")
+                && text.contains("does not exist under a writable root"))
+                || text.contains("ipc disconnected while waiting for worker_ready"),
+            "expected Linux bwrap to reject missing path-deny alias under writable root, got: {text}"
+        );
+        assert!(
+            !canonical_scratch.join("allowed.txt").exists(),
+            "rejected Linux path-deny alias policy should not run user code"
+        );
+        assert!(
+            !canonical_denied_dir.exists(),
+            "rejected Linux path-deny alias policy should not create {}",
+            canonical_denied_dir.display()
+        );
+    }
+    #[cfg(target_os = "macos")]
+    {
+        assert!(
+            text.contains("PATH_DENY_ALIAS_ALLOWED_WRITE_OK"),
+            "expected canonical writable-root alias to allow ordinary writes, got: {text}"
+        );
+        assert!(
+            !text.contains("PATH_DENY_ALIAS_ALLOWED_WRITE_ERROR:"),
+            "canonical writable-root alias unexpectedly blocked ordinary write: {text}"
+        );
+        assert!(
+            text.contains("PATH_DENY_ALIAS_WRITE_ERROR:"),
+            "expected canonical path-deny alias to block missing denied path creation, got: {text}"
+        );
+        assert!(
+            !text.contains("PATH_DENY_ALIAS_WRITE_OK"),
+            "canonical path-deny alias unexpectedly allowed denied path creation: {text}"
+        );
+        assert!(
+            canonical_scratch.join("allowed.txt").exists(),
+            "ordinary write through canonical writable-root alias should create the target file"
+        );
+        assert!(
+            !canonical_denied_dir.exists(),
+            "path-deny write should not create {}",
+            canonical_denied_dir.display()
+        );
+    }
     Ok(())
 }
 

--- a/tests/sandbox_state_meta.rs
+++ b/tests/sandbox_state_meta.rs
@@ -3062,8 +3062,12 @@ for (protected_name in c(".git", ".agents", ".codex")) {{
         );
         for protected_name in [".git", ".agents", ".codex"] {
             assert!(
-                text.contains(&format!("PROTECTED_WRITE_OK:{protected_name}")),
-                "Linux bwrap cannot block missing protected metadata without creating a host placeholder first; got: {text}"
+                text.contains(&format!("PROTECTED_WRITE_ERROR:{protected_name}:")),
+                "expected Linux bwrap explicit path write root to block missing protected metadata {protected_name}, got: {text}"
+            );
+            assert!(
+                !text.contains(&format!("PROTECTED_WRITE_OK:{protected_name}")),
+                "Linux bwrap explicit path write root unexpectedly allowed protected metadata write {protected_name}: {text}"
             );
         }
         session.cancel().await?;
@@ -3073,8 +3077,8 @@ for (protected_name in c(".git", ".agents", ".codex")) {{
         );
         for protected_name in [".git", ".agents", ".codex"] {
             assert!(
-                writable_root.join(protected_name).exists(),
-                "Linux bwrap missing protected metadata write should create {} after user code runs",
+                !writable_root.join(protected_name).exists(),
+                "protected metadata write should not create {}",
                 writable_root.join(protected_name).display()
             );
         }

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -955,6 +955,19 @@ async fn zod_files_timeout_drains_stderr_after_incomplete_utf8() -> TestResult<(
         )
         .await?;
     let timeout_text = result_text(&timed_out);
+    let mut drained_text = timeout_text.clone();
+    if !drained_text.contains("\\xC3") || !drained_text.contains("stderr: tail-visible\n") {
+        let follow_up = session
+            .call_tool_raw(
+                "repl",
+                json!({
+                    "input": "",
+                    "timeout_ms": 10_000
+                }),
+            )
+            .await?;
+        drained_text.push_str(&result_text(&follow_up));
+    }
 
     session.cancel().await?;
 
@@ -963,12 +976,12 @@ async fn zod_files_timeout_drains_stderr_after_incomplete_utf8() -> TestResult<(
         "expected the delayed UTF-8 request to time out, got: {timeout_text:?}"
     );
     assert!(
-        timeout_text.contains("\\xC3"),
-        "timeout drain should flush an incomplete leading UTF-8 tail, got: {timeout_text:?}"
+        drained_text.contains("\\xC3"),
+        "timeout or follow-up poll should flush an incomplete leading UTF-8 tail, got: {drained_text:?}"
     );
     assert!(
-        timeout_text.contains("stderr: tail-visible\n"),
-        "timeout drain should expose later stderr after an incomplete UTF-8 tail, got: {timeout_text:?}"
+        drained_text.contains("stderr: tail-visible\n"),
+        "timeout or follow-up poll should expose later stderr after an incomplete UTF-8 tail, got: {drained_text:?}"
     );
 
     Ok(())

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -950,24 +950,11 @@ async fn zod_files_timeout_drains_stderr_after_incomplete_utf8() -> TestResult<(
             "repl",
             json!({
                 "input": "partial-utf8-stderr-then-sleep",
-                "timeout_ms": 50
+                "timeout_ms": 300
             }),
         )
         .await?;
     let timeout_text = result_text(&timed_out);
-    let mut drained_text = timeout_text.clone();
-    if !drained_text.contains("\\xC3") || !drained_text.contains("stderr: tail-visible\n") {
-        let follow_up = session
-            .call_tool_raw(
-                "repl",
-                json!({
-                    "input": "",
-                    "timeout_ms": 10_000
-                }),
-            )
-            .await?;
-        drained_text.push_str(&result_text(&follow_up));
-    }
 
     session.cancel().await?;
 
@@ -976,12 +963,12 @@ async fn zod_files_timeout_drains_stderr_after_incomplete_utf8() -> TestResult<(
         "expected the delayed UTF-8 request to time out, got: {timeout_text:?}"
     );
     assert!(
-        drained_text.contains("\\xC3"),
-        "timeout or follow-up poll should flush an incomplete leading UTF-8 tail, got: {drained_text:?}"
+        timeout_text.contains("\\xC3"),
+        "timeout drain should flush an incomplete leading UTF-8 tail, got: {timeout_text:?}"
     );
     assert!(
-        drained_text.contains("stderr: tail-visible\n"),
-        "timeout or follow-up poll should expose later stderr after an incomplete UTF-8 tail, got: {drained_text:?}"
+        timeout_text.contains("stderr: tail-visible\n"),
+        "timeout drain should expose later stderr after an incomplete UTF-8 tail, got: {timeout_text:?}"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

Reapplies the post-merge sandbox review fixes onto the latest `main` branch.

- Fix Linux bwrap helper dispatch by invoking a session-temp helper path and preserving it through the bwrap launch.
- Preserve declared missing writable roots after bwrap exits while avoiding host placeholder creation for missing protected metadata under writable roots.
- Fail closed for missing read-only or deny paths under Linux bwrap writable roots when the sandbox cannot enforce them safely.
- Preserve legacy Landlock workspace-write fallback behavior while allowing non-legacy client sandbox metadata to re-enable bwrap after a legacy reset, subject to the server default override.
- Keep macOS platform defaults limited to the minimal-read profile and update sandbox metadata tests for the platform-specific behavior.

Followup to #150 

## Validation

- `cargo check`
- `cargo build`
- `python3 tests/run_integration_tests.py --binary target/debug/mcp-repl` (20 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo +nightly fmt`
