### PR TITLE
Stabilize restart and timeout tests

### DIFF
--- a/tests/fixtures/zod-worker.rs
+++ b/tests/fixtures/zod-worker.rs
@@ -31,6 +31,7 @@ const CONTROL_LOG_ENV: &str = "MCP_REPL_ZOD_CONTROL_LOG";
 const LATE_RAW_MARKER_ENV: &str = "MCP_REPL_ZOD_LATE_RAW_MARKER";
 const LATE_STDERR_MARKER_ENV: &str = "MCP_REPL_ZOD_LATE_STDERR_MARKER";
 const LATE_SIDEBAND_MARKER_ENV: &str = "MCP_REPL_ZOD_LATE_SIDEBAND_MARKER";
+const UTF8_TAIL_RELEASE_ENV: &str = "MCP_REPL_ZOD_UTF8_TAIL_RELEASE";
 const STALL_CONTROL_READER_ENV: &str = "MCP_REPL_ZOD_STALL_CONTROL_READER";
 const DELAY_READY_AFTER_INTERRUPT_ENV: &str = "MCP_REPL_ZOD_DELAY_READY_AFTER_INTERRUPT_MS";
 const INVALID_OUTPUT_TEXT_BASE64: &str =
@@ -364,6 +365,14 @@ fn run_command(
     if command == "partial-utf8-then-sleep" {
         output_text_with_continuation(writer, control_log_path, &[0xC3], false)?;
         sleep_for(200, sideband_interrupted, false);
+        return Ok(false);
+    }
+
+    if command == "partial-utf8-then-wait-for-release" {
+        output_text_with_continuation(writer, control_log_path, &[0xC3], false)?;
+        append_control_log(control_log_path.as_deref(), "waiting_utf8_tail_release")?;
+        wait_for_marker(UTF8_TAIL_RELEASE_ENV)?;
+        output_text_with_continuation(writer, control_log_path, &[0xA9], true)?;
         return Ok(false);
     }
 

--- a/tests/python_backend.rs
+++ b/tests/python_backend.rs
@@ -4900,13 +4900,26 @@ async fn python_ctrl_d_tail_includes_old_worker_shutdown_output() -> TestResult<
     let Some(session) = start_python_session().await? else {
         return Ok(());
     };
+    let tempdir = tempdir()?;
+    let release_path = tempdir.path().join("release-old-worker-output");
+    let emitted_path = tempdir.path().join("old-worker-output-emitted");
+    let release_literal = path_json_literal(&release_path, "release marker")?;
+    let emitted_literal = path_json_literal(&emitted_path, "emitted marker")?;
 
     let running = session
         .write_stdin_raw_with(
-            r#"import time
-time.sleep(0.3)
+            format!(
+                r#"import pathlib, sys, time
+_release = pathlib.Path({release_literal})
+_emitted = pathlib.Path({emitted_literal})
+while not _release.exists():
+    time.sleep(0.01)
 print('OLD_WORKER_SHUTDOWN_TAIL_VISIBLE')
-"#,
+sys.stdout.flush()
+_emitted.write_text('done')
+time.sleep(30)
+"#
+            ),
             Some(0.05),
         )
         .await?;
@@ -4915,6 +4928,19 @@ print('OLD_WORKER_SHUTDOWN_TAIL_VISIBLE')
         is_busy_response(&running_text),
         "expected first request to be busy before reset tail, got: {running_text:?}"
     );
+
+    fs::write(&release_path, "go")?;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !emitted_path.exists() {
+        if Instant::now() >= deadline {
+            session.cancel().await?;
+            return Err(format!(
+                "old worker did not emit restart-captured output before deadline; first reply: {running_text:?}"
+            )
+            .into());
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
 
     let reset = session
         .write_stdin_raw_with("\u{4}print('FRESH_RESET_TAIL_VISIBLE')", Some(5.0))
@@ -4928,7 +4954,7 @@ print('OLD_WORKER_SHUTDOWN_TAIL_VISIBLE')
     );
     assert!(
         reset_text.contains("OLD_WORKER_SHUTDOWN_TAIL_VISIBLE"),
-        "expected Ctrl-D tail to include old-worker shutdown output captured during shutdown, got: {reset_text:?}"
+        "expected Ctrl-D tail to include old-worker output captured while shutting down the pending request, got: {reset_text:?}"
     );
     Ok(())
 }

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -978,30 +978,62 @@ async fn zod_files_timeout_drains_stderr_after_incomplete_utf8() -> TestResult<(
 async fn zod_files_timeout_does_not_wait_for_utf8_tail_grace_after_expiry() -> TestResult<()> {
     let tempdir = tempfile::tempdir()?;
     let control_log = tempdir.path().join("control.log");
-    let session = spawn_zod_server(&control_log).await?;
+    let release_path = tempdir.path().join("release-utf8-tail");
+    let release = release_path
+        .to_str()
+        .ok_or("release path must be valid utf-8")?
+        .to_string();
+    let session = spawn_zod_server_with_extra_env_and_extra_args(
+        &control_log,
+        vec![("MCP_REPL_ZOD_UTF8_TAIL_RELEASE", release.as_str())],
+        Vec::new(),
+    )
+    .await?;
 
-    let started = std::time::Instant::now();
-    let timed_out = session
-        .call_tool_raw(
+    let timed_out = tokio::time::timeout(
+        Duration::from_secs(5),
+        session.call_tool_raw(
             "repl",
             json!({
-                "input": "partial-utf8-then-sleep",
+                "input": "partial-utf8-then-wait-for-release",
                 "timeout_ms": 50
             }),
-        )
-        .await?;
-    let elapsed = started.elapsed();
+        ),
+    )
+    .await
+    .map_err(|_| "timeout reply waited for unreleased UTF-8 tail")??;
     let timeout_text = result_text(&timed_out);
-
-    session.cancel().await?;
+    let control_text = wait_for_log_contains(&control_log, "waiting_utf8_tail_release")?;
 
     assert!(
         timeout_text.contains("<<repl status: busy"),
         "expected the incomplete UTF-8 request to time out, got: {timeout_text:?}"
     );
     assert!(
-        elapsed < Duration::from_millis(500),
-        "timeout should not wait for the UTF-8 tail grace after expiry; elapsed {elapsed:?}"
+        !timeout_text.contains("\\xC3"),
+        "timeout reply should keep the incomplete UTF-8 tail pending, got: {timeout_text:?}"
+    );
+    assert!(
+        !release_path.exists(),
+        "timeout reply should return before the test releases the UTF-8 tail; control log: {control_text:?}"
+    );
+
+    fs::write(&release_path, "go")?;
+    let completed = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "",
+                "timeout_ms": 10_000
+            }),
+        )
+        .await?;
+    let completed_text = result_text(&completed);
+    session.cancel().await?;
+
+    assert!(
+        completed_text.contains("é"),
+        "follow-up poll should drain the released UTF-8 sequence, got: {completed_text:?}"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

- Make the Windows Python restart-tail coverage deterministic with release and emitted marker files.
- Replace a load-sensitive UTF-8 timeout stopwatch assertion with a fixture-controlled release gate.
- Add a zod fixture command that holds an incomplete UTF-8 tail until the test explicitly releases it.

## Validation

- env RUSTFLAGS=-Dwarnings cargo check
- env RUSTFLAGS=-Dwarnings cargo build
- python3 tests/run_integration_tests.py --binary target/debug/mcp-repl
- cargo clippy --all-targets --all-features -- -D warnings
- env RUSTFLAGS=-Dwarnings cargo test --quiet
- cargo +nightly fmt
- env RUSTFLAGS=-Dwarnings cargo build --release --locked