### PR TITLE
Clarify sandbox inheritance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,14 @@ mcp-repl install --client codex --interpreter r  # limit to one interpreter
 By default this writes entries for both `r` and `python`.
 
 `install --client codex` writes
-`--sandbox inherit --oversized-output files` — `inherit` tells
-`mcp-repl` to take sandbox policy from Codex's per-call metadata (it
-fails closed if the metadata is missing or malformed).
+`--sandbox inherit-codex --oversized-output files` — `inherit-codex` tells
+`mcp-repl` to take sandbox policy from Codex's per-call
+`_meta["codex/sandbox-state-meta"]` metadata (it fails closed if the metadata
+is missing or malformed).
 `install --client claude` writes an explicit `--sandbox workspace-write`
-because Claude doesn't propagate that metadata. Bare `mcp-repl` (no
-install) defaults to `--oversized-output pager`.
+because Claude Code does not provide a way to propagate Codex's per-call
+sandbox metadata to MCP servers. Bare `mcp-repl` (no install) defaults to
+`--oversized-output pager`.
 
 Manual Codex entry:
 
@@ -110,11 +112,13 @@ Manual Codex entry:
 [mcp_servers.r]
 command = "/Users/alice/.cargo/bin/mcp-repl"
 tool_timeout_sec = 1800   # outer guard; mcp-repl handles the primary timeout
-args = ["--sandbox", "inherit", "--oversized-output", "files", "--interpreter", "r"]
+args = ["--sandbox", "inherit-codex", "--oversized-output", "files", "--interpreter", "r"]
 ```
 
 Swap `--interpreter r` for `--interpreter python` (and rename the
 section) for the Python entry.
+Existing Codex configs that use `--sandbox inherit` still work; it is a
+compatibility alias for `inherit-codex`.
 
 Manual Claude entry in `~/.claude.json`:
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -57,7 +57,7 @@ These switches are useful when the client is sending Codex sandbox metadata or w
 Example:
 
 ```sh
-MCP_REPL_DEBUG_DIR=/tmp/mcp-repl-debug mcp-repl --sandbox inherit
+MCP_REPL_DEBUG_DIR=/tmp/mcp-repl-debug mcp-repl --sandbox inherit-codex
 ```
 
 ## Interactive debug REPL
@@ -69,9 +69,9 @@ In debug/dev builds, `--debug-repl` runs `mcp-repl` as a local interactive
 driver for the worker instead of as an MCP server. This is the fastest way to
 reproduce REPL behavior without involving a client.
 
-If you start it with `--sandbox inherit`, the debug REPL bootstraps one local
-inherited sandbox snapshot from the current default sandbox state before the
-first worker spawn. That keeps the inherit code path debuggable even though
+If you start it with `--sandbox inherit-codex`, the debug REPL bootstraps one
+local inherited sandbox snapshot from the current default sandbox state before
+the first worker spawn. That keeps the inherit code path debuggable even though
 there is no per-tool-call MCP metadata in local debug mode.
 
 Start it with:

--- a/docs/futurework/claude-sandbox-inherit.md
+++ b/docs/futurework/claude-sandbox-inherit.md
@@ -39,8 +39,8 @@ Reference: <https://docs.claude.com/en/docs/claude-code/settings>
   instead of preserving stale assumptions about settings shape or permission
   semantics.
 - Decide whether to add a Claude-specific inherit mode, for example
-  `--sandbox inherit-claude`, or to extend `--sandbox inherit` with a documented
-  client source.
+  `--sandbox claude-inherit`, or to add a broader documented client-source
+  selector.
 - Claude inheritance is likely startup/project scoped, not per-tool-call scoped,
   unless Claude later sends sandbox metadata with MCP tool calls.
 - Do not silently broaden permissions. If the Claude settings shape cannot be

--- a/docs/futurework/mcp-client-install-managed-network-defaults.md
+++ b/docs/futurework/mcp-client-install-managed-network-defaults.md
@@ -62,10 +62,10 @@ prefer explicit, explainable entries over a large convenience allowlist.
 
 - MCP client install is written by `src/install.rs`.
 - `mcp-repl install --client codex` currently writes MCP server entries with
-  `--sandbox inherit --oversized-output files`.
-- `--sandbox inherit` means the server resolves the effective worker sandbox
-  from Codex per-tool-call sandbox metadata before applying later CLI/config
-  operations.
+  `--sandbox inherit-codex --oversized-output files`.
+- `--sandbox inherit-codex` means the server resolves the effective worker
+  sandbox from Codex per-tool-call sandbox metadata before applying later
+  CLI/config operations.
 - `mcp-repl install --client claude` currently writes Claude config with an
   explicit sandbox mode and `--oversized-output files`; Claude sandbox-inherit
   support is separate future work.
@@ -83,8 +83,8 @@ prefer explicit, explainable entries over a large convenience allowlist.
   sandbox, or that diverges from Claude's configured sandbox shape.
 - Avoid forcing network configuration onto read-only tool calls. A naive
   `--config sandbox_workspace_write.network_access=true` appended after
-  `--sandbox inherit` can fail when Codex sends read-only sandbox metadata,
-  because that setting only applies to workspace-write policies.
+  `--sandbox inherit-codex` can fail when Codex sends read-only sandbox
+  metadata, because that setting only applies to workspace-write policies.
 - Decide whether defaults belong in the MCP client's own sandbox configuration,
   in `mcp-repl` server args, or in a new install-time helper that only affects
   workspace-write calls. The MCP client and `mcp-repl` should agree on the
@@ -103,7 +103,7 @@ prefer explicit, explainable entries over a large convenience allowlist.
   client config contains default managed-network entries in the chosen config
   location.
 - For Codex, assert that generated MCP server entries still preserve
-  `--sandbox inherit`.
+  `--sandbox inherit-codex`.
 - For Codex, assert that read-only inherited sandbox metadata does not fail
   solely because install added managed-network defaults for workspace-write
   calls.

--- a/docs/futurework/portable-plugin-skill-mcp-bundle.md
+++ b/docs/futurework/portable-plugin-skill-mcp-bundle.md
@@ -234,8 +234,8 @@ Likely reasons to split:
 - The server command must reference a binary or script inside the plugin
   directory.
 - The server needs a plugin-persistent data directory.
-- The Codex config needs `--sandbox inherit` while Claude needs explicit default
-  sandbox behavior.
+- The Codex config needs `--sandbox inherit-codex` while Claude needs explicit
+  default sandbox behavior.
 - The client requires different environment variables or approval metadata.
 
 For plugin-relative code, a Codex-specific config can use a relative `cwd` that
@@ -354,8 +354,8 @@ the plugin root under `plugins/mcp-repl/`.
 
 - Should the plugin expose one server per interpreter, or one server with a
   selected default interpreter?
-- How should plugin install preserve Codex `--sandbox inherit` while using
-  explicit sandbox defaults for Claude?
+- How should plugin install preserve Codex `--sandbox inherit-codex` while
+  using explicit sandbox defaults for Claude?
 - Should the plugin be generated from the existing install code, or checked in
   as static assets?
 - What should be the release vehicle: repo artifact, package registry, or

--- a/docs/futurework/project-local-mcp-repl-config.md
+++ b/docs/futurework/project-local-mcp-repl-config.md
@@ -51,7 +51,7 @@ Example project config:
 oversized_output = "files"
 
 [sandbox]
-mode = "inherit"
+mode = "inherit-codex"
 
 [sandbox.workspace_write]
 network_access = true

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ checked-in execution plans without relying on stale notes.
 - `docs/worker_sideband_protocol.md`: IPC-queued server/worker protocol
   contract.
 - `docs/plans/AGENTS.md`: when to write a checked-in execution plan and where it lives.
-- `docs/plans/completed/codex-sandbox-state-meta-migration.md`: completed plan for migrating Codex `--sandbox inherit` from async updates to per-tool-call sandbox metadata.
+- `docs/plans/completed/codex-sandbox-state-meta-migration.md`: completed plan for migrating Codex sandbox inheritance from async updates to per-tool-call sandbox metadata.
 - `docs/plans/completed/unified-output-timeline-pipeline.md`: completed plan for consolidating normal replies, files overflow, and pager overflow onto one output timeline.
 
 ## Normative Docs

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -10,11 +10,20 @@ When no CLI sandbox mode is provided, the default is:
 - `workspace-write`
 - `network_access: false`
 
-When `--sandbox inherit` is used for MCP server operation, the MCP client must
+When `--sandbox inherit-codex` is used for MCP server operation, Codex must
 attach per-tool-call sandbox metadata in `_meta["codex/sandbox-state-meta"]`.
 That metadata is the source of truth for the tool call that is about to run. If
-it is missing or malformed, `mcp-repl` fails closed with `--sandbox inherit
-requested but no client sandbox state was provided`.
+it is missing or malformed, `mcp-repl` fails closed instead of guessing a local
+policy. `--sandbox inherit` is accepted as a compatibility alias for existing
+Codex configs.
+
+Claude Code and other generic MCP clients do not provide sandbox policy in
+Codex's per-call metadata shape. Claude Code may send ordinary tool-call
+bookkeeping in `_meta`, such as progress or tool-use identifiers, but not a
+sandbox policy that `mcp-repl` can apply. Use an explicit mode such as
+`--sandbox workspace-write` with those clients. Claude-inherit support would
+need a separate startup/project-scoped mapping from Claude settings; it cannot
+use the Codex per-tool-call metadata path.
 
 Current Codex builds send this metadata as a `permissionProfile` plus a
 `sandboxCwd` file URI. On macOS, `mcp-repl` consumes the managed filesystem
@@ -27,9 +36,9 @@ existing CLI surface.
 
 Debug/dev builds have one local-only exception: `--debug-repl`. Because there
 is no MCP client metadata channel in that mode, `mcp-repl --debug-repl
---sandbox inherit` bootstraps one local inherited snapshot from the current
-default sandbox state before the first worker spawn. Shipped release binaries
-do not include `--debug-repl`.
+--sandbox inherit-codex` bootstraps one local inherited snapshot from the
+current default sandbox state before the first worker spawn. Shipped release
+binaries do not include `--debug-repl`.
 
 For `repl`, inherited sandbox metadata controls the worker session that handles
 the call. When a non-empty tool call would use the worker and the effective
@@ -58,7 +67,7 @@ More specifically:
   `_meta["codex/sandbox-state-meta"]`.
 - A non-empty retry after the memory guardrail aborts a worker is an ordinary
   non-empty call. It must have valid current metadata before `mcp-repl` resets
-  or retries under `--sandbox inherit`.
+  or retries under `--sandbox inherit-codex`.
 - Non-empty `repl` calls resolve stale timeout markers before deciding whether
   they are still looking at a live worker request.
 - If current metadata changes the effective inherited sandbox, `mcp-repl`
@@ -80,7 +89,7 @@ The worker also gets a per-session temp directory, exported as:
 
 ## Configure sandbox policy
 
-- Base mode: `mcp-repl --sandbox inherit|read-only|workspace-write|danger-full-access`
+- Base mode: `mcp-repl --sandbox read-only|workspace-write|danger-full-access|inherit-codex`
 - Add writable roots (workspace-write only, repeatable):
   `mcp-repl --add-writable-root /absolute/path`
 - Add allowed domains (repeatable):
@@ -88,7 +97,7 @@ The worker also gets a per-session temp directory, exported as:
 - Advanced overrides:
   `mcp-repl --config key=value` with documented sandbox/config keys
 - MCP sandbox metadata capability:
-  `codex/sandbox-state-meta` (advertised only when the effective CLI sandbox mode still resolves to `inherit` after later overrides)
+  `codex/sandbox-state-meta` (advertised only when the effective CLI sandbox mode still resolves to `inherit-codex` after later overrides)
 
 Operations are applied strictly in CLI argument order. Later operations win.
 `--sandbox ...` resets the base policy at the point where it appears.

--- a/src/install.rs
+++ b/src/install.rs
@@ -11,7 +11,7 @@ use toml_edit::{Array, DocumentMut, Item, Table, value};
 const CODEX_TOOL_TIMEOUT_SECS: i64 = 1_800;
 const CODEX_TOOL_TIMEOUT_COMMENT: &str =
     "\n# mcp-repl handles the primary timeout; this higher Codex timeout is only an outer guard.\n";
-const CODEX_SANDBOX_INHERIT_COMMENT: &str = "\n# --sandbox inherit: use sandbox policy metadata sent by Codex on each tool call.\n# mcp-repl fails closed if the tool call omits or malforms that metadata.\n";
+const CODEX_SANDBOX_INHERIT_COMMENT: &str = "\n# --sandbox inherit-codex: use sandbox policy metadata sent by Codex on each tool call.\n# mcp-repl fails closed if the tool call omits or malforms that metadata.\n";
 pub const DEFAULT_R_SERVER_NAME: &str = "r";
 pub const DEFAULT_PYTHON_SERVER_NAME: &str = "python";
 const MCP_REPL_TOOL_NAMES: &[&str] = &["repl"];
@@ -346,7 +346,7 @@ fn codex_install_args(base_args: &[String]) -> Vec<String> {
     let mut args = base_args.to_vec();
     if !has_sandbox_config_arg(base_args) {
         args.push("--sandbox".to_string());
-        args.push("inherit".to_string());
+        args.push("inherit-codex".to_string());
     }
     if !has_oversized_output_arg(base_args) {
         args.push("--oversized-output".to_string());
@@ -428,7 +428,9 @@ fn upsert_codex_mcp_server(
             .leaf_decor_mut()
             .set_prefix(CODEX_TOOL_TIMEOUT_COMMENT);
     }
-    let args_prefix = if contains_sandbox_state_value(args, "inherit") {
+    let args_prefix = if contains_sandbox_state_value(args, "inherit-codex")
+        || contains_sandbox_state_value(args, "inherit")
+    {
         CODEX_SANDBOX_INHERIT_COMMENT
     } else {
         ""
@@ -1023,14 +1025,14 @@ name="demo"
             &config,
             "repl",
             "/path/to/mcp-repl",
-            &["--sandbox".to_string(), "inherit".to_string()],
+            &["--sandbox".to_string(), "inherit-codex".to_string()],
         )
         .expect("upsert codex");
 
         let text = fs::read_to_string(config).expect("read config");
         assert!(
             text.contains(
-                "--sandbox inherit: use sandbox policy metadata sent by Codex on each tool call"
+                "--sandbox inherit-codex: use sandbox policy metadata sent by Codex on each tool call"
             ),
             "expected inherit comment in codex config"
         );
@@ -1044,7 +1046,7 @@ name="demo"
             &config,
             "repl",
             "/path/to/mcp-repl",
-            &["--sandbox".to_string(), "inherit".to_string()],
+            &["--sandbox".to_string(), "inherit-codex".to_string()],
         )
         .expect("upsert codex inherit");
         upsert_codex_mcp_server(
@@ -1058,7 +1060,7 @@ name="demo"
         let text = fs::read_to_string(config).expect("read config");
         assert!(
             !text.contains(
-                "--sandbox inherit: use sandbox policy metadata sent by Codex on each tool call"
+                "--sandbox inherit-codex: use sandbox policy metadata sent by Codex on each tool call"
             ),
             "inherit-only comment should be removed when inherit is no longer configured"
         );
@@ -1073,7 +1075,7 @@ name="demo"
                 "--interpreter".to_string(),
                 "python".to_string(),
                 "--sandbox".to_string(),
-                "inherit".to_string(),
+                "inherit-codex".to_string(),
                 "--oversized-output".to_string(),
                 "files".to_string()
             ]
@@ -1170,7 +1172,7 @@ name="demo"
                 "--interpreter".to_string(),
                 "python".to_string(),
                 "--sandbox".to_string(),
-                "inherit".to_string(),
+                "inherit-codex".to_string(),
             ]
         );
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -616,9 +616,10 @@ Options:
       Choose oversized-output handling.
       Default: pager. Use files to spill oversized replies to bundle files.
 
-  --sandbox <inherit|read-only|workspace-write|danger-full-access>
+  --sandbox <read-only|workspace-write|danger-full-access|inherit-codex>
       Choose the base worker sandbox mode.
-      `inherit` uses client tool-call metadata.
+      `inherit-codex` uses Codex tool-call metadata.
+      `inherit` is accepted as a compatibility alias.
 
   --add-writable-root <abs-path>
       Append an absolute writable root in argument order.
@@ -869,7 +870,13 @@ mod tests {
     }
 
     #[test]
-    fn parse_sandbox_mode_accepts_inherit() {
+    fn parse_sandbox_mode_accepts_inherit_codex() {
+        let mode = SandboxModeArg::parse("inherit-codex").expect("sandbox mode");
+        assert!(matches!(mode, SandboxModeArg::Inherit));
+    }
+
+    #[test]
+    fn parse_sandbox_mode_accepts_inherit_alias() {
         let mode = SandboxModeArg::parse("inherit").expect("sandbox mode");
         assert!(matches!(mode, SandboxModeArg::Inherit));
     }
@@ -1070,7 +1077,7 @@ mod tests {
         };
         let err = resolve_effective_sandbox_state(&plan, None).expect_err("missing inherit update");
         assert!(
-            err.contains("--sandbox inherit requested but no client sandbox state was provided"),
+            err.contains("requires Codex per-tool-call sandbox metadata"),
             "unexpected error: {err}"
         );
     }

--- a/src/sandbox_cli.rs
+++ b/src/sandbox_cli.rs
@@ -3,8 +3,12 @@ use std::path::PathBuf;
 use crate::managed_network::validate_domain_patterns;
 use crate::sandbox::{SandboxPolicy, SandboxState};
 
-pub const MISSING_INHERITED_SANDBOX_STATE_MESSAGE: &str =
-    "--sandbox inherit requested but no client sandbox state was provided";
+pub const MISSING_INHERITED_SANDBOX_STATE_MESSAGE: &str = concat!(
+    "--sandbox inherit-codex (or its inherit alias) requires Codex per-tool-call ",
+    "sandbox metadata in _meta[\"codex/sandbox-state-meta\"]; Claude Code and other ",
+    "generic MCP clients do not provide that metadata, so use an explicit mode such ",
+    "as --sandbox workspace-write with those clients"
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SandboxModeArg {
@@ -17,12 +21,12 @@ pub enum SandboxModeArg {
 impl SandboxModeArg {
     pub fn parse(value: &str) -> Result<Self, String> {
         match value.trim() {
-            "inherit" => Ok(Self::Inherit),
+            "inherit-codex" | "inherit" => Ok(Self::Inherit),
             "read-only" => Ok(Self::ReadOnly),
             "workspace-write" => Ok(Self::WorkspaceWrite),
             "danger-full-access" => Ok(Self::DangerFullAccess),
             _ => Err(format!(
-                "invalid sandbox mode: {value} (expected inherit|read-only|workspace-write|danger-full-access)"
+                "invalid sandbox mode: {value} (expected read-only|workspace-write|danger-full-access|inherit-codex)"
             )),
         }
     }

--- a/tests/client_config_dual_backend.rs
+++ b/tests/client_config_dual_backend.rs
@@ -185,10 +185,10 @@ fn install_codex_target_defaults_to_r_and_python_servers() -> TestResult<()> {
     let has_sandbox_inherit = r_args
         .iter()
         .zip(r_args.iter().skip(1))
-        .any(|(a, b)| a.as_str() == Some("--sandbox") && b.as_str() == Some("inherit"));
+        .any(|(a, b)| a.as_str() == Some("--sandbox") && b.as_str() == Some("inherit-codex"));
     assert!(
         has_sandbox_inherit,
-        "expected r args to include `--sandbox inherit`"
+        "expected r args to include `--sandbox inherit-codex`"
     );
     let r_has_files_mode = r_args
         .iter()
@@ -213,10 +213,10 @@ fn install_codex_target_defaults_to_r_and_python_servers() -> TestResult<()> {
     let py_has_sandbox_inherit = py_args
         .iter()
         .zip(py_args.iter().skip(1))
-        .any(|(a, b)| a.as_str() == Some("--sandbox") && b.as_str() == Some("inherit"));
+        .any(|(a, b)| a.as_str() == Some("--sandbox") && b.as_str() == Some("inherit-codex"));
     assert!(
         py_has_sandbox_inherit,
-        "expected python args to include `--sandbox inherit`"
+        "expected python args to include `--sandbox inherit-codex`"
     );
     let py_has_files_mode = py_args
         .iter()

--- a/tests/codex_integration.rs
+++ b/tests/codex_integration.rs
@@ -1314,10 +1314,10 @@ mod unix_impl {
         let has_sandbox_inherit = r_args
             .iter()
             .zip(r_args.iter().skip(1))
-            .any(|(a, b)| a.as_str() == Some("--sandbox") && b.as_str() == Some("inherit"));
+            .any(|(a, b)| a.as_str() == Some("--sandbox") && b.as_str() == Some("inherit-codex"));
         assert!(
             has_sandbox_inherit,
-            "expected installed Codex config to include `--sandbox inherit`"
+            "expected installed Codex config to include `--sandbox inherit-codex`"
         );
         let direct_only = doc["features"]["code_mode"]["direct_only_tool_namespaces"]
             .as_array()
@@ -1407,7 +1407,7 @@ tool_suggest = false
 
 [mcp_servers.r]
 command = "{mcp_repl}"
-args = ["--sandbox", "inherit"]
+args = ["--sandbox", "inherit-codex"]
 env_vars = ["MCP_REPL_DEBUG_DIR"]
 [projects."{repo_root}"]
 trust_level = "trusted"
@@ -1441,7 +1441,7 @@ tool_suggest = false
 
 [mcp_servers.r]
 command = "{mcp_repl}"
-args = ["--sandbox", "inherit"]
+args = ["--sandbox", "inherit-codex"]
 env_vars = ["MCP_REPL_DEBUG_DIR"]
 [projects."{repo_root}"]
 trust_level = "trusted"
@@ -1489,7 +1489,7 @@ responses_websockets = false
 
 [mcp_servers.r]
 command = "{python_program}"
-args = ["{trace_script}", "{mcp_repl}", "--sandbox", "inherit"]
+args = ["{trace_script}", "{mcp_repl}", "--sandbox", "inherit-codex"]
 env_vars = ["MCP_REPL_DEBUG_DIR"]
 [projects."{repo_root}"]
 trust_level = "trusted"

--- a/tests/debug_repl_prompt.rs
+++ b/tests/debug_repl_prompt.rs
@@ -217,7 +217,7 @@ fn debug_repl_prints_initial_prompt() -> TestResult<()> {
 
 #[test]
 fn debug_repl_inherit_prints_initial_prompt() -> TestResult<()> {
-    assert_debug_repl_starts(&["--sandbox", "inherit"])
+    assert_debug_repl_starts(&["--sandbox", "inherit-codex"])
 }
 
 #[test]

--- a/tests/docs_contracts.rs
+++ b/tests/docs_contracts.rs
@@ -103,6 +103,26 @@ fn docs_index_lists_main_docs() {
 }
 
 #[test]
+fn sandbox_docs_explain_inherit_codex_scope() {
+    let sandbox = read(&repo_root().join("docs/sandbox.md"));
+    let readme = read(&repo_root().join("README.md"));
+
+    for (source, text) in [
+        ("docs/sandbox.md", sandbox.as_str()),
+        ("README.md", readme.as_str()),
+    ] {
+        for required in [
+            "--sandbox inherit-codex",
+            "_meta[\"codex/sandbox-state-meta\"]",
+            "Claude",
+            "--sandbox workspace-write",
+        ] {
+            assert!(text.contains(required), "missing {required} in {source}");
+        }
+    }
+}
+
+#[test]
 fn worker_sideband_protocol_keeps_images_one_way() {
     let protocol = read(&repo_root().join("docs/worker_sideband_protocol.md"));
 

--- a/tests/pager.rs
+++ b/tests/pager.rs
@@ -332,7 +332,7 @@ async fn pager_empty_input_does_not_start_worker_before_inherit_update() -> Test
     }
 
     assert!(
-        text.contains("--sandbox inherit requested but no client sandbox state was provided"),
+        text.contains("requires Codex per-tool-call sandbox metadata"),
         "expected initial empty pager input to surface sandbox-state failure, got: {text:?}"
     );
     assert!(

--- a/tests/sandbox_state_meta.rs
+++ b/tests/sandbox_state_meta.rs
@@ -12,8 +12,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tempfile::{Builder, TempDir, tempdir};
 
 const SANDBOX_STATE_META_CAPABILITY: &str = "codex/sandbox-state-meta";
-const MISSING_INHERITED_STATE_MESSAGE: &str =
-    "--sandbox inherit requested but no client sandbox state was provided";
+const MISSING_INHERITED_STATE_MESSAGE: &str = "requires Codex per-tool-call sandbox metadata";
 const INLINE_TEXT_BUDGET_CHARS: usize = 3500;
 const INLINE_TEXT_HARD_SPILL_THRESHOLD_CHARS: usize = INLINE_TEXT_BUDGET_CHARS * 5 / 4;
 const UNDER_HARD_SPILL_TEXT_LEN: usize = INLINE_TEXT_BUDGET_CHARS + 200;
@@ -607,6 +606,15 @@ async fn spawn_inherit_server(cwd: &Path) -> TestResult<McpTestSession> {
     .await
 }
 
+async fn spawn_inherit_codex_server(cwd: &Path) -> TestResult<McpTestSession> {
+    common::spawn_server_with_args_env_and_cwd(
+        vec!["--sandbox".to_string(), "inherit-codex".to_string()],
+        Vec::new(),
+        Some(cwd.to_path_buf()),
+    )
+    .await
+}
+
 #[cfg(target_os = "macos")]
 async fn spawn_python_inherit_server(cwd: &Path) -> TestResult<McpTestSession> {
     common::spawn_server_with_args_env_and_cwd(
@@ -1011,6 +1019,32 @@ async fn sandbox_state_meta_capability_advertised_with_inherit() -> TestResult<(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn sandbox_state_meta_capability_advertised_with_inherit_codex() -> TestResult<()> {
+    if skip_sandbox_state_meta_unavailable() {
+        return Ok(());
+    }
+    let _guard = test_guard();
+    let temp = tempdir()?;
+    let session = spawn_inherit_codex_server(temp.path()).await?;
+    let info = session.server_info().ok_or_else(|| {
+        Box::<dyn std::error::Error + Send + Sync>::from(
+            "missing server info from initialize".to_string(),
+        )
+    })?;
+    let experimental = info.capabilities.experimental.as_ref().ok_or_else(|| {
+        Box::<dyn std::error::Error + Send + Sync>::from(
+            "missing experimental capabilities".to_string(),
+        )
+    })?;
+    assert!(
+        experimental.contains_key(SANDBOX_STATE_META_CAPABILITY),
+        "expected sandbox state meta capability in experimental: {experimental:?}"
+    );
+    session.cancel().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn sandbox_state_meta_capability_hidden_without_inherit() -> TestResult<()> {
     if skip_sandbox_state_meta_unavailable() {
         return Ok(());
@@ -1029,7 +1063,7 @@ async fn sandbox_state_meta_capability_hidden_without_inherit() -> TestResult<()
         .is_some_and(|experimental| experimental.contains_key(SANDBOX_STATE_META_CAPABILITY));
     assert!(
         !advertised,
-        "did not expect sandbox state meta capability without `--sandbox inherit`: {info:?}"
+        "did not expect sandbox state meta capability without `--sandbox inherit-codex`: {info:?}"
     );
     session.cancel().await?;
     Ok(())
@@ -1093,7 +1127,7 @@ async fn sandbox_inherit_without_state_meta_fails_on_first_tool_call() -> TestRe
         return Ok(());
     }
     assert!(
-        text.contains("--sandbox inherit requested but no client sandbox state was provided"),
+        text.contains(MISSING_INHERITED_STATE_MESSAGE),
         "expected missing sandbox-state-meta error, got: {text}"
     );
     assert_eq!(
@@ -1180,7 +1214,7 @@ async fn sandbox_inherit_empty_repl_uses_state_meta_when_spawn_needed() -> TestR
         "expected empty inherit repl call with metadata to return idle status, got: {text}"
     );
     assert!(
-        !text.contains("--sandbox inherit requested but no client sandbox state was provided"),
+        !text.contains(MISSING_INHERITED_STATE_MESSAGE),
         "did not expect empty inherit repl call with metadata to fail closed, got: {text}"
     );
     session.cancel().await?;
@@ -5050,7 +5084,7 @@ async fn sandbox_inherit_without_state_meta_fails_on_ctrl_d() -> TestResult<()> 
         return Ok(());
     }
     assert!(
-        text.contains("--sandbox inherit requested but no client sandbox state was provided"),
+        text.contains(MISSING_INHERITED_STATE_MESSAGE),
         "expected missing sandbox-state-meta error, got: {text}"
     );
     assert_eq!(

--- a/tests/server_smoke.rs
+++ b/tests/server_smoke.rs
@@ -3,6 +3,7 @@ mod common;
 use common::McpSnapshot;
 use common::TestResult;
 use std::path::PathBuf;
+use std::process::Command as StdCommand;
 use std::process::Stdio;
 use std::time::Duration;
 use tokio::process::Command;
@@ -35,6 +36,23 @@ fn ipc_disconnect_is_not_treated_as_backend_unavailable() {
         !common::backend_unavailable(text),
         "request-completion IPC disconnects should fail tests instead of skipping them"
     );
+}
+
+#[test]
+fn cli_help_names_inherit_codex_sandbox_mode_last() -> TestResult<()> {
+    let exe = resolve_mcp_repl_path()?;
+    let output = StdCommand::new(exe).arg("--help").output()?;
+    assert!(output.status.success(), "expected --help to succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("--sandbox <read-only|workspace-write|danger-full-access|inherit-codex>"),
+        "expected --help to name inherit-codex sandbox mode last, got: {stdout:?}"
+    );
+    assert!(
+        stdout.contains("`inherit` is accepted as a compatibility alias."),
+        "expected --help to document inherit alias, got: {stdout:?}"
+    );
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Addresses #166.

## Summary
Clarifies that sandbox inheritance depends on client-specific per-call sandbox metadata and should fail closed when that metadata is unavailable.

## User-facing changes
- Renames the explicit inheritance mode to the requested client-scoped spelling and lists it last in help and docs mode lists.
- Keeps the legacy `inherit` spelling as a compatibility alias for existing configs.
- Documents that Claude Code and generic MCP clients should use explicit sandbox modes because their tool-call metadata does not include an applicable sandbox policy.

## Internal changes
- Updates installer defaults, parser/help text, sandbox error messaging, and related documentation.
- Adds docs contract, CLI smoke, parser, installer, and sandbox metadata coverage for the renamed mode and compatibility alias.
