### PR TITLE
Release 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-repl"
-version = "0.3.0-dev"
+version = "0.3.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
   name        = "mcp-repl"
-  version     = "0.3.0-dev"
+  version     = "0.3.0"
   edition     = "2024"
   publish     = false
   description = "MCP server exposing a long-lived interactive REPL runtime (R or Python backend) over stdio."


### PR DESCRIPTION
## Summary

Release 0.3.0 by changing the Cargo package version from `0.3.0-dev` to `0.3.0`. This prepares the repository for the immutable `v0.3.0` tag-driven release workflow after merge.

## User-facing changes

See the release notes below. The release includes PyPI packaging, Python cell execution, reset via Ctrl-D, output/session ordering improvements, sandbox updates, and platform packaging updates.

## Internal changes

- Updates only `Cargo.toml` and `Cargo.lock` package version metadata.
- Leaves tag creation and publishing to the documented post-merge release process.

## Release notes

## mcp-repl 0.3.0

### Install and upgrade notes

- Added a PyPI distribution as `posit-mcp-repl`, usable with `pipx`, `uv tool install`, or one-off `uvx posit-mcp-repl`. (#142, #160)
- Removed the separate `repl_reset` tool. Session resets now use `\u0004` (Ctrl-D / EOF) through `repl`, with any remaining input run in the fresh session. (#157)
- Renamed `--sandbox inherit` to `--sandbox inherit-codex`; the old spelling remains a compatibility alias. (#167)
- Release binaries no longer include `--debug-repl`; it remains available in debug/dev builds. (#149)

### REPL behavior

- Python submissions now run as complete cells, not line-oriented interactive input. This gives persistent cell globals, final-expression display through `sys.displayhook`, and stdin routing only when Python is waiting for input. (#132)
- Improved R plotting so console plot sizing options affect the live managed graphics device while plots are drawn, including new `console.plot.asp` support. (#147)
- Improved R startup errors when `R` or `R_HOME` cannot be resolved. (#158)

### Output and session handling

- Reworked output handling so normal replies, pager output, files-mode bundles, images, stderr, server notices, and transcripts share one ordering model. (#138, #148, #152)
- Improved reset behavior so Ctrl-D returns old-session shutdown output before fresh-session output, without leaking abandoned timed-out output into later replies. (#159, #164)
- Cleaned up worker session temp directories when workers are dropped. (#137)

### Sandbox and platform support

- Expanded managed sandbox metadata support on macOS and Linux, including narrower filesystem profiles, deny rules, protected metadata paths, and clearer fail-closed behavior. (#139, #144, #150, #156)
- Added Linux managed-domain allowlisting through the managed proxy while keeping direct worker egress blocked. (#161, #164)
- Added Windows network-policy parity for workspace-write sandboxes after one-time Windows sandbox setup. (#129)
- Clarified that `inherit-codex` requires Codex per-call sandbox metadata; other MCP clients should use explicit sandbox modes. (#167)

### Packaging and maintenance

- Switched releases to immutable tag-driven publishing with GitHub release archives and PyPI Trusted Publishing. (#142)
- Added a manual PyPI-only backfill path for existing release tags. (#151, #153)
- Updated installer behavior so REPL tools remain visible in code-mode configs with tool allowlists or blocklists. (#146, #157)
- Updated direct dependencies, made Rust warnings fail CI/release checks, and made restart, timeout, sandbox, and UTF-8 tests more deterministic. (#154, #158, #162, #163)
