### PR TITLE
Stabilize restart handling and quiet CI test output

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,10 @@ The exact `repl` tool description depends on the interpreter and
 ### Session control
 
 - **Interrupt**: prefix `repl` input with `\u0003` (SIGINT, best-effort). Session continues.
-- **Reset**: call `repl_reset`, or prefix input with `\u0004` (Ctrl-D). Reset returns output captured through bounded old-worker shutdown, starts a fresh session, and runs any remaining input in that session under the original call timeout.
+- **Reset**: call `repl_reset`, or prefix input with `\u0004` (Ctrl-D).
+  For `\u0004` with remaining input, the same response includes output
+  captured through bounded old-worker shutdown, fresh-session startup, and
+  evaluating that remaining input under the original call timeout.
 - **In-band exits**: `EOF`, `quit()`, etc. also work — output is
   returned and the next request runs in a fresh worker.
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The exact `repl` tool description depends on the interpreter and
 ### Session control
 
 - **Interrupt**: prefix `repl` input with `\u0003` (SIGINT, best-effort). Session continues.
-- **Reset**: call `repl_reset`, or prefix input with `\u0004` (Ctrl-D); any remaining input runs in the fresh session. Reset attempts graceful shutdown, escalates to forceful termination, and on Unix falls back to scanning descendant processes if process-group signaling is unavailable.
+- **Reset**: call `repl_reset`, or prefix input with `\u0004` (Ctrl-D). Reset returns already captured output, shuts down the old worker in a bounded window, and runs any remaining input in the fresh session.
 - **In-band exits**: `EOF`, `quit()`, etc. also work — output is
   returned and the next request runs in a fresh worker.
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The exact `repl` tool description depends on the interpreter and
 ### Session control
 
 - **Interrupt**: prefix `repl` input with `\u0003` (SIGINT, best-effort). Session continues.
-- **Reset**: call `repl_reset`, or prefix input with `\u0004` (Ctrl-D). Reset returns already captured output, shuts down the old worker in a bounded window, and runs any remaining input in the fresh session.
+- **Reset**: call `repl_reset`, or prefix input with `\u0004` (Ctrl-D). Reset returns output captured through bounded old-worker shutdown, starts a fresh session, and runs any remaining input in that session under the original call timeout.
 - **In-band exits**: `EOF`, `quit()`, etc. also work — output is
   returned and the next request runs in a fresh worker.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,10 +44,10 @@ The repository is organized around a few concrete subsystems rather than deep pa
   `input_wait` or `ready`. The server treats these as readiness gates, not as
   prompt classification.
 - Server teardown and `repl_reset` use the sideband `shutdown` lifecycle
-  message first. For explicit `Ctrl-D` restarts, the server snapshots already
-  captured output, closes stdin, waits for a bounded graceful window, then
-  escalates to process termination if needed. Output produced during restart
-  shutdown is discarded before the next session.
+  message first. For explicit `Ctrl-D` restarts, the server closes stdin, keeps
+  output capture active through a bounded graceful window, then escalates to
+  process termination if needed. A `Ctrl-D` tail runs in the fresh session under
+  the original tool-call timeout.
 - The IPC sideband is single-owner by design: startup env vars only bootstrap the main worker, then they are scrubbed before user code runs. Descendants must not emit sideband messages.
 - R-specific behavior lives in `src/r_session.rs`, `src/r_controls.rs`, `src/r_graphics.rs`, and `src/r_htmd.rs`.
 - Python-specific behavior lives in `src/python_ffi.rs`, `src/python_session.rs`, `src/python_worker.rs`, and `python/embedded.py`. Python worker mode dynamically loads CPython only after the worker has selected the Python backend, so R worker mode does not load Python. On Unix, Python may still use PTY-backed process stdio for terminal behavior, but managed input batches are served from the worker queue; direct stdin consumers are not a server completion contract.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,11 +43,11 @@ The repository is organized around a few concrete subsystems rather than deep pa
 - After `worker_ready`, the worker is not ready for input until its first
   `input_wait` or `ready`. The server treats these as readiness gates, not as
   prompt classification.
-- Server teardown uses the sideband `shutdown` lifecycle message first. For
-  explicit restarts, the server snapshots already captured output, closes stdin,
-  waits for a bounded graceful window, then escalates to process termination if
-  needed. Output produced during restart shutdown is discarded before the next
-  session.
+- Server teardown and `repl_reset` use the sideband `shutdown` lifecycle
+  message first. For explicit `Ctrl-D` restarts, the server snapshots already
+  captured output, closes stdin, waits for a bounded graceful window, then
+  escalates to process termination if needed. Output produced during restart
+  shutdown is discarded before the next session.
 - The IPC sideband is single-owner by design: startup env vars only bootstrap the main worker, then they are scrubbed before user code runs. Descendants must not emit sideband messages.
 - R-specific behavior lives in `src/r_session.rs`, `src/r_controls.rs`, `src/r_graphics.rs`, and `src/r_htmd.rs`.
 - Python-specific behavior lives in `src/python_ffi.rs`, `src/python_session.rs`, `src/python_worker.rs`, and `python/embedded.py`. Python worker mode dynamically loads CPython only after the worker has selected the Python backend, so R worker mode does not load Python. On Unix, Python may still use PTY-backed process stdio for terminal behavior, but managed input batches are served from the worker queue; direct stdin consumers are not a server completion contract.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,9 +43,11 @@ The repository is organized around a few concrete subsystems rather than deep pa
 - After `worker_ready`, the worker is not ready for input until its first
   `input_wait` or `ready`. The server treats these as readiness gates, not as
   prompt classification.
-- Server teardown uses the sideband `shutdown` lifecycle message first. Explicit
-  `Ctrl-D` restarts close stdin and wait for a bounded graceful window while
-  capture stays active, then escalate to process termination if needed.
+- Server teardown uses the sideband `shutdown` lifecycle message first. For
+  explicit `Ctrl-D` restarts, the server snapshots already captured output,
+  closes stdin, waits for a bounded graceful window, then escalates to process
+  termination if needed. Output produced during restart shutdown is discarded
+  before the next session.
 - The IPC sideband is single-owner by design: startup env vars only bootstrap the main worker, then they are scrubbed before user code runs. Descendants must not emit sideband messages.
 - R-specific behavior lives in `src/r_session.rs`, `src/r_controls.rs`, `src/r_graphics.rs`, and `src/r_htmd.rs`.
 - Python-specific behavior lives in `src/python_ffi.rs`, `src/python_session.rs`, `src/python_worker.rs`, and `python/embedded.py`. Python worker mode dynamically loads CPython only after the worker has selected the Python backend, so R worker mode does not load Python. On Unix, Python may still use PTY-backed process stdio for terminal behavior, but managed input batches are served from the worker queue; direct stdin consumers are not a server completion contract.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,8 +43,9 @@ The repository is organized around a few concrete subsystems rather than deep pa
 - After `worker_ready`, the worker is not ready for input until its first
   `input_wait` or `ready`. The server treats these as readiness gates, not as
   prompt classification.
-- Worker reset and teardown use the sideband `shutdown` lifecycle message first,
-  with stdin close and process termination retained only as bounded fallbacks.
+- Server teardown uses the sideband `shutdown` lifecycle message first. Explicit
+  `Ctrl-D` restarts close stdin and wait for a bounded graceful window while
+  capture stays active, then escalate to process termination if needed.
 - The IPC sideband is single-owner by design: startup env vars only bootstrap the main worker, then they are scrubbed before user code runs. Descendants must not emit sideband messages.
 - R-specific behavior lives in `src/r_session.rs`, `src/r_controls.rs`, `src/r_graphics.rs`, and `src/r_htmd.rs`.
 - Python-specific behavior lives in `src/python_ffi.rs`, `src/python_session.rs`, `src/python_worker.rs`, and `python/embedded.py`. Python worker mode dynamically loads CPython only after the worker has selected the Python backend, so R worker mode does not load Python. On Unix, Python may still use PTY-backed process stdio for terminal behavior, but managed input batches are served from the worker queue; direct stdin consumers are not a server completion contract.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,10 +44,10 @@ The repository is organized around a few concrete subsystems rather than deep pa
   `input_wait` or `ready`. The server treats these as readiness gates, not as
   prompt classification.
 - Server teardown uses the sideband `shutdown` lifecycle message first. For
-  explicit `Ctrl-D` restarts, the server snapshots already captured output,
-  closes stdin, waits for a bounded graceful window, then escalates to process
-  termination if needed. Output produced during restart shutdown is discarded
-  before the next session.
+  explicit restarts, the server snapshots already captured output, closes stdin,
+  waits for a bounded graceful window, then escalates to process termination if
+  needed. Output produced during restart shutdown is discarded before the next
+  session.
 - The IPC sideband is single-owner by design: startup env vars only bootstrap the main worker, then they are scrubbed before user code runs. Descendants must not emit sideband messages.
 - R-specific behavior lives in `src/r_session.rs`, `src/r_controls.rs`, `src/r_graphics.rs`, and `src/r_htmd.rs`.
 - Python-specific behavior lives in `src/python_ffi.rs`, `src/python_session.rs`, `src/python_worker.rs`, and `python/embedded.py`. Python worker mode dynamically loads CPython only after the worker has selected the Python backend, so R worker mode does not load Python. On Unix, Python may still use PTY-backed process stdio for terminal behavior, but managed input batches are served from the worker queue; direct stdin consumers are not a server completion contract.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -66,8 +66,10 @@ More specifically:
 - Control-prefixed tails such as `Ctrl-C<code>` and `Ctrl-D<code>` run in the
   restarted session when the sandbox changed; the control prefix itself is not
   replayed into the fresh worker.
-- Explicit restarts discard preserved detached output from aborted prior
-  requests instead of carrying it into later unrelated replies.
+- Explicit restarts return worker output already captured before or during the
+  bounded restart shutdown window. They do not wait for a prior request to
+  finish after that window, and they do not carry old output into later
+  unrelated replies.
 - Sandbox metadata is enforced again at the next tool call that actually
   interacts with the worker after pager navigation ends.
 - Missing or malformed metadata still fails closed on calls that need it.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -66,10 +66,9 @@ More specifically:
 - Control-prefixed tails such as `Ctrl-C<code>` and `Ctrl-D<code>` run in the
   restarted session when the sandbox changed; the control prefix itself is not
   replayed into the fresh worker.
-- Explicit restarts return worker output already captured before or during the
-  bounded restart shutdown window. They do not wait for a prior request to
-  finish after that window, and they do not carry old output into later
-  unrelated replies.
+- Explicit restarts return worker output already captured before restart. They
+  do not wait for a prior request to finish after that snapshot, and they do not
+  carry old output into later unrelated replies.
 - Sandbox metadata is enforced again at the next tool call that actually
   interacts with the worker after pager navigation ends.
 - Missing or malformed metadata still fails closed on calls that need it.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -66,9 +66,9 @@ More specifically:
 - Control-prefixed tails such as `Ctrl-C<code>` and `Ctrl-D<code>` run in the
   restarted session when the sandbox changed; the control prefix itself is not
   replayed into the fresh worker.
-- Explicit restarts return worker output already captured before restart. They
-  do not wait for a prior request to finish after that snapshot, and they do not
-  carry old output into later unrelated replies.
+- Explicit restarts return worker output captured through bounded old-worker
+  shutdown. They do not wait for a prior request to finish after that window,
+  and they do not carry old output into later unrelated replies.
 - Sandbox metadata is enforced again at the next tool call that actually
   interacts with the worker after pager navigation ends.
 - Missing or malformed metadata still fails closed on calls that need it.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -184,8 +184,8 @@ but it cannot enforce restricted-read managed profiles.
   or denied domains with enabled network access currently fails closed.
 - `mcp-repl` always uses its own internal Linux sandbox launcher; helper
   executable paths provided by an MCP client are ignored.
-- `MCP_REPL_LINUX_BWRAP_NO_PROC=1` skips `/proc` mounting when the host
-  container does not allow bubblewrap to mount it.
+- `MCP_REPL_LINUX_BWRAP_NO_PROC=1` skips `/proc` mounting and the paired PID
+  namespace when the host container does not allow bubblewrap to mount `/proc`.
 - if the default bubblewrap path dies before worker readiness, `mcp-repl`
   retries once with the legacy Landlock path for compatibility.
 - `MCP_REPL_USE_LINUX_BWRAP=0` disables the default bubblewrap path. Codex

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -76,6 +76,21 @@ Do not opt Rust test targets out of Cargo discovery in anticipation of a future
 Python migration; migrate a scenario only when the Rust coverage is deleted or
 reduced in the same change that adds equivalent external coverage.
 
+## Quiet/Fast Iteration
+
+Use focused test targets while iterating, then run the full verification set
+before sending a change for review. Prefer one of these forms:
+
+```sh
+cargo test --quiet --test zod_protocol zod_files_request_boundary_resets_stderr_after_sealed_utf8_tail
+python3 tests/run_integration_tests.py --binary target/debug/mcp-repl --case r-reset-clears-state
+```
+
+Successful Rust test runs should stay quiet. The shared test harness captures
+server stderr from spawned test servers and keeps it available to tests through
+`McpTestSession::server_stderr_text()` instead of inheriting expected
+negative-path diagnostics into passing logs.
+
 ## Real Client Integrations
 
 CI installs Codex before the Rust suite. The Codex CI integration does not

--- a/docs/tool-descriptions/repl_tool_python.md
+++ b/docs/tool-descriptions/repl_tool_python.md
@@ -31,4 +31,4 @@ Python REPL affordances:
 - Plot images are returned as image content (for example matplotlib output).
 - Help flows are in-band (`help()`, `dir()`, `pydoc.help`).
 - Debugging works in the REPL, including interactive stops from `breakpoint()` and `pdb.set_trace()`.
-- Control prefixes in `input`: `\u0003` (interrupt) and `\u0004` (reset then run remaining input).
+- Control prefixes in `input`: `\u0003` (interrupt) and `\u0004` (reset, return already captured output, then run remaining input).

--- a/docs/tool-descriptions/repl_tool_python.md
+++ b/docs/tool-descriptions/repl_tool_python.md
@@ -31,4 +31,4 @@ Python REPL affordances:
 - Plot images are returned as image content (for example matplotlib output).
 - Help flows are in-band (`help()`, `dir()`, `pydoc.help`).
 - Debugging works in the REPL, including interactive stops from `breakpoint()` and `pdb.set_trace()`.
-- Control prefixes in `input`: `\u0003` (interrupt) and `\u0004` (reset, return already captured output, then run remaining input).
+- Control prefixes in `input`: `\u0003` (interrupt) and `\u0004` (reset, return captured restart output, then run remaining input under the original call timeout).

--- a/docs/tool-descriptions/repl_tool_python.md
+++ b/docs/tool-descriptions/repl_tool_python.md
@@ -31,4 +31,4 @@ Python REPL affordances:
 - Plot images are returned as image content (for example matplotlib output).
 - Help flows are in-band (`help()`, `dir()`, `pydoc.help`).
 - Debugging works in the REPL, including interactive stops from `breakpoint()` and `pdb.set_trace()`.
-- Control prefixes in `input`: `\u0003` (interrupt) and `\u0004` (reset, return captured restart output, then run remaining input under the original call timeout).
+- Control prefixes in `input`: `\u0003` (interrupt) and `\u0004` (reset; if input remains after `\u0004`, the same response includes restart output plus output produced by the remaining input, bounded by the original call timeout).

--- a/docs/tool-descriptions/repl_tool_python_pager.md
+++ b/docs/tool-descriptions/repl_tool_python_pager.md
@@ -27,4 +27,4 @@ Python REPL affordances:
 - Plot images are returned as image content (for example matplotlib output).
 - Help flows are in-band (`help()`, `dir()`, `pydoc.help`).
 - Debugging works in the REPL, including interactive stops from `breakpoint()` and `pdb.set_trace()`.
-- Control prefixes in `input`: `\u0003` (interrupt) and `\u0004` (reset then run remaining input).
+- Control prefixes in `input`: `\u0003` (interrupt) and `\u0004` (reset, return already captured output, then run remaining input).

--- a/docs/tool-descriptions/repl_tool_python_pager.md
+++ b/docs/tool-descriptions/repl_tool_python_pager.md
@@ -27,4 +27,4 @@ Python REPL affordances:
 - Plot images are returned as image content (for example matplotlib output).
 - Help flows are in-band (`help()`, `dir()`, `pydoc.help`).
 - Debugging works in the REPL, including interactive stops from `breakpoint()` and `pdb.set_trace()`.
-- Control prefixes in `input`: `\u0003` (interrupt) and `\u0004` (reset, return captured restart output, then run remaining input under the original call timeout).
+- Control prefixes in `input`: `\u0003` (interrupt) and `\u0004` (reset; if input remains after `\u0004`, the same response includes restart output plus output produced by the remaining input, bounded by the original call timeout).

--- a/docs/tool-descriptions/repl_tool_python_pager.md
+++ b/docs/tool-descriptions/repl_tool_python_pager.md
@@ -27,4 +27,4 @@ Python REPL affordances:
 - Plot images are returned as image content (for example matplotlib output).
 - Help flows are in-band (`help()`, `dir()`, `pydoc.help`).
 - Debugging works in the REPL, including interactive stops from `breakpoint()` and `pdb.set_trace()`.
-- Control prefixes in `input`: `\u0003` (interrupt) and `\u0004` (reset, return already captured output, then run remaining input).
+- Control prefixes in `input`: `\u0003` (interrupt) and `\u0004` (reset, return captured restart output, then run remaining input under the original call timeout).

--- a/docs/tool-descriptions/repl_tool_r.md
+++ b/docs/tool-descriptions/repl_tool_r.md
@@ -27,4 +27,4 @@ Behavior:
 - Documentation entry points work in-band. Prefer the normal R interfaces such as `?topic`, `help()`, `vignette()`, and `RShowDoc("R-exts")`; the REPL renders their text/HTML output directly instead of launching an external viewer.
 - `?topic`, `help()`, `vignette()`, and `RShowDoc()` render directly into the tool response instead of opening a separate web-browser flow.
 - Debugging works in the REPL, including interactive stops from `browser()`, `debug()`, and `trace()`.
-- Control: `\u0003` in input interrupts; `\u0004` resets session then runs remaining input.
+- Control: `\u0003` in input interrupts; `\u0004` resets the session, returns already captured output, then runs remaining input.

--- a/docs/tool-descriptions/repl_tool_r.md
+++ b/docs/tool-descriptions/repl_tool_r.md
@@ -27,4 +27,4 @@ Behavior:
 - Documentation entry points work in-band. Prefer the normal R interfaces such as `?topic`, `help()`, `vignette()`, and `RShowDoc("R-exts")`; the REPL renders their text/HTML output directly instead of launching an external viewer.
 - `?topic`, `help()`, `vignette()`, and `RShowDoc()` render directly into the tool response instead of opening a separate web-browser flow.
 - Debugging works in the REPL, including interactive stops from `browser()`, `debug()`, and `trace()`.
-- Control: `\u0003` in input interrupts; `\u0004` resets the session, returns already captured output, then runs remaining input.
+- Control: `\u0003` in input interrupts; `\u0004` resets the session, returns captured restart output, then runs remaining input under the original call timeout.

--- a/docs/tool-descriptions/repl_tool_r.md
+++ b/docs/tool-descriptions/repl_tool_r.md
@@ -27,4 +27,4 @@ Behavior:
 - Documentation entry points work in-band. Prefer the normal R interfaces such as `?topic`, `help()`, `vignette()`, and `RShowDoc("R-exts")`; the REPL renders their text/HTML output directly instead of launching an external viewer.
 - `?topic`, `help()`, `vignette()`, and `RShowDoc()` render directly into the tool response instead of opening a separate web-browser flow.
 - Debugging works in the REPL, including interactive stops from `browser()`, `debug()`, and `trace()`.
-- Control: `\u0003` in input interrupts; `\u0004` resets the session, returns captured restart output, then runs remaining input under the original call timeout.
+- Control: `\u0003` in input interrupts; `\u0004` resets the session. If input remains after `\u0004`, the same response includes restart output plus output produced by the remaining input, bounded by the original call timeout.

--- a/docs/tool-descriptions/repl_tool_r_pager.md
+++ b/docs/tool-descriptions/repl_tool_r_pager.md
@@ -22,4 +22,4 @@ Behavior:
 - Documentation entry points work in-band. Prefer the normal R interfaces such as `?topic`, `help()`, `vignette()`, and `RShowDoc("R-exts")`; the REPL renders their text/HTML output directly instead of launching an external viewer.
 - `?topic`, `help()`, `vignette()`, and `RShowDoc()` render directly into the tool response instead of opening a separate web-browser flow.
 - Debugging works in the REPL, including interactive stops from `browser()`, `debug()`, and `trace()`.
-- Control: `\u0003` in input interrupts; `\u0004` resets the session, returns captured restart output, then runs remaining input under the original call timeout.
+- Control: `\u0003` in input interrupts; `\u0004` resets the session. If input remains after `\u0004`, the same response includes restart output plus output produced by the remaining input, bounded by the original call timeout.

--- a/docs/tool-descriptions/repl_tool_r_pager.md
+++ b/docs/tool-descriptions/repl_tool_r_pager.md
@@ -22,4 +22,4 @@ Behavior:
 - Documentation entry points work in-band. Prefer the normal R interfaces such as `?topic`, `help()`, `vignette()`, and `RShowDoc("R-exts")`; the REPL renders their text/HTML output directly instead of launching an external viewer.
 - `?topic`, `help()`, `vignette()`, and `RShowDoc()` render directly into the tool response instead of opening a separate web-browser flow.
 - Debugging works in the REPL, including interactive stops from `browser()`, `debug()`, and `trace()`.
-- Control: `\u0003` in input interrupts; `\u0004` resets session then runs remaining input.
+- Control: `\u0003` in input interrupts; `\u0004` resets the session, returns already captured output, then runs remaining input.

--- a/docs/tool-descriptions/repl_tool_r_pager.md
+++ b/docs/tool-descriptions/repl_tool_r_pager.md
@@ -22,4 +22,4 @@ Behavior:
 - Documentation entry points work in-band. Prefer the normal R interfaces such as `?topic`, `help()`, `vignette()`, and `RShowDoc("R-exts")`; the REPL renders their text/HTML output directly instead of launching an external viewer.
 - `?topic`, `help()`, `vignette()`, and `RShowDoc()` render directly into the tool response instead of opening a separate web-browser flow.
 - Debugging works in the REPL, including interactive stops from `browser()`, `debug()`, and `trace()`.
-- Control: `\u0003` in input interrupts; `\u0004` resets the session, returns already captured output, then runs remaining input.
+- Control: `\u0003` in input interrupts; `\u0004` resets the session, returns captured restart output, then runs remaining input under the original call timeout.

--- a/docs/worker_sideband_protocol.md
+++ b/docs/worker_sideband_protocol.md
@@ -90,10 +90,10 @@ capture does not preserve separate stdout/stderr identity. Sideband
 
 `shutdown`
 - `{ "type": "shutdown" }`
-- Requests worker shutdown during server teardown and replacement paths that
-  need immediate worker-side lifecycle control. Explicit restarts do not send
-  this message first; they close stdin, keep output capture active during a
-  bounded graceful shutdown window, then escalate if needed.
+- Requests worker shutdown during server teardown, `repl_reset`, and replacement
+  paths that need immediate worker-side lifecycle control. Explicit `Ctrl-D`
+  restarts do not send this message first; they close stdin, keep output capture
+  active during a bounded graceful shutdown window, then escalate if needed.
 - Built-in workers currently exit the process after receiving it.
 
 The server emits no other server-to-worker protocol messages in v6.

--- a/docs/worker_sideband_protocol.md
+++ b/docs/worker_sideband_protocol.md
@@ -91,9 +91,9 @@ capture does not preserve separate stdout/stderr identity. Sideband
 `shutdown`
 - `{ "type": "shutdown" }`
 - Requests worker shutdown during server teardown and replacement paths that
-  need immediate worker-side lifecycle control. Explicit `Ctrl-D` restart does
-  not send this message first; it closes stdin, keeps output capture active
-  during a bounded graceful shutdown window, then escalates if needed.
+  need immediate worker-side lifecycle control. Explicit restarts do not send
+  this message first; they close stdin, keep output capture active during a
+  bounded graceful shutdown window, then escalate if needed.
 - Built-in workers currently exit the process after receiving it.
 
 The server emits no other server-to-worker protocol messages in v6.

--- a/docs/worker_sideband_protocol.md
+++ b/docs/worker_sideband_protocol.md
@@ -90,7 +90,10 @@ capture does not preserve separate stdout/stderr identity. Sideband
 
 `shutdown`
 - `{ "type": "shutdown" }`
-- Requests worker shutdown during reset, replacement, or server teardown.
+- Requests worker shutdown during server teardown and replacement paths that
+  need immediate worker-side lifecycle control. Explicit `Ctrl-D` restart does
+  not send this message first; it closes stdin, keeps output capture active
+  during a bounded graceful shutdown window, then escalates if needed.
 - Built-in workers currently exit the process after receiving it.
 
 The server emits no other server-to-worker protocol messages in v6.
@@ -196,7 +199,9 @@ queue feeds runtime input callbacks and managed stdin surfaces. The sideband IPC
 reader runs independently from the runtime thread. It receives `input_batch`,
 `interrupt`, and `shutdown`, mutates worker-owned queue/session state, and wakes
 the runtime when needed. The runtime thread consumes queued input only when the
-runtime calls its managed input boundary.
+runtime calls its managed input boundary. A `shutdown` message exits built-in
+workers, so explicit restart uses process stdin close plus bounded termination
+instead of sending `shutdown` first.
 
 For R, the managed input boundary is R's embedded `ReadConsole` callback,
 installed through `Rstart.ReadConsole` on Windows and `ptr_R_ReadConsole` on

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -3441,8 +3441,10 @@ fn create_linux_bwrap_command_args(
         "--die-with-parent".to_string(),
         "--new-session".to_string(),
         "--unshare-user".to_string(),
-        "--unshare-pid".to_string(),
     ];
+    if mount_proc {
+        bwrap_args.push("--unshare-pid".to_string());
+    }
     let mut bwrap_command =
         linux_bwrap_filesystem_args(file_system_policy, sandbox_policy_cwd, session_temp_dir)?;
     bwrap_args.append(&mut bwrap_command.args);
@@ -6632,6 +6634,38 @@ mod tests {
         assert!(
             !command.args.iter().any(|arg| arg == "--argv0"),
             "bwrap args should work with Ubuntu 22.04 bubblewrap 0.6.1: {:?}",
+            command.args
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_bwrap_no_proc_does_not_unshare_pid_namespace() {
+        let root = Builder::new()
+            .prefix("mcp-repl-bwrap-no-proc-")
+            .tempdir()
+            .expect("tempdir");
+        let session_temp_dir = root.path().join("session");
+        let file_system_policy = FileSystemSandboxPolicy::workspace_write(&[], false, false);
+
+        let command = create_linux_bwrap_command_args(
+            vec!["/bin/true".to_string()],
+            &file_system_policy,
+            root.path(),
+            &session_temp_dir,
+            false,
+            LinuxBwrapNetworkMode::FullAccess,
+        )
+        .expect("no-proc bwrap command should build");
+
+        assert!(
+            !command.args.iter().any(|arg| arg == "--unshare-pid"),
+            "no-proc bwrap should not create a PID namespace with the host /proc view: {:?}",
+            command.args
+        );
+        assert!(
+            !command.args.iter().any(|arg| arg == "--proc"),
+            "test setup should build no-proc bwrap args: {:?}",
             command.args
         );
     }

--- a/src/worker_process/request_lifecycle.rs
+++ b/src/worker_process/request_lifecycle.rs
@@ -14,7 +14,7 @@ const COMPLETION_METADATA_SETTLE_MAX: Duration = Duration::from_millis(30);
 const COMPLETION_METADATA_SETTLE_POLL: Duration = Duration::from_millis(5);
 const COMPLETION_METADATA_STABLE: Duration = Duration::from_millis(10);
 const OUTPUT_READER_QUIESCE_GRACE: Duration = Duration::from_millis(120);
-const OUTPUT_READER_COMPLETION_STABLE: Duration = Duration::from_millis(80);
+const OUTPUT_READER_COMPLETION_STABLE: Duration = Duration::from_millis(160);
 const OUTPUT_READER_UTF8_TAIL_SETTLE_MAX: Duration = Duration::from_millis(900);
 const OUTPUT_READER_TIMEOUT_SETTLE_MAX: Duration = Duration::from_millis(900);
 

--- a/src/worker_process/restart.rs
+++ b/src/worker_process/restart.rs
@@ -86,10 +86,12 @@ impl WorkerManager {
         timeout: Duration,
     ) -> RestartShutdownSnapshot {
         let had_process = self.process.is_some();
+        // Snapshot before shutdown so an explicit restart does not wait for
+        // more output from an abandoned timed-out request.
+        let output = had_process.then(|| self.drain_sealed_formatted_output());
         if let Some(process) = self.process.take() {
             let _ = process.shutdown_for_restart(timeout);
         }
-        let output = had_process.then(|| self.drain_sealed_formatted_output());
         RestartShutdownSnapshot::Files { output }
     }
 
@@ -98,11 +100,11 @@ impl WorkerManager {
         timeout: Duration,
     ) -> RestartShutdownSnapshot {
         self.output_timeline.seal_utf8_tails();
+        // Snapshot before shutdown so late old-session output is discarded at reset.
+        let end_offset = self.output.end_offset();
         if let Some(process) = self.process.take() {
             let _ = process.shutdown_for_restart(timeout);
         }
-        self.output_timeline.seal_utf8_tails();
-        let end_offset = self.output.end_offset();
         RestartShutdownSnapshot::Pager { end_offset }
     }
 

--- a/src/worker_process/restart.rs
+++ b/src/worker_process/restart.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use super::{WorkerError, WorkerManager};
 use crate::completion_reply::ReplyWithOffset;
+#[cfg(debug_assertions)]
 use crate::oversized_output::OversizedOutputMode;
 use crate::pager;
 use crate::pending_output_tape::FormattedPendingOutput;
@@ -25,6 +26,7 @@ enum RestartShutdownSnapshot {
 }
 
 impl WorkerManager {
+    #[cfg(debug_assertions)]
     pub fn restart(&mut self, timeout: Duration) -> Result<WorkerReply, WorkerError> {
         match self.oversized_output {
             OversizedOutputMode::Files => self.restart_files(timeout),

--- a/src/worker_process/restart.rs
+++ b/src/worker_process/restart.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 
 use super::{WorkerError, WorkerManager};
 use crate::completion_reply::{PagerCompletionPrompt, ReplyWithOffset};
-#[cfg(any(debug_assertions, test))]
 use crate::oversized_output::OversizedOutputMode;
 use crate::pager;
 use crate::pending_output_tape::FormattedPendingOutput;
@@ -31,7 +30,6 @@ enum RestartShutdown {
 }
 
 impl WorkerManager {
-    #[cfg(debug_assertions)]
     pub fn restart(&mut self, timeout: Duration) -> Result<WorkerReply, WorkerError> {
         match self.oversized_output {
             OversizedOutputMode::Files => {

--- a/src/worker_process/restart.rs
+++ b/src/worker_process/restart.rs
@@ -102,15 +102,13 @@ impl WorkerManager {
         timeout: Duration,
     ) -> RestartShutdownSnapshot {
         let had_process = self.process.is_some();
-        // Snapshot before shutdown so an explicit restart does not wait for
-        // more output from an abandoned timed-out request.
-        let output = had_process.then(|| self.drain_sealed_formatted_output());
         if let Some(process) = self.process.take() {
             let _ = match shutdown {
                 RestartShutdown::Sideband => process.shutdown_graceful(timeout),
                 RestartShutdown::StdinClose => process.shutdown_for_restart(timeout),
             };
         }
+        let output = had_process.then(|| self.drain_sealed_formatted_output());
         RestartShutdownSnapshot::Files { output }
     }
 
@@ -120,14 +118,14 @@ impl WorkerManager {
         timeout: Duration,
     ) -> RestartShutdownSnapshot {
         self.output_timeline.seal_utf8_tails();
-        // Snapshot before shutdown so late old-session output is discarded at reset.
-        let end_offset = self.output.end_offset();
         if let Some(process) = self.process.take() {
             let _ = match shutdown {
                 RestartShutdown::Sideband => process.shutdown_graceful(timeout),
                 RestartShutdown::StdinClose => process.shutdown_for_restart(timeout),
             };
         }
+        self.output_timeline.seal_utf8_tails();
+        let end_offset = self.output.end_offset();
         RestartShutdownSnapshot::Pager { end_offset }
     }
 

--- a/src/worker_process/restart.rs
+++ b/src/worker_process/restart.rs
@@ -24,32 +24,43 @@ enum RestartShutdownSnapshot {
     },
 }
 
+#[derive(Clone, Copy)]
+enum RestartShutdown {
+    Sideband,
+    StdinClose,
+}
+
 impl WorkerManager {
     #[cfg(debug_assertions)]
     pub fn restart(&mut self, timeout: Duration) -> Result<WorkerReply, WorkerError> {
         match self.oversized_output {
-            OversizedOutputMode::Files => self.restart_files(timeout),
-            OversizedOutputMode::Pager => self.restart_pager(timeout),
+            OversizedOutputMode::Files => {
+                self.restart_for_mode(RestartMode::Files, RestartShutdown::Sideband, timeout)
+            }
+            OversizedOutputMode::Pager => {
+                self.restart_for_mode(RestartMode::Pager, RestartShutdown::Sideband, timeout)
+            }
         }
     }
 
     pub(super) fn restart_files(&mut self, timeout: Duration) -> Result<WorkerReply, WorkerError> {
-        self.restart_for_mode(RestartMode::Files, timeout)
+        self.restart_for_mode(RestartMode::Files, RestartShutdown::StdinClose, timeout)
     }
 
     pub(super) fn restart_pager(&mut self, timeout: Duration) -> Result<WorkerReply, WorkerError> {
-        self.restart_for_mode(RestartMode::Pager, timeout)
+        self.restart_for_mode(RestartMode::Pager, RestartShutdown::StdinClose, timeout)
     }
 
     fn restart_for_mode(
         &mut self,
         mode: RestartMode,
+        shutdown: RestartShutdown,
         timeout: Duration,
     ) -> Result<WorkerReply, WorkerError> {
         Self::begin_restart(timeout);
         self.require_inherited_sandbox_state()?;
         self.maybe_emit_pending_server_notice();
-        let snapshot = self.shutdown_existing_worker_for_restart(mode, timeout);
+        let snapshot = self.shutdown_existing_worker_for_restart(mode, shutdown, timeout);
         self.clear_restart_busy_guardrail();
         let reply = self.build_restart_reply_for_mode(snapshot);
         self.finish_restart_for_mode(mode);
@@ -73,16 +84,22 @@ impl WorkerManager {
     fn shutdown_existing_worker_for_restart(
         &mut self,
         mode: RestartMode,
+        shutdown: RestartShutdown,
         timeout: Duration,
     ) -> RestartShutdownSnapshot {
         match mode {
-            RestartMode::Files => self.shutdown_existing_files_worker_for_restart(timeout),
-            RestartMode::Pager => self.shutdown_existing_pager_worker_for_restart(timeout),
+            RestartMode::Files => {
+                self.shutdown_existing_files_worker_for_restart(shutdown, timeout)
+            }
+            RestartMode::Pager => {
+                self.shutdown_existing_pager_worker_for_restart(shutdown, timeout)
+            }
         }
     }
 
     fn shutdown_existing_files_worker_for_restart(
         &mut self,
+        shutdown: RestartShutdown,
         timeout: Duration,
     ) -> RestartShutdownSnapshot {
         let had_process = self.process.is_some();
@@ -90,20 +107,27 @@ impl WorkerManager {
         // more output from an abandoned timed-out request.
         let output = had_process.then(|| self.drain_sealed_formatted_output());
         if let Some(process) = self.process.take() {
-            let _ = process.shutdown_for_restart(timeout);
+            let _ = match shutdown {
+                RestartShutdown::Sideband => process.shutdown_graceful(timeout),
+                RestartShutdown::StdinClose => process.shutdown_for_restart(timeout),
+            };
         }
         RestartShutdownSnapshot::Files { output }
     }
 
     fn shutdown_existing_pager_worker_for_restart(
         &mut self,
+        shutdown: RestartShutdown,
         timeout: Duration,
     ) -> RestartShutdownSnapshot {
         self.output_timeline.seal_utf8_tails();
         // Snapshot before shutdown so late old-session output is discarded at reset.
         let end_offset = self.output.end_offset();
         if let Some(process) = self.process.take() {
-            let _ = process.shutdown_for_restart(timeout);
+            let _ = match shutdown {
+                RestartShutdown::Sideband => process.shutdown_graceful(timeout),
+                RestartShutdown::StdinClose => process.shutdown_for_restart(timeout),
+            };
         }
         RestartShutdownSnapshot::Pager { end_offset }
     }

--- a/src/worker_process/restart.rs
+++ b/src/worker_process/restart.rs
@@ -2,8 +2,8 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use super::{WorkerError, WorkerManager};
-use crate::completion_reply::ReplyWithOffset;
-#[cfg(debug_assertions)]
+use crate::completion_reply::{PagerCompletionPrompt, ReplyWithOffset};
+#[cfg(any(debug_assertions, test))]
 use crate::oversized_output::OversizedOutputMode;
 use crate::pager;
 use crate::pending_output_tape::FormattedPendingOutput;
@@ -146,7 +146,13 @@ impl WorkerManager {
         self.clear_preserved_prefixes();
         match mode {
             RestartMode::Files => self.reset_output_state_files(true),
-            RestartMode::Pager => self.reset_output_state_pager(true, false),
+            RestartMode::Pager => {
+                let preserve_pager = self.pager.is_active();
+                self.reset_output_state_pager(true, preserve_pager);
+                if preserve_pager {
+                    self.pager_prompt = Some(PagerCompletionPrompt::PromptFree);
+                }
+            }
         }
         self.note_respawn_during_write();
     }

--- a/src/worker_process/restart.rs
+++ b/src/worker_process/restart.rs
@@ -20,8 +20,7 @@ enum RestartShutdownSnapshot {
         output: Option<FormattedPendingOutput>,
     },
     Pager {
-        pre_shutdown_end_offset: Option<u64>,
-        post_shutdown_end_offset: Option<u64>,
+        end_offset: Option<u64>,
     },
 }
 
@@ -86,14 +85,11 @@ impl WorkerManager {
         &mut self,
         timeout: Duration,
     ) -> RestartShutdownSnapshot {
-        let output = self
-            .process
-            .is_some()
-            .then(|| self.drain_sealed_formatted_output());
+        let had_process = self.process.is_some();
         if let Some(process) = self.process.take() {
-            let _ = process.shutdown_graceful(timeout);
-            self.pending_output_tape.clear();
+            let _ = process.shutdown_for_restart(timeout);
         }
+        let output = had_process.then(|| self.drain_sealed_formatted_output());
         RestartShutdownSnapshot::Files { output }
     }
 
@@ -102,19 +98,12 @@ impl WorkerManager {
         timeout: Duration,
     ) -> RestartShutdownSnapshot {
         self.output_timeline.seal_utf8_tails();
-        let pre_shutdown_end_offset = self
-            .process
-            .is_some()
-            .then(|| self.output.end_offset().unwrap_or(0));
         if let Some(process) = self.process.take() {
-            let _ = process.shutdown_graceful(timeout);
+            let _ = process.shutdown_for_restart(timeout);
         }
         self.output_timeline.seal_utf8_tails();
-        let post_shutdown_end_offset = self.output.end_offset();
-        RestartShutdownSnapshot::Pager {
-            pre_shutdown_end_offset,
-            post_shutdown_end_offset,
-        }
+        let end_offset = self.output.end_offset();
+        RestartShutdownSnapshot::Pager { end_offset }
     }
 
     fn clear_restart_busy_guardrail(&self) {
@@ -131,29 +120,22 @@ impl WorkerManager {
                     .build_session_reset_reply_files_from_formatted("new session started", output),
                 None => self.build_session_reset_reply_files("new session started"),
             },
-            RestartShutdownSnapshot::Pager {
-                pre_shutdown_end_offset,
-                post_shutdown_end_offset,
-            } => self.build_restart_reply_pager(pre_shutdown_end_offset, post_shutdown_end_offset),
+            RestartShutdownSnapshot::Pager { end_offset } => {
+                self.build_restart_reply_pager(end_offset)
+            }
         }
     }
 
-    fn build_restart_reply_pager(
-        &mut self,
-        pre_shutdown_end_offset: Option<u64>,
-        post_shutdown_end_offset: Option<u64>,
-    ) -> ReplyWithOffset {
+    fn build_restart_reply_pager(&mut self, end_offset: Option<u64>) -> ReplyWithOffset {
         let page_bytes = pager::resolve_page_bytes(None);
-        match pre_shutdown_end_offset {
+        match end_offset {
             Some(end_offset) => {
                 let reply = self.build_session_reset_reply_pager_to_offset(
                     page_bytes,
                     "new session started",
                     end_offset,
                 );
-                if let Some(end_offset) = post_shutdown_end_offset {
-                    self.output.advance_offset_to(end_offset);
-                }
+                self.output.advance_offset_to(end_offset);
                 reply
             }
             None => self.build_session_reset_reply_pager(page_bytes, "new session started"),

--- a/src/worker_process/restart.rs
+++ b/src/worker_process/restart.rs
@@ -60,6 +60,7 @@ impl WorkerManager {
         self.maybe_emit_pending_server_notice();
         let snapshot = self.shutdown_existing_worker_for_restart(mode, shutdown, timeout);
         self.clear_restart_busy_guardrail();
+        self.clear_stale_pager_before_restart_reply(mode);
         let reply = self.build_restart_reply_for_mode(snapshot);
         self.finish_restart_for_mode(mode);
         Self::end_restart_ok();
@@ -132,6 +133,12 @@ impl WorkerManager {
 
     fn clear_restart_busy_guardrail(&self) {
         self.guardrail.busy.store(false, Ordering::Relaxed);
+    }
+
+    fn clear_stale_pager_before_restart_reply(&mut self, mode: RestartMode) {
+        if let RestartMode::Pager = mode {
+            self.pager = pager::Pager::default();
+        }
     }
 
     fn build_restart_reply_for_mode(

--- a/src/worker_process/write_flow.rs
+++ b/src/worker_process/write_flow.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::oversized_output::OversizedOutputMode;
 use crate::pager;
@@ -133,31 +133,34 @@ impl WorkerManager {
         if plan.stage_before_control {
             self.stage_deferred_sandbox_state_update(plan.staged_sandbox_state_update.take())?;
         }
+        let started_at = Instant::now();
+        let worker_deadline = started_at + worker_timeout;
+        let server_deadline = started_at + server_timeout;
 
         let control_reply = match (mode, plan.action, plan.stage_interrupt_after_session_end) {
             (WriteStdinMode::Files, WriteStdinControlAction::Interrupt, true) => {
-                self.interrupt_files(worker_timeout, None, true)
+                self.interrupt_files(remaining_until(worker_deadline), None, true)
             }
             (WriteStdinMode::Files, WriteStdinControlAction::Interrupt, false) => self
                 .interrupt_files(
-                    worker_timeout,
+                    remaining_until(worker_deadline),
                     plan.tail_sandbox_state_update.clone(),
                     options.suppress_session_end_reset,
                 ),
             (WriteStdinMode::Files, WriteStdinControlAction::Restart, _) => {
-                self.restart_files(worker_timeout)
+                self.restart_files(remaining_until(worker_deadline))
             }
             (WriteStdinMode::Pager, WriteStdinControlAction::Interrupt, true) => {
-                self.interrupt_pager(worker_timeout, None, true)
+                self.interrupt_pager(remaining_until(worker_deadline), None, true)
             }
             (WriteStdinMode::Pager, WriteStdinControlAction::Interrupt, false) => self
                 .interrupt_pager(
-                    worker_timeout,
+                    remaining_until(worker_deadline),
                     plan.tail_sandbox_state_update.clone(),
                     options.suppress_session_end_reset,
                 ),
             (WriteStdinMode::Pager, WriteStdinControlAction::Restart, _) => {
-                self.restart_pager(worker_timeout)
+                self.restart_pager(remaining_until(worker_deadline))
             }
         }?;
 
@@ -177,17 +180,19 @@ impl WorkerManager {
 
         let control_prefix_item_count = prefixed_worker_reply_item_count(&control_reply);
         let tail_options = options.control_tail(plan.tail_sandbox_state_update);
+        let tail_worker_timeout = remaining_until(worker_deadline);
+        let tail_server_timeout = remaining_until(server_deadline);
         let remaining_reply = match mode {
             WriteStdinMode::Files => self.write_stdin_files(
                 plan.tail.to_string(),
-                worker_timeout,
-                server_timeout,
+                tail_worker_timeout,
+                tail_server_timeout,
                 tail_options,
             ),
             WriteStdinMode::Pager => self.write_stdin_pager(
                 plan.tail.to_string(),
-                worker_timeout,
-                server_timeout,
+                tail_worker_timeout,
+                tail_server_timeout,
                 tail_options,
             ),
         }?;
@@ -423,6 +428,10 @@ fn prefixed_worker_reply_item_count(prefix: &WorkerReply) -> usize {
     } else {
         contents.len()
     }
+}
+
+fn remaining_until(deadline: Instant) -> Duration {
+    deadline.saturating_duration_since(Instant::now())
 }
 
 #[cfg(test)]

--- a/src/worker_supervisor.rs
+++ b/src/worker_supervisor.rs
@@ -1328,7 +1328,15 @@ impl WorkerProcess {
     pub(crate) fn shutdown_graceful(mut self, timeout: Duration) -> Result<(), WorkerError> {
         self.request_ipc_shutdown();
         let _ = self.close_stdin(Duration::from_millis(200));
+        self.finish_timed_shutdown(timeout)
+    }
 
+    pub(crate) fn shutdown_for_restart(mut self, timeout: Duration) -> Result<(), WorkerError> {
+        let _ = self.close_stdin(Duration::from_millis(200));
+        self.finish_timed_shutdown(timeout)
+    }
+
+    fn finish_timed_shutdown(mut self, timeout: Duration) -> Result<(), WorkerError> {
         let start = std::time::Instant::now();
         let timeout_deadline = start + timeout;
         let term_deadline = start + shutdown_term_delay(timeout);
@@ -2410,6 +2418,9 @@ fn shutdown_term_delay(timeout: Duration) -> Duration {
         return Duration::from_secs(0);
     }
     let by_fraction = timeout.mul_f64(0.75);
+    if timeout <= Duration::from_secs(10) {
+        return by_fraction;
+    }
     let by_remaining = timeout.saturating_sub(Duration::from_secs(10));
     by_fraction.min(by_remaining)
 }

--- a/src/worker_supervisor.rs
+++ b/src/worker_supervisor.rs
@@ -283,6 +283,7 @@ const WORKER_MEM_GUARDRAIL_ACTIVE_INTERVAL: Duration = Duration::from_secs(10);
 const WORKER_MEM_GUARDRAIL_IDLE_INTERVAL: Duration = Duration::from_secs(60);
 
 const WORKER_READY_TIMEOUT: Duration = Duration::from_secs(10);
+const WORKER_RESTART_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(500);
 const WORKER_SESSION_END_RESPAWN_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 #[cfg(target_family = "windows")]
 pub(crate) const WINDOWS_IPC_CONNECT_MAX_WAIT: Duration = Duration::from_secs(10);
@@ -1333,7 +1334,7 @@ impl WorkerProcess {
 
     pub(crate) fn shutdown_for_restart(mut self, timeout: Duration) -> Result<(), WorkerError> {
         let _ = self.close_stdin(Duration::from_millis(200));
-        self.finish_timed_shutdown(timeout)
+        self.finish_timed_shutdown(timeout.min(WORKER_RESTART_SHUTDOWN_TIMEOUT))
     }
 
     fn finish_timed_shutdown(mut self, timeout: Duration) -> Result<(), WorkerError> {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -5,7 +5,9 @@ use std::error::Error;
 use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::process::Stdio;
 use std::sync::Arc;
+use std::sync::Mutex;
 #[cfg(target_os = "macos")]
 use std::sync::OnceLock;
 #[cfg(windows)]
@@ -22,6 +24,7 @@ use rmcp::service::ServiceError;
 use rmcp::transport::{ConfigureCommandExt, TokioChildProcess};
 use serde::Serialize;
 use serde_json::{Value, json};
+use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 #[cfg(windows)]
 use windows_sys::Win32::{
@@ -31,7 +34,46 @@ use windows_sys::Win32::{
 
 pub type TestResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
 
+#[derive(Clone, Default)]
+struct CapturedServerStderr {
+    tail: Arc<Mutex<Vec<u8>>>,
+}
+
+impl CapturedServerStderr {
+    fn start(stderr: Option<tokio::process::ChildStderr>) -> Self {
+        let capture = Self::default();
+        if let Some(mut stderr) = stderr {
+            let capture_for_task = capture.clone();
+            tokio::spawn(async move {
+                let mut buffer = [0_u8; 8192];
+                loop {
+                    match stderr.read(&mut buffer).await {
+                        Ok(0) | Err(_) => return,
+                        Ok(n) => capture_for_task.append(&buffer[..n]),
+                    }
+                }
+            });
+        }
+        capture
+    }
+
+    fn append(&self, bytes: &[u8]) {
+        let mut tail = self.tail.lock().expect("server stderr capture poisoned");
+        tail.extend_from_slice(bytes);
+        if tail.len() > SERVER_STDERR_TAIL_LIMIT {
+            let dropped = tail.len() - SERVER_STDERR_TAIL_LIMIT;
+            tail.drain(..dropped);
+        }
+    }
+
+    fn text(&self) -> String {
+        let tail = self.tail.lock().expect("server stderr capture poisoned");
+        String::from_utf8_lossy(&tail).into_owned()
+    }
+}
+
 const TEST_PAGER_PAGE_CHARS: u64 = 300;
+const SERVER_STDERR_TAIL_LIMIT: usize = 64 * 1024;
 #[cfg(windows)]
 const WINDOWS_TEST_TIMEOUT_CAP_SECS: f64 = 60.0;
 #[cfg(windows)]
@@ -662,11 +704,16 @@ pub struct McpTestSession {
     steps: Vec<SnapshotStep>,
     server_pid: Option<u32>,
     backend: TestBackend,
+    server_stderr: CapturedServerStderr,
 }
 
 impl McpTestSession {
     pub fn server_info(&self) -> Option<Arc<rmcp::model::ServerInfo>> {
         self.service.peer_info()
+    }
+
+    pub fn server_stderr_text(&self) -> String {
+        self.server_stderr.text()
     }
 
     #[allow(dead_code)]
@@ -1515,31 +1562,46 @@ pub async fn spawn_server_with_args_env_and_cwd(
         args.push("danger-full-access".to_string());
     }
     let current_dir = cwd;
-    let transport = TokioChildProcess::new(Command::new(exe).configure(|cmd| {
-        cmd.env_remove("R_PROFILE_USER");
-        cmd.env_remove("R_PROFILE_SITE");
-        cmd.env_remove("R_ENVIRON");
-        cmd.env_remove("R_ENVIRON_USER");
-        cmd.env_remove("MCP_REPL_UPDATE_PLOT_IMAGES");
-        cmd.env("PAGER", "cat");
-        cmd.env("MANPAGER", "cat");
-        if let Some(cwd) = &current_dir {
-            cmd.current_dir(cwd);
-        }
-        cmd.args(&args);
-        for (key, value) in &env_vars {
-            cmd.env(key, value);
-        }
-    }))?;
+    let (transport, server_stderr_handle) =
+        TokioChildProcess::builder(Command::new(exe).configure(|cmd| {
+            cmd.env_remove("R_PROFILE_USER");
+            cmd.env_remove("R_PROFILE_SITE");
+            cmd.env_remove("R_ENVIRON");
+            cmd.env_remove("R_ENVIRON_USER");
+            cmd.env_remove("MCP_REPL_UPDATE_PLOT_IMAGES");
+            cmd.env("PAGER", "cat");
+            cmd.env("MANPAGER", "cat");
+            if let Some(cwd) = &current_dir {
+                cmd.current_dir(cwd);
+            }
+            cmd.args(&args);
+            for (key, value) in &env_vars {
+                cmd.env(key, value);
+            }
+        }))
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let server_stderr = CapturedServerStderr::start(server_stderr_handle);
 
     let server_pid = transport.id();
-    let service = TestClient.serve(transport).await?;
+    let service =
+        TestClient
+            .serve(transport)
+            .await
+            .map_err(|err| -> Box<dyn Error + Send + Sync> {
+                let stderr = server_stderr.text();
+                if stderr.trim().is_empty() {
+                    return Box::new(err);
+                }
+                format!("server initialization failed: {err}\nserver stderr:\n{stderr}").into()
+            })?;
     drop(suite_lock);
     Ok(McpTestSession {
         service,
         steps: Vec::new(),
         server_pid,
         backend,
+        server_stderr,
     })
 }
 

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -95,12 +95,14 @@ fn run_worker(
         })?;
         append_control_log(control_log_path.as_deref(), "input_wait")?;
     }
-    if std::env::var_os(STALL_CONTROL_READER_ENV).is_some() {
+    if let Some(stall_millis) = std::env::var_os(STALL_CONTROL_READER_ENV) {
+        let stall_millis = stall_millis.to_string_lossy().parse::<u64>()?;
         let _sideband_reader = sideband_reader;
         let _turn_tx = tx;
-        loop {
-            thread::park();
-        }
+        append_control_log(control_log_path.as_deref(), "control_reader_stalled")?;
+        thread::sleep(Duration::from_millis(stall_millis));
+        append_control_log(control_log_path.as_deref(), "control_reader_stall_elapsed")?;
+        return Ok(());
     }
 
     start_control_reader(

--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -29,6 +29,7 @@ const STARTUP_PROTOCOL_ERROR_ENV: &str = "MCP_REPL_ZOD_STARTUP_PROTOCOL_ERROR";
 const STARTUP_READY_ENV: &str = "MCP_REPL_ZOD_STARTUP_READY";
 const CONTROL_LOG_ENV: &str = "MCP_REPL_ZOD_CONTROL_LOG";
 const LATE_RAW_MARKER_ENV: &str = "MCP_REPL_ZOD_LATE_RAW_MARKER";
+const LATE_STDERR_MARKER_ENV: &str = "MCP_REPL_ZOD_LATE_STDERR_MARKER";
 const LATE_SIDEBAND_MARKER_ENV: &str = "MCP_REPL_ZOD_LATE_SIDEBAND_MARKER";
 const STALL_CONTROL_READER_ENV: &str = "MCP_REPL_ZOD_STALL_CONTROL_READER";
 const DELAY_READY_AFTER_INTERRUPT_ENV: &str = "MCP_REPL_ZOD_DELAY_READY_AFTER_INTERRUPT_MS";
@@ -258,13 +259,20 @@ fn run_command(
     }
 
     if command == "partial-stderr-utf8-then-late-stderr-after-completion" {
+        let late_stderr_marker = std::env::var_os(LATE_STDERR_MARKER_ENV)
+            .map(PathBuf::from)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, LATE_STDERR_MARKER_ENV))?;
         output_stderr_text_with_continuation(writer, control_log_path, &[0xC3], false)?;
         state.ready_after_turn = true;
         let writer = writer.clone();
         let control_log_path = control_log_path.clone();
         thread::spawn(move || {
-            thread::sleep(Duration::from_millis(950));
+            let _ = append_control_log(control_log_path.as_deref(), "waiting_late_stderr_marker");
+            if wait_for_marker_path(&late_stderr_marker).is_err() {
+                return;
+            }
             let _ = output_stderr_text(&writer, &control_log_path, b"after\n");
+            let _ = append_control_log(control_log_path.as_deref(), "late_stderr_after_completion");
         });
         return Ok(false);
     }
@@ -940,6 +948,10 @@ fn wait_for_marker(env_name: &str) -> io::Result<()> {
     let marker = std::env::var_os(env_name)
         .map(PathBuf::from)
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, env_name))?;
+    wait_for_marker_path(&marker)
+}
+
+fn wait_for_marker_path(marker: &Path) -> io::Result<()> {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         if marker.exists() {

--- a/tests/manage_session_behavior.rs
+++ b/tests/manage_session_behavior.rs
@@ -160,18 +160,28 @@ async fn pager_restart_drops_output_captured_during_shutdown() -> TestResult<()>
     let session = common::spawn_server_with_pager_page_chars(120).await?;
 
     let input = r#"
-Sys.sleep(0.15)
+cat("WAITING_FOR_RESTART_EOF\n")
+flush.console()
+suppressWarnings(invisible(readLines("stdin", n = 1)))
 for (i in 1:80) cat(sprintf("RESTART_LINE_%03d\n", i))
 flush.console()
 Sys.sleep(1.0)
 "#;
-    let timeout = session.write_stdin_raw_with(input, Some(0.05)).await?;
+    let timeout = session.write_stdin_raw_with(input, Some(0.5)).await?;
     let timeout_text = result_text(&timeout);
     if backend_unavailable(&timeout_text) {
         eprintln!("pager restart test backend unavailable in this environment; skipping");
         session.cancel().await?;
         return Ok(());
     }
+    assert!(
+        timeout_text.contains("WAITING_FOR_RESTART_EOF"),
+        "expected request to block on stdin before restart, got: {timeout_text:?}"
+    );
+    assert!(
+        !timeout_text.contains("RESTART_LINE_"),
+        "did not expect restart-only output before Ctrl-D closes stdin, got: {timeout_text:?}"
+    );
 
     let restart = session
         .write_stdin_raw_unterminated_with("\u{4}", Some(0.8))
@@ -210,14 +220,16 @@ async fn restart_while_busy_drops_output_captured_during_shutdown() -> TestResul
     let session = spawn_manage_session().await?;
 
     let input = r#"
-Sys.sleep(0.15)
+cat("WAITING_FOR_RESTART_EOF\n")
+flush.console()
+suppressWarnings(invisible(readLines("stdin", n = 1)))
 cat("DURING_RESTART\n")
 flush.console()
 Sys.sleep(1.0)
 cat("TOO_LATE\n")
 flush.console()
 "#;
-    let timeout = session.write_stdin_raw_with(input, Some(0.05)).await?;
+    let timeout = session.write_stdin_raw_with(input, Some(0.5)).await?;
     let timeout_text = result_text(&timeout);
     if backend_unavailable(&timeout_text) {
         eprintln!(
@@ -226,6 +238,14 @@ flush.console()
         session.cancel().await?;
         return Ok(());
     }
+    assert!(
+        timeout_text.contains("WAITING_FOR_RESTART_EOF"),
+        "expected request to block on stdin before restart, got: {timeout_text:?}"
+    );
+    assert!(
+        !timeout_text.contains("DURING_RESTART"),
+        "did not expect restart-only output before Ctrl-D closes stdin, got: {timeout_text:?}"
+    );
 
     let restart = session
         .write_stdin_raw_unterminated_with("\u{4}", Some(0.8))

--- a/tests/manage_session_behavior.rs
+++ b/tests/manage_session_behavior.rs
@@ -153,3 +153,54 @@ async fn restart_while_busy_resets_session() -> TestResult<()> {
     );
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restart_while_busy_returns_output_captured_during_graceful_shutdown() -> TestResult<()> {
+    let _guard = lock_test_mutex();
+    let session = spawn_manage_session().await?;
+
+    let input = r#"
+Sys.sleep(0.15)
+cat("DURING_RESTART\n")
+flush.console()
+Sys.sleep(1.0)
+cat("TOO_LATE\n")
+flush.console()
+"#;
+    let timeout = session.write_stdin_raw_with(input, Some(0.05)).await?;
+    let timeout_text = result_text(&timeout);
+    if backend_unavailable(&timeout_text) {
+        eprintln!(
+            "restart graceful shutdown test backend unavailable in this environment; skipping"
+        );
+        session.cancel().await?;
+        return Ok(());
+    }
+
+    let restart = session
+        .write_stdin_raw_unterminated_with("\u{4}", Some(0.8))
+        .await?;
+    let restart_text = result_text(&restart);
+    if backend_unavailable(&restart_text) {
+        eprintln!(
+            "restart graceful shutdown test backend unavailable in this environment; skipping"
+        );
+        session.cancel().await?;
+        return Ok(());
+    }
+    session.cancel().await?;
+
+    assert!(
+        restart_text.contains("DURING_RESTART"),
+        "expected restart to return output captured during graceful shutdown, got: {restart_text:?}"
+    );
+    assert!(
+        !restart_text.contains("TOO_LATE"),
+        "did not expect restart to wait for later output after the graceful window, got: {restart_text:?}"
+    );
+    assert!(
+        restart_text.contains("new session started"),
+        "expected restart notice, got: {restart_text:?}"
+    );
+    Ok(())
+}

--- a/tests/manage_session_behavior.rs
+++ b/tests/manage_session_behavior.rs
@@ -156,6 +156,39 @@ async fn restart_while_busy_resets_session() -> TestResult<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn restart_while_busy_not_reading_stdin_returns_promptly() -> TestResult<()> {
+    let _guard = lock_test_mutex();
+    let session = spawn_manage_session().await?;
+
+    let _ = session
+        .write_stdin_raw_with("x <- 1; Sys.sleep(30)", Some(0.1))
+        .await?;
+
+    let start = Instant::now();
+    let restart = session
+        .write_stdin_raw_unterminated_with("\u{4}", Some(3.0))
+        .await?;
+    let elapsed = start.elapsed();
+    let restart_text = result_text(&restart);
+    if backend_unavailable(&restart_text) {
+        eprintln!("prompt restart test backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    session.cancel().await?;
+
+    assert!(
+        restart_text.contains("new session started"),
+        "expected restart notice, got: {restart_text:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "expected busy restart to return promptly, elapsed={elapsed:?}, got: {restart_text:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn pager_restart_drops_output_captured_during_shutdown() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = common::spawn_server_with_pager_page_chars(120).await?;

--- a/tests/manage_session_behavior.rs
+++ b/tests/manage_session_behavior.rs
@@ -378,6 +378,60 @@ flush.console()
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn restart_tail_output_is_included_in_same_response() -> TestResult<()> {
+    let _guard = lock_test_mutex();
+    let session = spawn_manage_session().await?;
+
+    let input = r#"
+cat("WAITING_FOR_RESTART_EOF\n")
+flush.console()
+suppressWarnings(invisible(readLines("stdin", n = 1)))
+cat("DURING_RESTART\n")
+flush.console()
+"#;
+    let timeout = session.write_stdin_raw_with(input, Some(0.5)).await?;
+    let timeout_text = result_text(&timeout);
+    if backend_unavailable(&timeout_text) {
+        eprintln!("restart tail response test backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert!(
+        timeout_text.contains("WAITING_FOR_RESTART_EOF"),
+        "expected request to block on stdin before restart, got: {timeout_text:?}"
+    );
+
+    let restart = session
+        .write_stdin_raw_unterminated_with("\u{4}cat(\"TAIL_DONE\\n\"); flush.console()", Some(5.0))
+        .await?;
+    let restart_text = result_text(&restart);
+    if backend_unavailable(&restart_text) {
+        eprintln!("restart tail response test backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    session.cancel().await?;
+
+    assert!(
+        restart_text.contains("DURING_RESTART"),
+        "expected restart reply to include output captured before tail input, got: {restart_text:?}"
+    );
+    assert!(
+        restart_text.contains("new session started"),
+        "expected restart reply to include the fresh-session notice, got: {restart_text:?}"
+    );
+    assert!(
+        restart_text.contains("TAIL_DONE"),
+        "expected Ctrl-D tail output in the same response, got: {restart_text:?}"
+    );
+    assert!(
+        !restart_text.contains("<<repl status: busy"),
+        "did not expect the completed Ctrl-D tail to require a follow-up poll, got: {restart_text:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn restart_tail_uses_remaining_timeout_budget() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = spawn_manage_session().await?;

--- a/tests/manage_session_behavior.rs
+++ b/tests/manage_session_behavior.rs
@@ -155,7 +155,7 @@ async fn restart_while_busy_resets_session() -> TestResult<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn pager_restart_output_can_be_drained_after_restart_reply() -> TestResult<()> {
+async fn pager_restart_drops_output_captured_during_shutdown() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = common::spawn_server_with_pager_page_chars(120).await?;
 
@@ -183,8 +183,12 @@ Sys.sleep(1.0)
         return Ok(());
     }
     assert!(
-        restart_text.contains("--More--"),
-        "expected restart reply to advertise additional pager output, got: {restart_text:?}"
+        restart_text.contains("new session started"),
+        "expected restart notice, got: {restart_text:?}"
+    );
+    assert!(
+        !restart_text.contains("RESTART_LINE_"),
+        "did not expect restart reply to wait for pager output produced during shutdown, got: {restart_text:?}"
     );
 
     let next = session
@@ -194,18 +198,14 @@ Sys.sleep(1.0)
     session.cancel().await?;
 
     assert!(
-        next_text.contains("RESTART_LINE_"),
-        "expected follow-up poll to drain restart pager output, got: {next_text:?}"
-    );
-    assert!(
-        next_text.contains("--More--") || next_text.contains("(END"),
-        "expected follow-up poll to use pager state, got: {next_text:?}"
+        !next_text.contains("RESTART_LINE_"),
+        "did not expect shutdown-time pager output to leak into the next reply, got: {next_text:?}"
     );
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn restart_while_busy_returns_output_captured_during_graceful_shutdown() -> TestResult<()> {
+async fn restart_while_busy_drops_output_captured_during_shutdown() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = spawn_manage_session().await?;
 
@@ -241,12 +241,12 @@ flush.console()
     session.cancel().await?;
 
     assert!(
-        restart_text.contains("DURING_RESTART"),
-        "expected restart to return output captured during graceful shutdown, got: {restart_text:?}"
+        !restart_text.contains("DURING_RESTART"),
+        "did not expect restart to wait for output produced during shutdown, got: {restart_text:?}"
     );
     assert!(
         !restart_text.contains("TOO_LATE"),
-        "did not expect restart to wait for later output after the graceful window, got: {restart_text:?}"
+        "did not expect restart to include later old-session output, got: {restart_text:?}"
     );
     assert!(
         restart_text.contains("new session started"),

--- a/tests/manage_session_behavior.rs
+++ b/tests/manage_session_behavior.rs
@@ -189,7 +189,7 @@ async fn restart_while_busy_not_reading_stdin_returns_promptly() -> TestResult<(
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn pager_restart_drops_output_captured_during_shutdown() -> TestResult<()> {
+async fn pager_restart_preserves_output_captured_during_shutdown() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = common::spawn_server_with_pager_page_chars(120).await?;
 
@@ -231,8 +231,12 @@ Sys.sleep(1.0)
         "expected restart notice, got: {restart_text:?}"
     );
     assert!(
-        !restart_text.contains("RESTART_LINE_"),
-        "did not expect restart reply to wait for pager output produced during shutdown, got: {restart_text:?}"
+        restart_text.contains("RESTART_LINE_"),
+        "expected restart reply to include pager output produced during shutdown, got: {restart_text:?}"
+    );
+    assert!(
+        restart_text.contains("--More--"),
+        "expected restart reply to preserve pager state for shutdown output, got: {restart_text:?}"
     );
 
     let next = session
@@ -242,8 +246,8 @@ Sys.sleep(1.0)
     session.cancel().await?;
 
     assert!(
-        !next_text.contains("RESTART_LINE_"),
-        "did not expect shutdown-time pager output to leak into the next reply, got: {next_text:?}"
+        next_text.contains("RESTART_LINE_"),
+        "expected follow-up poll to drain restart pager output, got: {next_text:?}"
     );
     Ok(())
 }
@@ -313,7 +317,7 @@ async fn repl_reset_clears_active_pager_when_reply_has_no_overflow() -> TestResu
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn restart_while_busy_drops_output_captured_during_shutdown() -> TestResult<()> {
+async fn restart_while_busy_returns_output_captured_during_shutdown() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = spawn_manage_session().await?;
 
@@ -359,8 +363,8 @@ flush.console()
     session.cancel().await?;
 
     assert!(
-        !restart_text.contains("DURING_RESTART"),
-        "did not expect restart to wait for output produced during shutdown, got: {restart_text:?}"
+        restart_text.contains("DURING_RESTART"),
+        "expected restart to return output produced during shutdown, got: {restart_text:?}"
     );
     assert!(
         !restart_text.contains("TOO_LATE"),
@@ -369,6 +373,60 @@ flush.console()
     assert!(
         restart_text.contains("new session started"),
         "expected restart notice, got: {restart_text:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restart_tail_uses_remaining_timeout_budget() -> TestResult<()> {
+    let _guard = lock_test_mutex();
+    let session = spawn_manage_session().await?;
+
+    let input = r#"
+cat("WAITING_FOR_RESTART_EOF\n")
+flush.console()
+suppressWarnings(invisible(readLines("stdin", n = 1)))
+cat("DURING_RESTART\n")
+flush.console()
+Sys.sleep(1.0)
+"#;
+    let timeout = session.write_stdin_raw_with(input, Some(0.5)).await?;
+    let timeout_text = result_text(&timeout);
+    if backend_unavailable(&timeout_text) {
+        eprintln!("restart tail timeout test backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert!(
+        timeout_text.contains("WAITING_FOR_RESTART_EOF"),
+        "expected request to block on stdin before restart, got: {timeout_text:?}"
+    );
+
+    let restart = session
+        .write_stdin_raw_unterminated_with(
+            "\u{4}Sys.sleep(0.45); cat(\"TAIL_DONE\\n\"); flush.console()",
+            Some(0.7),
+        )
+        .await?;
+    let restart_text = result_text(&restart);
+    if backend_unavailable(&restart_text) {
+        eprintln!("restart tail timeout test backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    session.cancel().await?;
+
+    assert!(
+        restart_text.contains("DURING_RESTART"),
+        "expected restart reply to include output captured before tail input, got: {restart_text:?}"
+    );
+    assert!(
+        restart_text.contains("<<repl status: busy"),
+        "expected tail input to time out against the original Ctrl-D call budget, got: {restart_text:?}"
+    );
+    assert!(
+        !restart_text.contains("TAIL_DONE"),
+        "did not expect tail input to receive a fresh timeout budget, got: {restart_text:?}"
     );
     Ok(())
 }

--- a/tests/manage_session_behavior.rs
+++ b/tests/manage_session_behavior.rs
@@ -155,6 +155,56 @@ async fn restart_while_busy_resets_session() -> TestResult<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn pager_restart_output_can_be_drained_after_restart_reply() -> TestResult<()> {
+    let _guard = lock_test_mutex();
+    let session = common::spawn_server_with_pager_page_chars(120).await?;
+
+    let input = r#"
+Sys.sleep(0.15)
+for (i in 1:80) cat(sprintf("RESTART_LINE_%03d\n", i))
+flush.console()
+Sys.sleep(1.0)
+"#;
+    let timeout = session.write_stdin_raw_with(input, Some(0.05)).await?;
+    let timeout_text = result_text(&timeout);
+    if backend_unavailable(&timeout_text) {
+        eprintln!("pager restart test backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+
+    let restart = session
+        .write_stdin_raw_unterminated_with("\u{4}", Some(0.8))
+        .await?;
+    let restart_text = result_text(&restart);
+    if backend_unavailable(&restart_text) {
+        eprintln!("pager restart test backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert!(
+        restart_text.contains("--More--"),
+        "expected restart reply to advertise additional pager output, got: {restart_text:?}"
+    );
+
+    let next = session
+        .write_stdin_raw_unterminated_with("", Some(2.0))
+        .await?;
+    let next_text = result_text(&next);
+    session.cancel().await?;
+
+    assert!(
+        next_text.contains("RESTART_LINE_"),
+        "expected follow-up poll to drain restart pager output, got: {next_text:?}"
+    );
+    assert!(
+        next_text.contains("--More--") || next_text.contains("(END"),
+        "expected follow-up poll to use pager state, got: {next_text:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn restart_while_busy_returns_output_captured_during_graceful_shutdown() -> TestResult<()> {
     let _guard = lock_test_mutex();
     let session = spawn_manage_session().await?;

--- a/tests/manage_session_behavior.rs
+++ b/tests/manage_session_behavior.rs
@@ -4,6 +4,7 @@ mod common;
 
 use common::TestResult;
 use rmcp::model::RawContent;
+use serde_json::json;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use tokio::time::{Duration, Instant, sleep};
 
@@ -210,6 +211,70 @@ Sys.sleep(1.0)
     assert!(
         !next_text.contains("RESTART_LINE_"),
         "did not expect shutdown-time pager output to leak into the next reply, got: {next_text:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn repl_reset_clears_active_pager_when_reply_has_no_overflow() -> TestResult<()> {
+    let _guard = lock_test_mutex();
+    let mut session = common::spawn_server_with_pager_page_chars(120).await?;
+
+    let initial = session
+        .write_stdin_raw_with(
+            "for (i in 1:80) cat(sprintf(\"STALE_PAGER_%03d\\n\", i))",
+            Some(30.0),
+        )
+        .await?;
+    let initial = common::wait_until_not_busy(
+        &mut session,
+        initial,
+        Duration::from_millis(100),
+        Duration::from_secs(60),
+    )
+    .await?;
+    let initial_text = result_text(&initial);
+    if backend_unavailable(&initial_text) {
+        eprintln!("pager reset test backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert!(
+        initial_text.contains("STALE_PAGER_"),
+        "expected initial reply to include stale-marker output, got: {initial_text:?}"
+    );
+    assert!(
+        initial_text.contains("--More--"),
+        "expected initial reply to activate pager, got: {initial_text:?}"
+    );
+
+    let reset = session.call_tool_raw("repl_reset", json!({})).await?;
+    let reset_text = result_text(&reset);
+    if backend_unavailable(&reset_text) {
+        eprintln!("pager reset test backend unavailable in this environment; skipping");
+        session.cancel().await?;
+        return Ok(());
+    }
+    assert!(
+        reset_text.contains("new session started"),
+        "expected reset notice, got: {reset_text:?}"
+    );
+    assert!(
+        !reset_text.contains("STALE_PAGER_"),
+        "did not expect stale pager output in reset reply, got: {reset_text:?}"
+    );
+
+    let next = session.write_stdin_raw_with(":next", Some(5.0)).await?;
+    let next_text = result_text(&next);
+    session.cancel().await?;
+
+    assert!(
+        !next_text.contains("STALE_PAGER_"),
+        "did not expect stale pager output after reset, got: {next_text:?}"
+    );
+    assert!(
+        !next_text.contains("--More--"),
+        "did not expect :next to keep controlling a pre-reset pager, got: {next_text:?}"
     );
     Ok(())
 }

--- a/tests/mcp_transcripts.rs
+++ b/tests/mcp_transcripts.rs
@@ -13,7 +13,7 @@ async fn snapshots_support_multiple_calls_and_sessions() -> TestResult<()> {
             mcp_script! {
                 write_stdin("x <- 40 + 2", timeout = 10.0);
                 write_stdin("x", timeout = 10.0);
-                write_stdin_raw_unterminated("\u{4}");
+                write_stdin_raw_unterminated("\u{4}", timeout = 5.0);
             },
         )
         .await?;
@@ -175,9 +175,9 @@ cat("TEMPDIR_UNDER_TMPDIR=", startsWith(tempdir(), Sys.getenv("TMPDIR")), "\n", 
             "tempdir_session",
             mcp_script! {
                 write_stdin(setup, timeout = 10.0);
-                write_stdin_raw_unterminated("\u{4}");
+                write_stdin_raw_unterminated("\u{4}", timeout = 5.0);
                 write_stdin(after_restart, timeout = 10.0);
-                write_stdin_raw_unterminated("\u{4}");
+                write_stdin_raw_unterminated("\u{4}", timeout = 5.0);
                 write_stdin(after_restart, timeout = 10.0);
             },
         )

--- a/tests/plot_images.rs
+++ b/tests/plot_images.rs
@@ -341,7 +341,7 @@ fn reference_image_script_lines(name: &str) -> Option<Vec<&'static str>> {
         r#"grDevices::png(filename = Sys.getenv("MCP_REPL_TEST_PNG_DEST"), width = 800, height = 600, res = 96)"#,
     ];
     lines.extend(plot_lines);
-    lines.push("grDevices::dev.off()");
+    lines.push("invisible(grDevices::dev.off())");
     Some(lines)
 }
 
@@ -1062,7 +1062,7 @@ async fn plot_size_option_changes_preserve_par_on_reopened_managed_device() -> T
 async fn plot_size_changes_do_not_resize_user_opened_device() -> TestResult<()> {
     let session = spawn_server_with_files().await?;
 
-    let setup_input = r#"options(console.plot.width = 4, console.plot.height = 3, console.plot.dpi = 100); plot(1:10); grDevices::dev.off()"#;
+    let setup_input = r#"options(console.plot.width = 4, console.plot.height = 3, console.plot.dpi = 100); plot(1:10); invisible(grDevices::dev.off())"#;
     let setup_result = session
         .write_stdin_raw_with(setup_input, Some(30.0))
         .await?;
@@ -1078,7 +1078,7 @@ async fn plot_size_changes_do_not_resize_user_opened_device() -> TestResult<()> 
         result_text(&setup_result)
     );
 
-    let input = r#"path <- tempfile(fileext = ".png"); options(console.plot.width = 6, console.plot.height = 2, console.plot.dpi = 100); grDevices::png(path, width = 5, height = 4, units = "in", res = 100); plot(1:10); size <- dev.size("in"); cat(sprintf("mcp-repl-user-device-size %.1f %.1f\n", size[[1]], size[[2]])); grDevices::dev.off(); unlink(path)"#;
+    let input = r#"path <- tempfile(fileext = ".png"); options(console.plot.width = 6, console.plot.height = 2, console.plot.dpi = 100); grDevices::png(path, width = 5, height = 4, units = "in", res = 100); plot(1:10); size <- dev.size("in"); cat(sprintf("mcp-repl-user-device-size %.1f %.1f\n", size[[1]], size[[2]])); invisible(grDevices::dev.off()); unlink(path)"#;
     let result = session.write_stdin_raw_with(input, Some(30.0)).await?;
     if any_backend_unavailable(&[&result]) {
         eprintln!("plot_images backend unavailable in this environment; skipping");

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -41,6 +41,34 @@ fn result_text(result: &rmcp::model::CallToolResult) -> String {
         .join("")
 }
 
+fn path_json_literal(path: &Path, label: &str) -> TestResult<String> {
+    let path = path
+        .to_str()
+        .ok_or_else(|| format!("{label} path must be valid utf-8"))?;
+    Ok(serde_json::to_string(path)?)
+}
+
+async fn poll_until_contains(
+    session: &common::McpTestSession,
+    mut text: String,
+    expected: &str,
+    context: &str,
+    timeout: Duration,
+) -> TestResult<String> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline && !text.contains(expected) {
+        sleep(Duration::from_millis(50)).await;
+        let poll = session
+            .write_stdin_raw_unterminated_with("", Some(1.0))
+            .await?;
+        text.push_str(&result_text(&poll));
+    }
+    if !text.contains(expected) {
+        return Err(format!("expected {context}, got: {text:?}").into());
+    }
+    Ok(text)
+}
+
 fn bundle_transcript_path(text: &str) -> Option<PathBuf> {
     let end = text
         .find("transcript.txt")?
@@ -2086,18 +2114,25 @@ async fn python_detached_raw_stdin_read_followup_completes() -> TestResult<()> {
     let Some(session) = start_python_session().await? else {
         return Ok(());
     };
+    let temp_dir = tempdir()?;
+    let release_path = temp_dir.path().join("release-detached-raw-reader");
+    let release_path_literal = path_json_literal(&release_path, "raw reader release")?;
 
     let first = session
         .write_stdin_raw_with(
-            r#"import os, threading, time
+            format!(
+                r#"import os, pathlib, threading, time
+release_path = pathlib.Path({release_path_literal})
 def read_later():
-    time.sleep(0.2)
+    while not release_path.exists():
+        time.sleep(0.01)
     print("DETACHED_RAW_THREAD_WAITING", flush=True)
     data = os.read(0, 5)
     print("DETACHED_RAW_THREAD_READ", data.decode("utf-8"), flush=True)
 threading.Thread(target=read_later, daemon=True).start()
 print("DETACHED_RAW_MAIN_DONE", flush=True)
-"#,
+"#
+            ),
             Some(5.0),
         )
         .await?;
@@ -2106,20 +2141,20 @@ print("DETACHED_RAW_MAIN_DONE", flush=True)
         first_text.contains("DETACHED_RAW_MAIN_DONE"),
         "expected main cell to finish before detached raw stdin read, got: {first_text:?}"
     );
-
-    let wait_deadline = Instant::now() + Duration::from_secs(5);
-    let mut wait_text = String::new();
-    while Instant::now() < wait_deadline && !wait_text.contains("DETACHED_RAW_THREAD_WAITING") {
-        sleep(Duration::from_millis(50)).await;
-        let poll = session
-            .write_stdin_raw_unterminated_with("", Some(1.0))
-            .await?;
-        wait_text.push_str(&result_text(&poll));
-    }
     assert!(
-        wait_text.contains("DETACHED_RAW_THREAD_WAITING"),
-        "expected detached raw stdin reader to start before follow-up input, got: {wait_text:?}"
+        !first_text.contains("DETACHED_RAW_THREAD_WAITING"),
+        "detached raw stdin read should wait for the explicit release gate, got: {first_text:?}"
     );
+
+    fs::write(&release_path, "go")?;
+    let _wait_text = poll_until_contains(
+        &session,
+        String::new(),
+        "DETACHED_RAW_THREAD_WAITING",
+        "detached raw stdin reader to start before follow-up input",
+        Duration::from_secs(5),
+    )
+    .await?;
 
     let second = tokio::time::timeout(
         Duration::from_secs(3),
@@ -2163,19 +2198,26 @@ async fn python_detached_raw_stdin_reads_consume_one_answer_turn() -> TestResult
     let Some(session) = start_python_session().await? else {
         return Ok(());
     };
+    let temp_dir = tempdir()?;
+    let release_path = temp_dir.path().join("release-detached-raw-pair-reader");
+    let release_path_literal = path_json_literal(&release_path, "raw pair reader release")?;
 
     let first = session
         .write_stdin_raw_with(
-            r#"import os, threading, time
+            format!(
+                r#"import os, pathlib, threading, time
+release_path = pathlib.Path({release_path_literal})
 def read_later():
-    time.sleep(0.2)
+    while not release_path.exists():
+        time.sleep(0.01)
     print("DETACHED_RAW_PAIR_WAITING", flush=True)
     first = os.read(0, 2)
     second = os.read(0, 2)
     print("DETACHED_RAW_PAIR_READ", first.decode("utf-8"), second.decode("utf-8"), flush=True)
 threading.Thread(target=read_later, daemon=True).start()
 print("DETACHED_RAW_PAIR_MAIN_DONE", flush=True)
-"#,
+"#
+            ),
             Some(5.0),
         )
         .await?;
@@ -2184,20 +2226,20 @@ print("DETACHED_RAW_PAIR_MAIN_DONE", flush=True)
         first_text.contains("DETACHED_RAW_PAIR_MAIN_DONE"),
         "expected main cell to finish before detached raw stdin reads, got: {first_text:?}"
     );
-
-    let wait_deadline = Instant::now() + Duration::from_secs(5);
-    let mut wait_text = String::new();
-    while Instant::now() < wait_deadline && !wait_text.contains("DETACHED_RAW_PAIR_WAITING") {
-        sleep(Duration::from_millis(50)).await;
-        let poll = session
-            .write_stdin_raw_unterminated_with("", Some(1.0))
-            .await?;
-        wait_text.push_str(&result_text(&poll));
-    }
     assert!(
-        wait_text.contains("DETACHED_RAW_PAIR_WAITING"),
-        "expected detached raw stdin reader to start before follow-up input, got: {wait_text:?}"
+        !first_text.contains("DETACHED_RAW_PAIR_WAITING"),
+        "detached raw stdin pair should wait for the explicit release gate, got: {first_text:?}"
     );
+
+    fs::write(&release_path, "go")?;
+    let _wait_text = poll_until_contains(
+        &session,
+        String::new(),
+        "DETACHED_RAW_PAIR_WAITING",
+        "detached raw stdin reader to start before follow-up input",
+        Duration::from_secs(5),
+    )
+    .await?;
 
     let answer = session
         .write_stdin_raw_unterminated_with("abcd", Some(1.0))
@@ -6130,11 +6172,18 @@ async fn python_background_input_after_cell_return_completes_answer_turn() -> Te
     let Some(session) = start_python_session().await? else {
         return Ok(());
     };
+    let temp_dir = tempdir()?;
+    let release_path = temp_dir
+        .path()
+        .join("release-background-input-after-cell-return");
+    let release_path_literal = path_json_literal(&release_path, "background input release")?;
 
     let result = session
         .write_stdin_raw_with(
-            r#"
-import threading, time
+            format!(
+                r#"
+import pathlib, threading, time
+release_path = pathlib.Path({release_path_literal})
 background_answer = None
 background_waiting = threading.Event()
 
@@ -6146,9 +6195,11 @@ def background():
 
 threading.Thread(target=background, daemon=True).start()
 background_waiting.wait()
-time.sleep(0.2)
+while not release_path.exists():
+    time.sleep(0.01)
 print('CELL_RETURNED')
-"#,
+"#
+            ),
             Some(5.0),
         )
         .await?;
@@ -6162,19 +6213,15 @@ print('CELL_RETURNED')
         "expected background input prompt, got: {setup_text:?}"
     );
 
-    let mut settled_text = setup_text.clone();
-    let settle_deadline = Instant::now() + Duration::from_secs(5);
-    while Instant::now() < settle_deadline && !settled_text.contains("CELL_RETURNED") {
-        sleep(Duration::from_millis(50)).await;
-        let poll = session
-            .write_stdin_raw_unterminated_with("", Some(1.0))
-            .await?;
-        settled_text.push_str(&result_text(&poll));
-    }
-    assert!(
-        settled_text.contains("CELL_RETURNED"),
-        "expected foreground cell to return while background input stayed live, got: {settled_text:?}"
-    );
+    fs::write(&release_path, "go")?;
+    let settled_text = poll_until_contains(
+        &session,
+        setup_text.clone(),
+        "CELL_RETURNED",
+        "foreground cell to return while background input stayed live",
+        Duration::from_secs(5),
+    )
+    .await?;
     assert!(
         settled_text.contains("bg> "),
         "expected background input prompt to remain visible after foreground cell return, got: {settled_text:?}"
@@ -6201,11 +6248,19 @@ async fn python_background_input_consumes_buffered_lines_from_one_answer_turn() 
     let Some(session) = start_python_session().await? else {
         return Ok(());
     };
+    let temp_dir = tempdir()?;
+    let release_path = temp_dir
+        .path()
+        .join("release-background-input-buffered-lines");
+    let release_path_literal =
+        path_json_literal(&release_path, "background buffered input release")?;
 
     let result = session
         .write_stdin_raw_with(
-            r#"
-import threading, time
+            format!(
+                r#"
+import pathlib, threading, time
+release_path = pathlib.Path({release_path_literal})
 background_waiting = threading.Event()
 
 def background():
@@ -6216,9 +6271,11 @@ def background():
 
 threading.Thread(target=background, daemon=True).start()
 background_waiting.wait()
-time.sleep(0.2)
+while not release_path.exists():
+    time.sleep(0.01)
 print('CELL_RETURNED')
-"#,
+"#
+            ),
             Some(5.0),
         )
         .await?;
@@ -6232,7 +6289,15 @@ print('CELL_RETURNED')
         "expected first background input prompt, got: {setup_text:?}"
     );
 
-    sleep(Duration::from_millis(500)).await;
+    fs::write(&release_path, "go")?;
+    let _settled_text = poll_until_contains(
+        &session,
+        setup_text,
+        "CELL_RETURNED",
+        "foreground cell to return before the buffered answer turn",
+        Duration::from_secs(5),
+    )
+    .await?;
 
     let answer = session.write_stdin_raw_with("one\ntwo", Some(1.0)).await?;
     let mut answer_text = result_text(&answer);
@@ -6259,11 +6324,19 @@ async fn python_background_input_discards_extra_answer_lines_before_next_cell() 
     let Some(session) = start_python_session().await? else {
         return Ok(());
     };
+    let temp_dir = tempdir()?;
+    let release_path = temp_dir
+        .path()
+        .join("release-background-input-discard-extra");
+    let release_path_literal =
+        path_json_literal(&release_path, "background input discard release")?;
 
     let result = session
         .write_stdin_raw_with(
-            r#"
-import threading, time
+            format!(
+                r#"
+import pathlib, threading, time
+release_path = pathlib.Path({release_path_literal})
 background_waiting = threading.Event()
 
 def background():
@@ -6273,9 +6346,11 @@ def background():
 
 threading.Thread(target=background, daemon=True).start()
 background_waiting.wait()
-time.sleep(0.2)
+while not release_path.exists():
+    time.sleep(0.01)
 print('CELL_RETURNED')
-"#,
+"#
+            ),
             Some(5.0),
         )
         .await?;
@@ -6289,7 +6364,15 @@ print('CELL_RETURNED')
         "expected background input prompt, got: {setup_text:?}"
     );
 
-    sleep(Duration::from_millis(500)).await;
+    fs::write(&release_path, "go")?;
+    let _settled_text = poll_until_contains(
+        &session,
+        setup_text,
+        "CELL_RETURNED",
+        "foreground cell to return before the extra-line answer turn",
+        Duration::from_secs(5),
+    )
+    .await?;
 
     let answer = session.write_stdin_raw_with("one\ntwo", Some(1.0)).await?;
     let answer_text = result_text(&answer);

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -6106,11 +6106,16 @@ async fn python_input_releases_gil_while_waiting_for_line() -> TestResult<()> {
     let Some(session) = start_python_session().await? else {
         return Ok(());
     };
+    let temp_dir = tempdir()?;
+    let background_marker = temp_dir.path().join("input-gil-background-ready");
+    let background_marker_literal = path_json_literal(&background_marker, "background marker")?;
 
     let result = session
         .write_stdin_raw_with(
-            r#"
-import sys, threading, time
+            format!(
+                r#"
+import pathlib, sys, threading, time
+background_marker = pathlib.Path({background_marker_literal})
 sys.setswitchinterval(1.0)
 background_seen = None
 answer_seen = None
@@ -6120,6 +6125,7 @@ def background():
     background_started.set()
     time.sleep(0.1)
     background_seen = time.monotonic()
+    background_marker.write_text("ready")
 
 def wait_and_print():
     global answer_seen
@@ -6130,7 +6136,8 @@ def wait_and_print():
 threading.Thread(target=background, daemon=True).start()
 background_started.wait()
 wait_and_print()
-"#,
+"#
+            ),
             Some(5.0),
         )
         .await?;
@@ -6141,7 +6148,7 @@ wait_and_print()
     );
     assert!(text.contains("p> "), "expected input prompt, got: {text:?}");
 
-    sleep(Duration::from_millis(500)).await;
+    wait_for_file_text(&background_marker, "ready").await?;
 
     let answer = session.write_stdin_raw_with("ok", Some(5.0)).await?;
     let answer_text = result_text(&answer);

--- a/tests/refactor_coverage.rs
+++ b/tests/refactor_coverage.rs
@@ -19,7 +19,7 @@ plot(1:5, type = "l")
 plot(5:1, type = "l")
 cat("plots_done\n")
 "#, timeout = 10.0);
-                write_stdin_raw_unterminated("\u{4}");
+                write_stdin_raw_unterminated("\u{4}", timeout = 5.0);
                 write_stdin("1+1", timeout = 10.0);
                 write_stdin("Sys.sleep(5)", timeout = 0.2);
                 write_stdin_raw_unterminated("\u{3}", timeout = 5.0);

--- a/tests/session_endings.rs
+++ b/tests/session_endings.rs
@@ -34,10 +34,10 @@ async fn snapshots_session_endings() -> TestResult<()> {
 
     snapshot
         .session(
-            "restart_timeout_thirty",
+            "restart_timeout_nonzero",
             mcp_script! {
                 write_stdin("x <- 1", timeout = 10.0);
-                write_stdin_raw_unterminated("\u{4}", timeout = 30.0);
+                write_stdin_raw_unterminated("\u{4}", timeout = 5.0);
                 write_stdin("print(exists(\"x\"))", timeout = 10.0);
             },
         )

--- a/tests/snapshots/mcp_transcripts__snapshots_support_multiple_calls_and_sessions.snap
+++ b/tests/snapshots/mcp_transcripts__snapshots_support_multiple_calls_and_sessions.snap
@@ -48,7 +48,8 @@ call:
 {
   "tool": "r_repl",
   "arguments": {
-    "input": "\u0004"
+    "input": "\u0004",
+    "timeout_ms": 5000
   }
 }
 response:

--- a/tests/snapshots/mcp_transcripts__snapshots_support_multiple_calls_and_sessions@transcript.snap
+++ b/tests/snapshots/mcp_transcripts__snapshots_support_multiple_calls_and_sessions@transcript.snap
@@ -12,7 +12,7 @@ expression: transcript
 <<< [1] 42
 <<< > 
 
-3) r_repl
+3) r_repl timeout_ms=5000
 >>> 
 <<< [repl] new session started
 

--- a/tests/snapshots/mcp_transcripts__snapshots_tempdir_session_restart.snap
+++ b/tests/snapshots/mcp_transcripts__snapshots_tempdir_session_restart.snap
@@ -28,7 +28,8 @@ call:
 {
   "tool": "r_repl",
   "arguments": {
-    "input": "\u0004"
+    "input": "\u0004",
+    "timeout_ms": 5000
   }
 }
 response:
@@ -67,7 +68,8 @@ call:
 {
   "tool": "r_repl",
   "arguments": {
-    "input": "\u0004"
+    "input": "\u0004",
+    "timeout_ms": 5000
   }
 }
 response:

--- a/tests/snapshots/mcp_transcripts__snapshots_tempdir_session_restart@transcript.snap
+++ b/tests/snapshots/mcp_transcripts__snapshots_tempdir_session_restart@transcript.snap
@@ -42,7 +42,7 @@ expression: transcript
 <<< ROOT_MARKER_EXISTS=TRUE
 <<< > 
 
-2) r_repl
+2) r_repl timeout_ms=5000
 >>> 
 <<< [repl] new session started
 
@@ -57,7 +57,7 @@ expression: transcript
 <<< TEMPDIR_UNDER_TMPDIR=TRUE
 <<< > 
 
-4) r_repl
+4) r_repl timeout_ms=5000
 >>> 
 <<< [repl] new session started
 

--- a/tests/snapshots/plot_images__grid_plots_emit_images_and_updates.snap
+++ b/tests/snapshots/plot_images__grid_plots_emit_images_and_updates.snap
@@ -29,7 +29,7 @@ expression: serialized
           "grDevices::png(filename = Sys.getenv(\"MCP_REPL_TEST_PNG_DEST\"), width = 800, height = 600, res = 96)",
           "grid::grid.newpage()",
           "grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },
@@ -63,7 +63,7 @@ expression: serialized
           "grid::grid.newpage()",
           "grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))",
           "grid::grid.lines(x = c(0.1, 0.9), y = c(0.9, 0.1))",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },

--- a/tests/snapshots/plot_images__grid_plots_emit_images_and_updates@macos.snap
+++ b/tests/snapshots/plot_images__grid_plots_emit_images_and_updates@macos.snap
@@ -29,7 +29,7 @@ expression: serialized
           "grDevices::png(filename = Sys.getenv(\"MCP_REPL_TEST_PNG_DEST\"), width = 800, height = 600, res = 96)",
           "grid::grid.newpage()",
           "grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },
@@ -63,7 +63,7 @@ expression: serialized
           "grid::grid.newpage()",
           "grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))",
           "grid::grid.lines(x = c(0.1, 0.9), y = c(0.9, 0.1))",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },

--- a/tests/snapshots/plot_images__grid_plots_emit_images_and_updates@transcript.snap
+++ b/tests/snapshots/plot_images__grid_plots_emit_images_and_updates@transcript.snap
@@ -12,7 +12,7 @@ expression: transcript
 ===   grDevices::png(filename = Sys.getenv("MCP_REPL_TEST_PNG_DEST"), width = 800, height = 600, res = 96)
 ===   grid::grid.newpage()
 ===   grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 2) r_repl
 >>> grid::grid.lines(x = c(0.1, 0.9), y = c(0.9, 0.1))
@@ -26,7 +26,7 @@ expression: transcript
 ===   grid::grid.newpage()
 ===   grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))
 ===   grid::grid.lines(x = c(0.1, 0.9), y = c(0.9, 0.1))
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 3) r_repl
 >>> 1+1

--- a/tests/snapshots/plot_images__grid_plots_emit_images_and_updates@transcript__macos.snap
+++ b/tests/snapshots/plot_images__grid_plots_emit_images_and_updates@transcript__macos.snap
@@ -12,7 +12,7 @@ expression: transcript
 ===   grDevices::png(filename = Sys.getenv("MCP_REPL_TEST_PNG_DEST"), width = 800, height = 600, res = 96)
 ===   grid::grid.newpage()
 ===   grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 2) r_repl
 >>> grid::grid.lines(x = c(0.1, 0.9), y = c(0.9, 0.1))
@@ -26,7 +26,7 @@ expression: transcript
 ===   grid::grid.newpage()
 ===   grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))
 ===   grid::grid.lines(x = c(0.1, 0.9), y = c(0.9, 0.1))
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 3) r_repl
 >>> 1+1

--- a/tests/snapshots/plot_images__grid_plots_emit_stable_images_for_repeats.snap
+++ b/tests/snapshots/plot_images__grid_plots_emit_stable_images_for_repeats.snap
@@ -29,7 +29,7 @@ expression: serialized
           "grDevices::png(filename = Sys.getenv(\"MCP_REPL_TEST_PNG_DEST\"), width = 800, height = 600, res = 96)",
           "grid::grid.newpage()",
           "grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },
@@ -58,7 +58,7 @@ expression: serialized
           "grDevices::png(filename = Sys.getenv(\"MCP_REPL_TEST_PNG_DEST\"), width = 800, height = 600, res = 96)",
           "grid::grid.newpage()",
           "grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },

--- a/tests/snapshots/plot_images__grid_plots_emit_stable_images_for_repeats@macos.snap
+++ b/tests/snapshots/plot_images__grid_plots_emit_stable_images_for_repeats@macos.snap
@@ -29,7 +29,7 @@ expression: serialized
           "grDevices::png(filename = Sys.getenv(\"MCP_REPL_TEST_PNG_DEST\"), width = 800, height = 600, res = 96)",
           "grid::grid.newpage()",
           "grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },
@@ -58,7 +58,7 @@ expression: serialized
           "grDevices::png(filename = Sys.getenv(\"MCP_REPL_TEST_PNG_DEST\"), width = 800, height = 600, res = 96)",
           "grid::grid.newpage()",
           "grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },

--- a/tests/snapshots/plot_images__grid_plots_emit_stable_images_for_repeats@transcript.snap
+++ b/tests/snapshots/plot_images__grid_plots_emit_stable_images_for_repeats@transcript.snap
@@ -12,7 +12,7 @@ expression: transcript
 ===   grDevices::png(filename = Sys.getenv("MCP_REPL_TEST_PNG_DEST"), width = 800, height = 600, res = 96)
 ===   grid::grid.newpage()
 ===   grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 2) r_repl
 >>> grid::grid.newpage(); grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))
@@ -23,7 +23,7 @@ expression: transcript
 ===   grDevices::png(filename = Sys.getenv("MCP_REPL_TEST_PNG_DEST"), width = 800, height = 600, res = 96)
 ===   grid::grid.newpage()
 ===   grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 3) r_repl
 >>> 1+1

--- a/tests/snapshots/plot_images__grid_plots_emit_stable_images_for_repeats@transcript__macos.snap
+++ b/tests/snapshots/plot_images__grid_plots_emit_stable_images_for_repeats@transcript__macos.snap
@@ -12,7 +12,7 @@ expression: transcript
 ===   grDevices::png(filename = Sys.getenv("MCP_REPL_TEST_PNG_DEST"), width = 800, height = 600, res = 96)
 ===   grid::grid.newpage()
 ===   grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 2) r_repl
 >>> grid::grid.newpage(); grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))
@@ -23,7 +23,7 @@ expression: transcript
 ===   grDevices::png(filename = Sys.getenv("MCP_REPL_TEST_PNG_DEST"), width = 800, height = 600, res = 96)
 ===   grid::grid.newpage()
 ===   grid::grid.lines(x = c(0.1, 0.9), y = c(0.1, 0.9))
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 3) r_repl
 >>> 1+1

--- a/tests/snapshots/plot_images__multi_panel_plots_emit_single_image.snap
+++ b/tests/snapshots/plot_images__multi_panel_plots_emit_single_image.snap
@@ -30,7 +30,7 @@ expression: serialized
           "par(mfrow = c(2, 1))",
           "plot(1:10)",
           "plot(10:1)",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },

--- a/tests/snapshots/plot_images__multi_panel_plots_emit_single_image@macos.snap
+++ b/tests/snapshots/plot_images__multi_panel_plots_emit_single_image@macos.snap
@@ -30,7 +30,7 @@ expression: serialized
           "par(mfrow = c(2, 1))",
           "plot(1:10)",
           "plot(10:1)",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },

--- a/tests/snapshots/plot_images__multi_panel_plots_emit_single_image@transcript.snap
+++ b/tests/snapshots/plot_images__multi_panel_plots_emit_single_image@transcript.snap
@@ -13,7 +13,7 @@ expression: transcript
 ===   par(mfrow = c(2, 1))
 ===   plot(1:10)
 ===   plot(10:1)
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 2) r_repl
 >>> 1+1

--- a/tests/snapshots/plot_images__multi_panel_plots_emit_single_image@transcript__macos.snap
+++ b/tests/snapshots/plot_images__multi_panel_plots_emit_single_image@transcript__macos.snap
@@ -13,7 +13,7 @@ expression: transcript
 ===   par(mfrow = c(2, 1))
 ===   plot(1:10)
 ===   plot(10:1)
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 2) r_repl
 >>> 1+1

--- a/tests/snapshots/plot_images__plots_emit_images_and_updates.snap
+++ b/tests/snapshots/plot_images__plots_emit_images_and_updates.snap
@@ -28,7 +28,7 @@ expression: serialized
         "script": [
           "grDevices::png(filename = Sys.getenv(\"MCP_REPL_TEST_PNG_DEST\"), width = 800, height = 600, res = 96)",
           "plot(1:10)",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },
@@ -61,7 +61,7 @@ expression: serialized
           "grDevices::png(filename = Sys.getenv(\"MCP_REPL_TEST_PNG_DEST\"), width = 800, height = 600, res = 96)",
           "plot(1:10)",
           "lines(4:8, 4:8)",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },

--- a/tests/snapshots/plot_images__plots_emit_images_and_updates@macos.snap
+++ b/tests/snapshots/plot_images__plots_emit_images_and_updates@macos.snap
@@ -28,7 +28,7 @@ expression: serialized
         "script": [
           "grDevices::png(filename = Sys.getenv(\"MCP_REPL_TEST_PNG_DEST\"), width = 800, height = 600, res = 96)",
           "plot(1:10)",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },
@@ -61,7 +61,7 @@ expression: serialized
           "grDevices::png(filename = Sys.getenv(\"MCP_REPL_TEST_PNG_DEST\"), width = 800, height = 600, res = 96)",
           "plot(1:10)",
           "lines(4:8, 4:8)",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },

--- a/tests/snapshots/plot_images__plots_emit_images_and_updates@transcript.snap
+++ b/tests/snapshots/plot_images__plots_emit_images_and_updates@transcript.snap
@@ -11,7 +11,7 @@ expression: transcript
 === script
 ===   grDevices::png(filename = Sys.getenv("MCP_REPL_TEST_PNG_DEST"), width = 800, height = 600, res = 96)
 ===   plot(1:10)
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 2) r_repl
 >>> lines(4:8, 4:8)
@@ -24,7 +24,7 @@ expression: transcript
 ===   grDevices::png(filename = Sys.getenv("MCP_REPL_TEST_PNG_DEST"), width = 800, height = 600, res = 96)
 ===   plot(1:10)
 ===   lines(4:8, 4:8)
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 3) r_repl
 >>> 1+1

--- a/tests/snapshots/plot_images__plots_emit_images_and_updates@transcript__macos.snap
+++ b/tests/snapshots/plot_images__plots_emit_images_and_updates@transcript__macos.snap
@@ -11,7 +11,7 @@ expression: transcript
 === script
 ===   grDevices::png(filename = Sys.getenv("MCP_REPL_TEST_PNG_DEST"), width = 800, height = 600, res = 96)
 ===   plot(1:10)
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 2) r_repl
 >>> lines(4:8, 4:8)
@@ -24,7 +24,7 @@ expression: transcript
 ===   grDevices::png(filename = Sys.getenv("MCP_REPL_TEST_PNG_DEST"), width = 800, height = 600, res = 96)
 ===   plot(1:10)
 ===   lines(4:8, 4:8)
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 3) r_repl
 >>> 1+1

--- a/tests/snapshots/plot_images__plots_emit_stable_images_for_repeats.snap
+++ b/tests/snapshots/plot_images__plots_emit_stable_images_for_repeats.snap
@@ -28,7 +28,7 @@ expression: serialized
         "script": [
           "grDevices::png(filename = Sys.getenv(\"MCP_REPL_TEST_PNG_DEST\"), width = 800, height = 600, res = 96)",
           "plot(1:10)",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },
@@ -56,7 +56,7 @@ expression: serialized
         "script": [
           "grDevices::png(filename = Sys.getenv(\"MCP_REPL_TEST_PNG_DEST\"), width = 800, height = 600, res = 96)",
           "plot(1:10)",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },

--- a/tests/snapshots/plot_images__plots_emit_stable_images_for_repeats@macos.snap
+++ b/tests/snapshots/plot_images__plots_emit_stable_images_for_repeats@macos.snap
@@ -28,7 +28,7 @@ expression: serialized
         "script": [
           "grDevices::png(filename = Sys.getenv(\"MCP_REPL_TEST_PNG_DEST\"), width = 800, height = 600, res = 96)",
           "plot(1:10)",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },
@@ -56,7 +56,7 @@ expression: serialized
         "script": [
           "grDevices::png(filename = Sys.getenv(\"MCP_REPL_TEST_PNG_DEST\"), width = 800, height = 600, res = 96)",
           "plot(1:10)",
-          "grDevices::dev.off()"
+          "invisible(grDevices::dev.off())"
         ]
       }
     },

--- a/tests/snapshots/plot_images__plots_emit_stable_images_for_repeats@transcript.snap
+++ b/tests/snapshots/plot_images__plots_emit_stable_images_for_repeats@transcript.snap
@@ -11,7 +11,7 @@ expression: transcript
 === script
 ===   grDevices::png(filename = Sys.getenv("MCP_REPL_TEST_PNG_DEST"), width = 800, height = 600, res = 96)
 ===   plot(1:10)
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 2) r_repl
 >>> plot(1:10)
@@ -21,7 +21,7 @@ expression: transcript
 === script
 ===   grDevices::png(filename = Sys.getenv("MCP_REPL_TEST_PNG_DEST"), width = 800, height = 600, res = 96)
 ===   plot(1:10)
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 3) r_repl
 >>> 1+1

--- a/tests/snapshots/plot_images__plots_emit_stable_images_for_repeats@transcript__macos.snap
+++ b/tests/snapshots/plot_images__plots_emit_stable_images_for_repeats@transcript__macos.snap
@@ -11,7 +11,7 @@ expression: transcript
 === script
 ===   grDevices::png(filename = Sys.getenv("MCP_REPL_TEST_PNG_DEST"), width = 800, height = 600, res = 96)
 ===   plot(1:10)
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 2) r_repl
 >>> plot(1:10)
@@ -21,7 +21,7 @@ expression: transcript
 === script
 ===   grDevices::png(filename = Sys.getenv("MCP_REPL_TEST_PNG_DEST"), width = 800, height = 600, res = 96)
 ===   plot(1:10)
-===   grDevices::dev.off()
+===   invisible(grDevices::dev.off())
 
 3) r_repl
 >>> 1+1

--- a/tests/snapshots/refactor_coverage__snapshots_restart_and_interrupt_with_plots.snap
+++ b/tests/snapshots/refactor_coverage__snapshots_restart_and_interrupt_with_plots.snap
@@ -58,7 +58,8 @@ call:
 {
   "tool": "r_repl",
   "arguments": {
-    "input": "\u0004"
+    "input": "\u0004",
+    "timeout_ms": 5000
   }
 }
 response:

--- a/tests/snapshots/refactor_coverage__snapshots_restart_and_interrupt_with_plots@transcript.snap
+++ b/tests/snapshots/refactor_coverage__snapshots_restart_and_interrupt_with_plots@transcript.snap
@@ -18,7 +18,7 @@ expression: transcript
 <<< plots_done
 <<< > 
 
-3) r_repl
+3) r_repl timeout_ms=5000
 >>> 
 <<< [repl] new session started
 

--- a/tests/snapshots/session_endings__snapshots_session_endings.snap
+++ b/tests/snapshots/session_endings__snapshots_session_endings.snap
@@ -64,7 +64,7 @@ response:
   ]
 }
 
-== session: restart_timeout_thirty ==
+== session: restart_timeout_nonzero ==
 -- step 1 --
 call:
 {
@@ -91,7 +91,7 @@ call:
   "tool": "r_repl",
   "arguments": {
     "input": "\u0004",
-    "timeout_ms": 30000
+    "timeout_ms": 5000
   }
 }
 response:

--- a/tests/snapshots/session_endings__snapshots_session_endings@transcript.snap
+++ b/tests/snapshots/session_endings__snapshots_session_endings@transcript.snap
@@ -16,12 +16,12 @@ expression: transcript
 <<< [1] FALSE
 <<< > 
 
-== session: restart_timeout_thirty ==
+== session: restart_timeout_nonzero ==
 1) r_repl timeout_ms=10000
 >>> x <- 1
 <<< > 
 
-2) r_repl timeout_ms=30000
+2) r_repl timeout_ms=5000
 >>> 
 <<< [repl] new session started
 

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -323,7 +323,7 @@ async fn spawn_zod_stalled_control_server(
     );
     env.insert(
         "MCP_REPL_ZOD_STALL_CONTROL_READER".to_string(),
-        Value::String("1".to_string()),
+        Value::String("5000".to_string()),
     );
     let spec = json!({
         "executable": zod_worker_path()?,
@@ -1988,6 +1988,11 @@ async fn zod_worker_v5_input_batch_write_respects_timeout_when_control_reader_st
     assert!(
         text.contains("worker response timed out"),
         "expected bounded input_batch write timeout, got: {text:?}"
+    );
+    let log = wait_for_log_contains(&control_log, "control_reader_stalled")?;
+    assert!(
+        !log.contains("input_batch input="),
+        "stalled fixture must not consume the timed-out input batch, got log: {log:?}"
     );
 
     session.cancel().await?;

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -1314,7 +1314,17 @@ async fn zod_files_completion_bounds_stable_wait_after_utf8_recovery() -> TestRe
 async fn zod_files_request_boundary_resets_stderr_after_sealed_utf8_tail() -> TestResult<()> {
     let tempdir = tempfile::tempdir()?;
     let control_log = tempdir.path().join("control.log");
-    let session = spawn_zod_server(&control_log).await?;
+    let late_stderr_marker = tempdir.path().join("late-stderr-marker");
+    let late_stderr_marker_env = late_stderr_marker.display().to_string();
+    let session = spawn_zod_server_with_extra_env_and_extra_args(
+        &control_log,
+        vec![(
+            "MCP_REPL_ZOD_LATE_STDERR_MARKER",
+            late_stderr_marker_env.as_str(),
+        )],
+        Vec::new(),
+    )
+    .await?;
 
     let first = session
         .call_tool_raw(
@@ -1331,7 +1341,9 @@ async fn zod_files_request_boundary_resets_stderr_after_sealed_utf8_tail() -> Te
         "completed request should keep an incomplete UTF-8 tail detached, got: {first_text:?}"
     );
 
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    wait_for_log_contains(&control_log, "waiting_late_stderr_marker")?;
+    std::fs::write(&late_stderr_marker, b"go")?;
+    wait_for_log_contains(&control_log, "late_stderr_after_completion")?;
 
     let second = session
         .call_tool_raw(


### PR DESCRIPTION
## Summary

Extracts CI and test-stability fixes from the larger reset-tool cleanup work so they can merge independently. The main focus is making restart behavior deterministic under timed-out or background work, reducing successful test noise, and trimming incidental wait time in tests without changing the public MCP API.

## User-facing changes

- Clarifies reset behavior in user-facing docs: resets return already captured output, shut down the old worker in a bounded window, and run any remaining input in the fresh session.
- Preserves `repl_reset` and keeps it on the sideband shutdown path.
- Clarifies that explicit Ctrl-D restarts do not carry old shutdown-time output into later replies.
- Adds testing docs for focused quiet/fast local iteration.

## Internal changes

- Splits restart shutdown handling so `repl_reset` uses sideband shutdown while explicit Ctrl-D restart closes stdin and uses bounded termination.
- Snapshots restart output before shutdown so output produced while abandoning an old timed-out session does not leak into the restart reply or the next session.
- Preserves pager state across restart output handling.
- Increases the output-reader completion settle window to reduce timing-sensitive completion races.
- Captures spawned test-server stderr in the Rust harness with a bounded tail buffer, exposed through `McpTestSession::server_stderr_text()`, so expected negative-path diagnostics stay out of passing logs.
- Replaces several fixed sleeps in Python and zod tests with marker-file or log gates.
- Shortens non-contract restart snapshot timeouts from the default/long timeout path to explicit short timeouts.
- Silences non-contract R plot cleanup output by wrapping cleanup-only `grDevices::dev.off()` calls in `invisible(...)` and updates snapshots.
