### PR TITLE
Protect managed-network sockets and preserve reset output

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,11 +188,11 @@ The exact `repl` tool description depends on the interpreter and
 
 - **Interrupt**: prefix `repl` input with `\u0003` (SIGINT, best-effort). Session continues.
 - **Reset**: prefix `repl` input with `\u0004` (Ctrl-D / EOF). Reset
-  closes stdin, waits through a bounded graceful shutdown window, escalates to
-  forceful termination when that window expires, then starts a fresh session.
-  The same reply includes old-worker output captured through that window,
-  followed by any remaining input's fresh-session output under the original call
-  timeout.
+  requests worker shutdown, waits through a bounded graceful shutdown window,
+  escalates to forceful termination when that window expires, then starts a
+  fresh session. The same reply includes old-worker output captured through
+  that window, followed by any remaining input's fresh-session output under the
+  original call timeout.
 - **In-band exits**: `EOF`, `quit()`, etc. also work — output is
   returned and the next request runs in a fresh worker.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,11 +44,12 @@ The repository is organized around a few concrete subsystems rather than deep pa
   `input_wait` or `ready`. The server treats these as readiness gates, not as
   prompt classification.
 - Server teardown uses the sideband `shutdown` lifecycle message first. For
-  explicit restarts, the server closes stdin, waits for a bounded graceful
-  window, then escalates to process termination if needed. Output captured
-  through restart shutdown is included in the restart reply. A `Ctrl-D` tail
-  runs in the fresh session under the original tool-call timeout, and its output
-  is included in the same reply after the restart output.
+  explicit restarts, the server requests sideband shutdown, applies the
+  worker's stdin shutdown policy, waits for a bounded graceful window, then
+  escalates to process termination if needed. Output captured through restart
+  shutdown is included in the restart reply. A `Ctrl-D` tail runs in the fresh
+  session under the original tool-call timeout, and its output is included in
+  the same reply after the restart output.
 - The IPC sideband is single-owner by design: startup env vars only bootstrap the main worker, then they are scrubbed before user code runs. Descendants must not emit sideband messages.
 - R-specific behavior lives in `src/r_session.rs`, `src/r_controls.rs`, `src/r_graphics.rs`, and `src/r_htmd.rs`.
 - Python-specific behavior lives in `src/python_ffi.rs`, `src/python_session.rs`, `src/python_worker.rs`, and `python/embedded.py`. Python worker mode dynamically loads CPython only after the worker has selected the Python backend, so R worker mode does not load Python. On Unix, Python may still use PTY-backed process stdio for terminal behavior, but managed input batches are served from the worker queue; direct stdin consumers are not a server completion contract.

--- a/docs/worker_sideband_protocol.md
+++ b/docs/worker_sideband_protocol.md
@@ -91,12 +91,19 @@ capture does not preserve separate stdout/stderr identity. Sideband
 `shutdown`
 - `{ "type": "shutdown" }`
 - Requests worker shutdown during server teardown and replacement paths that
-  need immediate worker-side lifecycle control. Explicit restarts do not send
-  this message first; they close stdin, wait through a bounded graceful shutdown
-  window, then escalate if needed. Restart replies include output captured
-  through that window, followed by fresh-session tail output when the same input
-  contains text after `Ctrl-D`.
-- Built-in workers currently exit the process after receiving it.
+  need worker-side lifecycle control. The worker should stop accepting new
+  input, preserve already accepted input until the runtime consumes it, wake
+  managed stdin readers with EOF once that accepted input is drained, let the
+  active runtime request reach a safe boundary, and exit. The server waits
+  through a bounded graceful shutdown window, then escalates if needed. The
+  server may also close process stdin during that window for worker types that
+  rely on stdin EOF to unblock direct stdin consumers; built-in Python keeps
+  process stdin open during the graceful window because sideband owns accepted
+  input. Restart replies include output captured through that window, followed
+  by fresh-session tail output when the same input contains text after
+  `Ctrl-D`.
+- Built-in workers request runtime shutdown after receiving it. They may emit
+  output from the active request before `session_end` and process exit.
 
 The server emits no other server-to-worker protocol messages in v6.
 Built-in worker readers treat malformed or unknown server-to-worker messages as
@@ -201,9 +208,13 @@ queue feeds runtime input callbacks and managed stdin surfaces. The sideband IPC
 reader runs independently from the runtime thread. It receives `input_batch`,
 `interrupt`, and `shutdown`, mutates worker-owned queue/session state, and wakes
 the runtime when needed. The runtime thread consumes queued input only when the
-runtime calls its managed input boundary. A `shutdown` message exits built-in
-workers, so explicit restart uses process stdin close plus bounded termination
-instead of sending `shutdown` first.
+runtime calls its managed input boundary. A `shutdown` message asks built-in
+workers to stop accepting new input, preserve already accepted input until it
+is consumed, wake managed input readers with EOF after that queue drains, and
+exit after the active runtime request reaches a safe boundary or the server's
+bounded shutdown window expires. The server still applies the worker's process
+stdin shutdown policy so stdin-backed readers can be unblocked without making
+stdin EOF the only shutdown signal.
 
 For R, the managed input boundary is R's embedded `ReadConsole` callback,
 installed through `Rstart.ReadConsole` on Windows and `ptr_R_ReadConsole` on

--- a/src/managed_network.rs
+++ b/src/managed_network.rs
@@ -64,6 +64,8 @@ pub(crate) const LINUX_MANAGED_NETWORK_SOCKS_BRIDGE_PORT: u16 = 39081;
 const LINUX_MANAGED_NETWORK_HTTP_SOCKET_NAME: &str = "mn-http.sock";
 #[cfg(target_os = "linux")]
 const LINUX_MANAGED_NETWORK_SOCKS_SOCKET_NAME: &str = "mn-socks.sock";
+#[cfg(target_os = "linux")]
+pub(crate) const LINUX_MANAGED_NETWORK_SOCKET_DIR_NAME: &str = ".mcp-repl-managed-network";
 
 #[cfg(test)]
 pub(crate) fn loopback_sockets_available_for_tests() -> bool {
@@ -227,6 +229,7 @@ pub struct ManagedNetworkProxy {
 #[cfg(target_os = "linux")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct LinuxManagedNetworkBridgeConfig {
+    pub(crate) socket_dir: PathBuf,
     pub(crate) http_socket: PathBuf,
     pub(crate) socks_socket: PathBuf,
 }
@@ -349,11 +352,17 @@ impl ManagedNetworkProxy {
             .lock()
             .map_err(|_| io::Error::other("managed network relay mutex poisoned"))?;
         let expected = LinuxManagedNetworkBridgeConfig {
-            http_socket: session_temp_dir.join(LINUX_MANAGED_NETWORK_HTTP_SOCKET_NAME),
-            socks_socket: session_temp_dir.join(LINUX_MANAGED_NETWORK_SOCKS_SOCKET_NAME),
+            socket_dir: session_temp_dir.join(LINUX_MANAGED_NETWORK_SOCKET_DIR_NAME),
+            http_socket: session_temp_dir
+                .join(LINUX_MANAGED_NETWORK_SOCKET_DIR_NAME)
+                .join(LINUX_MANAGED_NETWORK_HTTP_SOCKET_NAME),
+            socks_socket: session_temp_dir
+                .join(LINUX_MANAGED_NETWORK_SOCKET_DIR_NAME)
+                .join(LINUX_MANAGED_NETWORK_SOCKS_SOCKET_NAME),
         };
         let needs_new = relay.as_ref().is_none_or(|existing| {
             existing.config != expected
+                || !existing.config.socket_dir.is_dir()
                 || !existing.config.http_socket.exists()
                 || !existing.config.socks_socket.exists()
         });
@@ -400,9 +409,7 @@ impl LinuxManagedNetworkRelay {
         http_addr: SocketAddr,
         socks_addr: SocketAddr,
     ) -> Result<Self, ManagedNetworkError> {
-        if let Some(parent) = config.http_socket.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
+        prepare_unix_socket_dir(&config.socket_dir)?;
         remove_stale_unix_socket(&config.http_socket)?;
         remove_stale_unix_socket(&config.socks_socket)?;
         let http_listener = UnixListener::bind(&config.http_socket)?;
@@ -434,6 +441,20 @@ impl Drop for LinuxManagedNetworkRelay {
         }
         let _ = std::fs::remove_file(&self.config.http_socket);
         let _ = std::fs::remove_file(&self.config.socks_socket);
+        let _ = std::fs::remove_dir(&self.config.socket_dir);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn prepare_unix_socket_dir(path: &Path) -> io::Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            std::fs::remove_file(path)?;
+            std::fs::create_dir_all(path)
+        }
+        Ok(_) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => std::fs::create_dir_all(path),
+        Err(err) => Err(err),
     }
 }
 
@@ -1324,6 +1345,18 @@ mod tests {
         let bridge = proxy
             .apply_linux_bridge_to_env(&mut env, temp.path())
             .expect("Linux relay sockets");
+        assert_eq!(
+            bridge.socket_dir,
+            temp.path().join(LINUX_MANAGED_NETWORK_SOCKET_DIR_NAME)
+        );
+        assert_eq!(
+            bridge.http_socket.parent(),
+            Some(bridge.socket_dir.as_path())
+        );
+        assert_eq!(
+            bridge.socks_socket.parent(),
+            Some(bridge.socket_dir.as_path())
+        );
 
         let mut client = UnixStream::connect(&bridge.http_socket).expect("connect HTTP relay");
         client
@@ -1347,6 +1380,27 @@ mod tests {
         assert!(response.contains("HTTP/1.1 200 OK"), "{response}");
         assert!(response.ends_with("relayed"), "{response}");
         origin_thread.join().expect("origin thread");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_unix_socket_relay_replaces_stale_socket_dir_symlink() {
+        let temp = tempfile::Builder::new()
+            .prefix("mcp-repl-linux-relay-dir-")
+            .tempdir()
+            .expect("tempdir");
+        let target = temp.path().join("target");
+        std::fs::create_dir(&target).expect("target dir");
+        let socket_dir = temp.path().join("relay");
+        std::os::unix::fs::symlink(&target, &socket_dir).expect("relay dir symlink");
+
+        prepare_unix_socket_dir(&socket_dir).expect("prepare relay dir");
+        let metadata = std::fs::symlink_metadata(&socket_dir).expect("relay dir metadata");
+
+        assert!(
+            metadata.is_dir() && !metadata.file_type().is_symlink(),
+            "relay dir should be a real directory, not a stale symlink"
+        );
     }
 
     #[test]

--- a/src/python_session.rs
+++ b/src/python_session.rs
@@ -158,6 +158,18 @@ pub(crate) fn begin_input(input: String) -> Result<(), String> {
     Ok(())
 }
 
+pub(crate) fn request_shutdown() {
+    let Some(state) = SESSION_STATE.get() else {
+        return;
+    };
+    let mut guard = state.inner.lock().unwrap();
+    // Preserve already accepted input; reset replies include output produced
+    // while the old worker drains to a safe runtime boundary.
+    guard.shutdown = true;
+    guard.interrupt_requested = false;
+    state.cvar.notify_all();
+}
+
 #[cfg(target_family = "unix")]
 fn discard_pending_stdin() {
     discard_queued_input();
@@ -362,7 +374,7 @@ fn wait_for_next_cell() -> Option<CellInput> {
     let state = session_state();
     let mut guard = state.inner.lock().unwrap();
     loop {
-        if guard.shutdown || guard.exit_requested {
+        if guard.exit_requested {
             return None;
         }
         if guard.interrupt_requested {
@@ -382,6 +394,9 @@ fn wait_for_next_cell() -> Option<CellInput> {
         {
             guard.cell_running = true;
             return Some(CellInput { source });
+        }
+        if guard.shutdown {
+            return None;
         }
         guard = state.cvar.wait(guard).unwrap();
     }
@@ -536,7 +551,7 @@ fn next_queue_line_action(
 ) -> QueueReadAction {
     let mut guard = state.inner.lock().unwrap();
     loop {
-        if guard.shutdown || guard.exit_requested {
+        if guard.exit_requested {
             if *owns_consumer {
                 guard.input_queue.end_read_consumer();
                 *owns_consumer = false;
@@ -578,6 +593,14 @@ fn next_queue_line_action(
                 detached_request,
                 emit_input_line,
             };
+        }
+        if guard.shutdown {
+            if *owns_consumer {
+                guard.input_queue.end_read_consumer();
+                *owns_consumer = false;
+            }
+            state.cvar.notify_all();
+            return QueueReadAction::Shutdown;
         }
         if !*prompt_wait_emitted {
             *prompt_wait_emitted = true;
@@ -664,7 +687,7 @@ fn read_queue_raw_bytes(size: usize) -> Result<Vec<u8>, RawStdinReadError> {
         let action = {
             let mut guard = state.inner.lock().unwrap();
             loop {
-                if guard.shutdown || guard.exit_requested {
+                if guard.exit_requested {
                     if owns_consumer {
                         guard.input_queue.end_read_consumer();
                         state.cvar.notify_all();
@@ -706,6 +729,13 @@ fn read_queue_raw_bytes(size: usize) -> Result<Vec<u8>, RawStdinReadError> {
                         detached_request: !guard.cell_running,
                         emit_input_line,
                     };
+                }
+                if guard.shutdown {
+                    if owns_consumer {
+                        guard.input_queue.end_read_consumer();
+                        state.cvar.notify_all();
+                    }
+                    return Ok(output);
                 }
                 if !prompt_wait_emitted {
                     prompt_wait_emitted = true;

--- a/src/python_worker.rs
+++ b/src/python_worker.rs
@@ -51,7 +51,7 @@ fn init_ipc() -> Result<(), Box<dyn std::error::Error>> {
                         }
                     }
                     Some(ServerToWorkerIpcMessage::Shutdown {}) => {
-                        std::process::exit(0);
+                        python_session::request_shutdown();
                     }
                     None => {
                         std::process::exit(0);

--- a/src/r_session.rs
+++ b/src/r_session.rs
@@ -71,6 +71,18 @@ impl RSession {
         state.cvar.notify_all();
         Ok(())
     }
+
+    pub fn request_shutdown(&self) -> Result<(), String> {
+        self.wait_until_ready()?;
+        let state = session_state();
+        let mut guard = state.inner.lock().unwrap();
+        // Preserve already accepted input; reset replies include output produced
+        // while the old worker drains to a safe runtime boundary.
+        guard.shutdown = true;
+        guard.read_interrupted = false;
+        state.cvar.notify_all();
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -1038,17 +1050,6 @@ pub extern "C-unwind" fn r_read_console(
             return 0;
         }
 
-        if guard.shutdown {
-            let should_emit = !guard.session_end_emitted;
-            guard.session_end_emitted = true;
-            drop(guard);
-            complete_session_if_needed(should_emit);
-            if !buf.is_null() {
-                unsafe { *buf = 0 };
-            }
-            return 0;
-        }
-
         if guard.read_interrupted {
             guard.read_interrupted = false;
             guard.waiting_for_input = false;
@@ -1077,6 +1078,17 @@ pub extern "C-unwind" fn r_read_console(
             ipc::emit_input_line(prompt, &line_text.text);
 
             return 1;
+        }
+
+        if guard.shutdown {
+            let should_emit = !guard.session_end_emitted;
+            guard.session_end_emitted = true;
+            drop(guard);
+            complete_session_if_needed(should_emit);
+            if !buf.is_null() {
+                unsafe { *buf = 0 };
+            }
+            return 0;
         }
 
         if guard.active_input {

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -2205,6 +2205,7 @@ fn sanitize_linux_sandbox_policy(policy: &SandboxPolicy) -> SandboxPolicy {
 fn linux_effective_file_system_policy(
     policy: &SandboxPolicy,
     session_temp_dir: &Path,
+    managed_network_socket_dir: Option<&Path>,
 ) -> FileSystemSandboxPolicy {
     let mut file_system = file_system_policy_from_legacy(policy);
     if matches!(file_system.kind, FileSystemSandboxKind::Restricted)
@@ -2222,24 +2223,30 @@ fn linux_effective_file_system_policy(
         }
     }
     if matches!(file_system.kind, FileSystemSandboxKind::Restricted)
+        && let Some(socket_dir) =
+            managed_network_socket_dir.and_then(|path| ensure_absolute(path.to_path_buf()))
+    {
+        push_linux_read_entry(&mut file_system, socket_dir);
+    }
+    if matches!(file_system.kind, FileSystemSandboxKind::Restricted)
         && !file_system.has_full_disk_read_access()
         && let Ok(current_exe) = std::env::current_exe()
         && let Some(current_exe) = ensure_absolute(current_exe)
     {
-        push_linux_implementation_read_entry(&mut file_system, current_exe);
+        push_linux_read_entry(&mut file_system, current_exe);
     }
     if matches!(file_system.kind, FileSystemSandboxKind::Restricted)
         && !file_system.has_full_disk_read_access()
         && let Some(r_home) = embedded_r_home()
         && let Some(r_home) = ensure_absolute(r_home.clone())
     {
-        push_linux_implementation_read_entry(&mut file_system, r_home);
+        push_linux_read_entry(&mut file_system, r_home);
     }
     file_system
 }
 
 #[cfg(target_os = "linux")]
-fn push_linux_implementation_read_entry(file_system: &mut FileSystemSandboxPolicy, path: PathBuf) {
+fn push_linux_read_entry(file_system: &mut FileSystemSandboxPolicy, path: PathBuf) {
     let entry = FileSystemSandboxEntry {
         path: FileSystemPath::Path { path },
         access: FileSystemAccessMode::Read,
@@ -3143,6 +3150,7 @@ struct LinuxSandboxArgs {
 #[cfg(target_os = "linux")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct LinuxManagedNetworkBridgeArgs {
+    socket_dir: PathBuf,
     http_socket: PathBuf,
     socks_socket: PathBuf,
 }
@@ -3266,10 +3274,10 @@ fn linux_sandbox_parse_args() -> Result<LinuxSandboxArgs, String> {
         return Err("no command specified to execute".to_string());
     }
     let managed_network_bridge = match (managed_network_http_socket, managed_network_socks_socket) {
-        (Some(http_socket), Some(socks_socket)) => Some(LinuxManagedNetworkBridgeArgs {
+        (Some(http_socket), Some(socks_socket)) => Some(linux_managed_network_bridge_args(
             http_socket,
             socks_socket,
-        }),
+        )?),
         (None, None) => None,
         _ => {
             return Err(
@@ -3288,6 +3296,43 @@ fn linux_sandbox_parse_args() -> Result<LinuxSandboxArgs, String> {
         apply_seccomp_then_exec,
         no_proc,
         managed_network_bridge,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn linux_managed_network_bridge_args(
+    http_socket: PathBuf,
+    socks_socket: PathBuf,
+) -> Result<LinuxManagedNetworkBridgeArgs, String> {
+    if !http_socket.is_absolute() {
+        return Err(format!(
+            "HTTP managed network bridge socket path must be absolute: {}",
+            http_socket.display()
+        ));
+    }
+    if !socks_socket.is_absolute() {
+        return Err(format!(
+            "SOCKS managed network bridge socket path must be absolute: {}",
+            socks_socket.display()
+        ));
+    }
+    let http_parent = http_socket
+        .parent()
+        .ok_or_else(|| "HTTP managed network bridge socket path has no parent".to_string())?;
+    let socks_parent = socks_socket
+        .parent()
+        .ok_or_else(|| "SOCKS managed network bridge socket path has no parent".to_string())?;
+    if http_parent != socks_parent {
+        return Err(format!(
+            "Linux managed network bridge sockets must share a directory: {} and {}",
+            http_socket.display(),
+            socks_socket.display()
+        ));
+    }
+    Ok(LinuxManagedNetworkBridgeArgs {
+        socket_dir: http_parent.to_path_buf(),
+        http_socket,
+        socks_socket,
     })
 }
 
@@ -3599,8 +3644,15 @@ fn linux_exec_bwrap_sandbox(args: LinuxSandboxArgs) -> Result<(), String> {
     let bwrap_program = linux_find_bwrap_program()
         .ok_or_else(|| "bwrap executable not found (tried /usr/bin/bwrap and PATH)".to_string())?;
     let inner = linux_build_inner_seccomp_command(&args)?;
-    let file_system_policy =
-        linux_effective_file_system_policy(&args.sandbox_policy, &args.session_temp_dir);
+    let managed_network_socket_dir = args
+        .managed_network_bridge
+        .as_ref()
+        .map(|bridge| bridge.socket_dir.as_path());
+    let file_system_policy = linux_effective_file_system_policy(
+        &args.sandbox_policy,
+        &args.session_temp_dir,
+        managed_network_socket_dir,
+    );
     let network_mode =
         linux_bwrap_network_mode(&args.sandbox_policy, args.managed_network_bridge.is_some());
     let mount_proc = !args.no_proc
@@ -5096,7 +5148,8 @@ fn linux_apply_sandbox_policy_to_current_thread(
     apply_landlock_fs: bool,
     network_seccomp_mode: Option<LinuxNetworkSeccompMode>,
 ) -> Result<(), String> {
-    let file_system_policy = linux_effective_file_system_policy(sandbox_policy, session_temp_dir);
+    let file_system_policy =
+        linux_effective_file_system_policy(sandbox_policy, session_temp_dir, None);
     if !file_system_policy.has_full_disk_write_access() || network_seccomp_mode.is_some() {
         linux_set_no_new_privs()?;
     }
@@ -6380,6 +6433,21 @@ mod tests {
             "SOCKS relay socket should live under session temp: {:?}",
             prepared.args
         );
+        let http_socket = Path::new(&prepared.args[http_socket_index + 1]);
+        let socks_socket = Path::new(&prepared.args[socks_socket_index + 1]);
+        let socket_dir = http_socket.parent().expect("HTTP socket parent");
+        assert_eq!(
+            socks_socket.parent(),
+            Some(socket_dir),
+            "bridge sockets should share a private relay directory: {:?}",
+            prepared.args
+        );
+        assert_ne!(
+            socket_dir,
+            session_temp_dir.as_path(),
+            "bridge sockets should not live directly in writable session temp: {:?}",
+            prepared.args
+        );
     }
 
     #[cfg(target_os = "linux")]
@@ -6540,6 +6608,7 @@ mod tests {
                 exclude_slash_tmp: true,
             },
             &session_temp_dir,
+            None,
         );
 
         let err = linux_landlock_writable_root_paths(
@@ -6565,6 +6634,7 @@ mod tests {
                 network_access: false,
             },
             &session_temp_dir,
+            None,
         );
 
         let writable_roots =
@@ -7033,6 +7103,7 @@ mod tests {
                 network_access: false,
             },
             &session_temp_dir,
+            None,
         );
 
         let command =
@@ -7046,6 +7117,41 @@ mod tests {
                 .windows(3)
                 .any(|args| args[0] == "--ro-bind" && args[2] == git_text),
             "read-only session temp metadata should use private synthetic binds: {:?}",
+            command.args
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_bwrap_managed_network_socket_dir_is_read_only() {
+        let root = Builder::new()
+            .prefix("mcp-repl-bwrap-managed-network-")
+            .tempdir()
+            .expect("tempdir");
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        let session_temp_dir = root.path().join("session");
+        let socket_dir =
+            session_temp_dir.join(crate::managed_network::LINUX_MANAGED_NETWORK_SOCKET_DIR_NAME);
+        std::fs::create_dir_all(&socket_dir).expect("managed network socket dir");
+        let file_system_policy = linux_effective_file_system_policy(
+            &SandboxPolicy::ReadOnly {
+                network_access: false,
+            },
+            &session_temp_dir,
+            Some(&socket_dir),
+        );
+
+        let command =
+            linux_bwrap_filesystem_args(&file_system_policy, &workspace, &session_temp_dir)
+                .expect("managed network bwrap profile should build");
+        let socket_dir_text = linux_path_to_string(&socket_dir);
+
+        assert!(
+            command.args.windows(3).any(|args| args[0] == "--ro-bind"
+                && args[1] == socket_dir_text
+                && args[2] == socket_dir_text),
+            "managed network relay socket directory should be read-only in bwrap: {:?}",
             command.args
         );
     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -66,7 +66,7 @@ fn init_ipc() -> Result<(), Box<dyn std::error::Error>> {
                         crate::r_session::interrupt_pending_input();
                     }
                     Some(ServerToWorkerIpcMessage::Shutdown {}) => {
-                        std::process::exit(0);
+                        let _ = wait_for_r_session().and_then(RSession::request_shutdown);
                     }
                     None => {
                         // Without IPC, the worker cannot participate in input accounting (prompt,

--- a/src/worker_supervisor.rs
+++ b/src/worker_supervisor.rs
@@ -415,6 +415,7 @@ fn seed_initial_readiness_from_process(
 pub(crate) struct WorkerProcess {
     child: WorkerChild,
     stdin_tx: mpsc::Sender<StdinCommand>,
+    shutdown_stdin_policy: ShutdownStdinPolicy,
     session_tmpdir: Option<PathBuf>,
     ipc: IpcHandle,
     live_output: LiveOutputCapture,
@@ -433,6 +434,21 @@ pub(crate) struct WorkerProcess {
     linux_bwrap_sandboxed: bool,
     #[cfg(target_os = "macos")]
     denial_logger: Option<crate::sandbox::DenialLogger>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ShutdownStdinPolicy {
+    CloseBeforeWait,
+    CloseAfterWait,
+}
+
+impl ShutdownStdinPolicy {
+    fn for_worker_launch(worker_launch: &WorkerLaunch) -> Self {
+        match worker_launch {
+            WorkerLaunch::Builtin(Backend::Python) => Self::CloseAfterWait,
+            WorkerLaunch::Builtin(Backend::R) | WorkerLaunch::Custom(_) => Self::CloseBeforeWait,
+        }
+    }
 }
 
 enum StdinCommand {
@@ -705,6 +721,7 @@ impl WorkerProcess {
         sandbox_state: &SandboxState,
         context: WorkerSpawnContext<'_>,
     ) -> Result<Self, WorkerError> {
+        let shutdown_stdin_policy = ShutdownStdinPolicy::for_worker_launch(&worker_launch);
         let WorkerSpawnContext {
             oversized_output,
             output_timeline,
@@ -843,6 +860,7 @@ impl WorkerProcess {
         Ok(Self {
             child,
             stdin_tx,
+            shutdown_stdin_policy,
             session_tmpdir,
             ipc,
             live_output,
@@ -1328,13 +1346,20 @@ impl WorkerProcess {
 
     pub(crate) fn shutdown_graceful(mut self, timeout: Duration) -> Result<(), WorkerError> {
         self.request_ipc_shutdown();
-        let _ = self.close_stdin(Duration::from_millis(200));
+        self.close_stdin_before_shutdown_wait();
         self.finish_timed_shutdown(timeout)
     }
 
     pub(crate) fn shutdown_for_restart(mut self, timeout: Duration) -> Result<(), WorkerError> {
-        let _ = self.close_stdin(Duration::from_millis(200));
+        self.request_ipc_shutdown();
+        self.close_stdin_before_shutdown_wait();
         self.finish_timed_shutdown(timeout.min(WORKER_RESTART_SHUTDOWN_TIMEOUT))
+    }
+
+    fn close_stdin_before_shutdown_wait(&mut self) {
+        if self.shutdown_stdin_policy == ShutdownStdinPolicy::CloseBeforeWait {
+            let _ = self.close_stdin(Duration::from_millis(200));
+        }
     }
 
     fn finish_timed_shutdown(mut self, timeout: Duration) -> Result<(), WorkerError> {
@@ -1379,6 +1404,11 @@ impl WorkerProcess {
             }
         }
 
+        // Ensure the stdin writer is closed before finalization. Built-in
+        // Python reaches this point without an early close because Windows
+        // ConPTY can terminate the console worker before sideband shutdown lets
+        // an active request emit its final output.
+        let _ = self.close_stdin(Duration::from_millis(200));
         self.finalize_terminated_process()
     }
 
@@ -1565,6 +1595,7 @@ impl WorkerProcess {
         Self {
             child: WorkerChild::standard(child),
             stdin_tx,
+            shutdown_stdin_policy: ShutdownStdinPolicy::CloseBeforeWait,
             session_tmpdir: None,
             ipc: IpcHandle::new(),
             live_output: LiveOutputCapture::new(
@@ -2395,8 +2426,9 @@ where
                 }
                 StdinCommand::Close { reply } => {
                     let result = writer.flush().map_err(WorkerError::Io);
+                    drop(writer);
                     let _ = reply.send(result);
-                    break;
+                    return;
                 }
             }
         }

--- a/tests/manage_session_behavior.rs
+++ b/tests/manage_session_behavior.rs
@@ -213,7 +213,7 @@ Sys.sleep(1.0)
     );
     assert!(
         !timeout_text.contains("RESTART_LINE_"),
-        "did not expect restart-only output before Ctrl-D closes stdin, got: {timeout_text:?}"
+        "did not expect restart-only output before Ctrl-D requests shutdown, got: {timeout_text:?}"
     );
 
     let restart = session
@@ -343,7 +343,7 @@ flush.console()
     );
     assert!(
         !timeout_text.contains("DURING_RESTART"),
-        "did not expect restart-only output before Ctrl-D closes stdin, got: {timeout_text:?}"
+        "did not expect restart-only output before Ctrl-D requests shutdown, got: {timeout_text:?}"
     );
 
     let restart = session

--- a/tests/sandbox_state_meta.rs
+++ b/tests/sandbox_state_meta.rs
@@ -486,6 +486,22 @@ fn encode_path(path: &Path) -> TestResult<String> {
     Ok(serde_json::to_string(&path.to_string_lossy().to_string())?)
 }
 
+async fn wait_for_path_then_remove(path: &Path, label: &str) -> TestResult<()> {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        match fs::remove_file(path) {
+            Ok(()) => return Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                if tokio::time::Instant::now() >= deadline {
+                    return Err(format!("timed out waiting for {label}: {}", path.display()).into());
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
+}
+
 fn bundle_transcript_path(text: &str) -> Option<std::path::PathBuf> {
     disclosed_path(text, "transcript.txt")
 }
@@ -2150,7 +2166,7 @@ async fn sandbox_inherit_empty_poll_session_end_respawn_uses_current_state_meta(
         return Ok(());
     }
 
-    let _ = fs::remove_file(&startup_target);
+    wait_for_path_then_remove(&startup_target, "initial R startup marker").await?;
     tokio::time::sleep(std::time::Duration::from_millis(260)).await;
 
     let drained = session
@@ -2312,7 +2328,7 @@ async fn sandbox_inherit_empty_poll_session_end_without_state_meta_does_not_resp
         return Ok(());
     }
 
-    let _ = fs::remove_file(&startup_target);
+    wait_for_path_then_remove(&startup_target, "initial R startup marker").await?;
     tokio::time::sleep(std::time::Duration::from_millis(260)).await;
 
     let drained = session.write_stdin_raw_with("", Some(2.0)).await?;
@@ -2388,7 +2404,7 @@ async fn sandbox_inherit_bare_interrupt_after_session_end_uses_current_state_met
         return Ok(());
     }
 
-    let _ = fs::remove_file(&startup_target);
+    wait_for_path_then_remove(&startup_target, "initial R startup marker").await?;
     tokio::time::sleep(std::time::Duration::from_millis(260)).await;
 
     let interrupt = session
@@ -2453,7 +2469,7 @@ async fn sandbox_inherit_bare_interrupt_after_session_end_without_state_meta_doe
         return Ok(());
     }
 
-    let _ = fs::remove_file(&startup_target);
+    wait_for_path_then_remove(&startup_target, "initial R startup marker").await?;
     tokio::time::sleep(std::time::Duration::from_millis(260)).await;
 
     let interrupt = session

--- a/tests/zod_protocol.rs
+++ b/tests/zod_protocol.rs
@@ -249,6 +249,24 @@ async fn spawn_zod_server(control_log: &std::path::Path) -> TestResult<common::M
     spawn_zod_server_with_extra_args(control_log, Vec::new()).await
 }
 
+async fn warm_zod_session(session: &common::McpTestSession) -> TestResult<()> {
+    let result = session
+        .call_tool_raw(
+            "repl",
+            json!({
+                "input": "emit-output-after-input",
+                "timeout_ms": 5_000
+            }),
+        )
+        .await?;
+    let text = result_text(&result);
+    assert!(
+        text.contains("after input_line"),
+        "zod worker warm-up did not complete as expected, got: {text:?}"
+    );
+    Ok(())
+}
+
 async fn spawn_zod_startup_ready_server(
     control_log: &std::path::Path,
 ) -> TestResult<common::McpTestSession> {
@@ -989,6 +1007,7 @@ async fn zod_files_timeout_does_not_wait_for_utf8_tail_grace_after_expiry() -> T
         Vec::new(),
     )
     .await?;
+    warm_zod_session(&session).await?;
 
     let timed_out = tokio::time::timeout(
         Duration::from_secs(5),
@@ -1314,6 +1333,7 @@ async fn zod_files_completion_bounds_stable_wait_after_utf8_recovery() -> TestRe
     let tempdir = tempfile::tempdir()?;
     let control_log = tempdir.path().join("control.log");
     let session = spawn_zod_server(&control_log).await?;
+    warm_zod_session(&session).await?;
 
     let start = std::time::Instant::now();
     let result = session


### PR DESCRIPTION
## Summary
- Public-facing: On Linux, managed-network bridge sockets now live under a private session subdirectory that is mounted read-only in bubblewrap, so sandboxed workers can connect without being able to replace the socket path entries.
- Public-facing: Ctrl-D reset/restart now requests worker shutdown over sideband before worker-specific stdin handling, preserving already accepted R/Python input long enough to return old-worker shutdown output before any fresh-session tail output.
- Internal-only: The Linux bridge validates absolute socket paths in a shared directory, replaces stale relay-directory symlinks with a real directory, and cleans up relay socket files plus the private directory.
- Internal-only: Session-end and Zod timing tests now wait for observable startup markers or warm the session before timing-sensitive assertions; docs describe the new shutdown contract.
